### PR TITLE
Expose invalidate/supersede on the public API (completes D5/D7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Public invalidate/supersede surface (completes D5/D7).** The non-destructive soft-invalidate (D5) and supersession (D7) writers, previously only on the repositories, are now reachable through the public API. New on `ILongTermMemoryService`: `InvalidateFactAsync` / `InvalidateEntityAsync` / `InvalidatePreferenceAsync` and `SupersedeFactAsync` / `SupersedePreferenceAsync` (owner-scoped via `MemoryScope`, thin delegations to the repos). New `agentmemory` CLI verbs: `invalidate --type <fact|entity|preference> --id <id> [--owner <id>]` and `supersede --type <fact|preference> --loser <id> --winner <id> [--owner <id>]`. New MCP tools: `memory_invalidate` and `memory_supersede` (owner-scoped via `userId`). All non-destructive (kept + as-of-recallable) and R1 owner-scoped. Unit-tested at every layer (service delegation, CLI routing/exit codes, MCP routing/scoping); the underlying repo writers already have live-Neo4j coverage from D5/D7.
+
 ## [0.1.0-preview.2] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It is designed to support:
 - **Neo4j-backed persistent memory** with vector, fulltext, and hybrid search
 - **Graph-native retrieval** with relationship traversal and entity resolution
 - **GraphRAG interoperability** for blended retrieval and knowledge graph enrichment
-- **MCP Server** for external clients and tools (21 tools, 6 resources, 3 prompts)
+- **MCP Server** for external clients and tools (25 tools, 6 resources, 3 prompts)
 
 ## Why this exists
 
@@ -195,7 +195,7 @@ Long-term knowledge is **owner-scoped** so one user cannot recall another user's
 
 ## Project status
 
-R1/R1b multi-user isolation (above) plus 6 implementation phases complete, plus a gap-closure sprint (Waves A–C) bringing Python parity to ~99%. Foundation memory engine fully implemented with Neo4j persistence, extraction pipeline with LLM and Azure Language backends, Microsoft Agent Framework adapter, Semantic Kernel adapter, GraphRAG blended retrieval (built into the Neo4j package), OpenTelemetry observability, geocoding and entity enrichment services, and MCP Server with 21 tools, 6 resources, and 3 prompts — all ready for deployment. All timestamps use native Neo4j `datetime()` storage. Session ID generation supports 3 strategies (PerConversation, PerDay, PersistentPerUser). MetadataFilterBuilder provides 5 operators ($eq, $ne, $contains, $in, $exists).
+R1/R1b multi-user isolation (above) plus 6 implementation phases complete, plus a gap-closure sprint (Waves A–C) bringing Python parity to ~99%. Foundation memory engine fully implemented with Neo4j persistence, extraction pipeline with LLM and Azure Language backends, Microsoft Agent Framework adapter, Semantic Kernel adapter, GraphRAG blended retrieval (built into the Neo4j package), OpenTelemetry observability, geocoding and entity enrichment services, and MCP Server with 25 tools, 6 resources, and 3 prompts — all ready for deployment. All timestamps use native Neo4j `datetime()` storage. Session ID generation supports 3 strategies (PerConversation, PerDay, PersistentPerUser). MetadataFilterBuilder provides 5 operators ($eq, $ne, $contains, $in, $exists).
 
 The solution ships these packages:
 
@@ -210,7 +210,7 @@ The solution ships these packages:
 | `AgentMemory.SemanticKernel` | 6 | Semantic Kernel adapter — memory plugin with native SK integration |
 | `AgentMemory.Enrichment` | 5 | Geocoding (Nominatim) + entity enrichment (Wikimedia) with caching and rate limiting |
 | `AgentMemory.Observability` | 4 | OpenTelemetry decorators — tracing spans and metrics for all memory operations |
-| `AgentMemory.McpServer` | 6 | MCP Server — 21 tools, 6 resources, 3 prompts (search, context, store, entities, facts, preferences, reasoning traces, observations, graph query, export, extract) |
+| `AgentMemory.McpServer` | 6 | MCP Server — 25 tools, 6 resources, 3 prompts (search, context, store, entities, facts, preferences, reasoning traces, observations, graph query, export, extract) |
 | `AgentMemory` | Release | Meta-package bundling core + Neo4j + Abstractions for convenient dependencies |
 
 Extensively tested with unit and integration tests covering all packages. ~99% functional parity with the Python reference implementation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,7 +293,7 @@ All adapter packages have shipped. The table below was the original roadmap; `Ag
 
 | Package | Phase | External Dependency | Implements |
 |---|---|---|---|
-| `AgentMemory.McpServer` | 6 ✅ | ModelContextProtocol SDK 1.2.0, M.E.Hosting | 21 MCP tools, 6 resources, 3 prompts |
+| `AgentMemory.McpServer` | 6 ✅ | ModelContextProtocol SDK 1.2.0, M.E.Hosting | 25 MCP tools, 6 resources, 3 prompts |
 
 ---
 

--- a/docs/nextsteps.md
+++ b/docs/nextsteps.md
@@ -56,7 +56,7 @@ Concretely:
 - **Persistence:** Native Neo4j `datetime()` for all timestamps, 145+ centralised Cypher constants, MigrationRunner with versioned `.cypher` files.
 - **Search:** Vector (5 indexes + reasoning-step index), fulltext BM25 (3 indexes), hybrid (vector + BM25), and graph multi-hop traversal.
 - **Memory features:** Temporal point-in-time recall (`RecallAsOfAsync`), exponential memory decay (`MemoryDecayService`), multi-extractor merge strategies (five modes), batch UNWIND upserts.
-- **Agent integrations:** Microsoft Agent Framework, Semantic Kernel, MCP server (21 tools, 6 resources, 3 prompts).
+- **Agent integrations:** Microsoft Agent Framework, Semantic Kernel, MCP server (25 tools, 6 resources, 3 prompts).
 - **Observability:** OpenTelemetry ActivitySource + Meter, instrumented decorators for all extraction and enrichment services.
 
 What is **not** done yet: NuGet release artifacts (CHANGELOG, CONTRIBUTING, package versioning), streaming extraction for long documents, an Aspire demo application for developer onboarding, and an optional GDS analytics package. Package rename is complete (merged 2026-04-30).

--- a/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
@@ -158,4 +158,30 @@ public interface ILongTermMemoryService
         double minScore = 0.0,
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default);
+
+    // ── Invalidation & supersession (D5 / D7) ───────────────────────────
+
+    /// <summary>
+    /// Soft-invalidates a fact by id (D5 transaction clock): it leaves live recall but is retained and
+    /// stays visible to as-of recall for times before invalidation. Owner-scoped (R1) when
+    /// <paramref name="scope"/> is set. Idempotent. Returns true if a matching fact existed in scope.
+    /// </summary>
+    Task<bool> InvalidateFactAsync(string factId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Soft-invalidates an entity by id (D5). See <see cref="InvalidateFactAsync"/>.</summary>
+    Task<bool> InvalidateEntityAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Soft-invalidates a preference by id (D5). See <see cref="InvalidateFactAsync"/>.</summary>
+    Task<bool> InvalidatePreferenceAsync(string preferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Supersedes the <paramref name="loserFactId"/> with the <paramref name="winnerFactId"/> (D7): closes
+    /// the loser non-destructively (<c>invalidated_at</c> + <c>valid_until</c>) and links
+    /// <c>(loser)-[:SUPERSEDED_BY]-&gt;(winner)</c>. Owner-scoped (R1) — both facts must belong to the
+    /// owner. Idempotent. Returns true if a matching loser+winner existed in scope.
+    /// </summary>
+    Task<bool> SupersedeFactAsync(string loserFactId, string winnerFactId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Supersedes the loser preference with the winner (D7). See <see cref="SupersedeFactAsync"/>.</summary>
+    Task<bool> SupersedePreferenceAsync(string loserPreferenceId, string winnerPreferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -314,4 +314,26 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         var scored = await _prefRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, cancellationToken);
         return scored.Select(r => r.Preference).ToList();
     }
+
+    // ── Invalidation & supersession (D5 / D7) — thin owner-scoped delegations ──
+
+    /// <inheritdoc/>
+    public Task<bool> InvalidateFactAsync(string factId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+        => _factRepo.InvalidateAsync(factId, scope, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<bool> InvalidateEntityAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+        => _entityRepo.InvalidateAsync(entityId, scope, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<bool> InvalidatePreferenceAsync(string preferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+        => _prefRepo.InvalidateAsync(preferenceId, scope, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<bool> SupersedeFactAsync(string loserFactId, string winnerFactId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+        => _factRepo.SupersedeAsync(loserFactId, winnerFactId, scope, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<bool> SupersedePreferenceAsync(string loserPreferenceId, string winnerPreferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+        => _prefRepo.SupersedeAsync(loserPreferenceId, winnerPreferenceId, scope, cancellationToken);
 }

--- a/src/AgentMemory.McpServer/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.McpServer/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
             .WithTools<ReasoningTools>()
             .WithTools<GraphQueryTools>()
             .WithTools<AdvancedMemoryTools>()
+            .WithTools<MaintenanceTools>()
             .WithTools<ObservationTools>();
     }
 

--- a/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
+++ b/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+
+namespace AgentMemory.McpServer.Tools;
+
+/// <summary>
+/// Memory-hygiene maintenance tools (D5 / D7): soft-invalidate and supersede long-term memory nodes
+/// <b>non-destructively</b>. Nothing is deleted — invalidated/superseded nodes leave live recall but are
+/// kept and stay visible to as-of recall before the change. Owner-scoped via <c>userId</c> (R1): a scoped
+/// call never touches another owner's data; a null/blank <c>userId</c> is an unscoped (admin) operation.
+/// </summary>
+[McpServerToolType]
+public sealed class MaintenanceTools
+{
+    [McpServerTool(Name = "memory_invalidate"), Description("Soft-invalidate a long-term memory node (fact, entity, or preference) by id. It drops from live recall but is kept and remains visible to as-of recall for times before invalidation (non-destructive, reversible). Owner-scoped when userId is set.")]
+    public static async Task<string> MemoryInvalidate(
+        ILongTermMemoryService longTerm,
+        [Description("Node kind: fact, entity, or preference")] string type,
+        [Description("The node id to invalidate")] string id,
+        [Description("User identifier for owner scoping (optional; null/blank = unscoped/admin)")] string? userId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var scope = string.IsNullOrEmpty(userId) ? null : MemoryScope.For(userId);
+        var kind = (type ?? string.Empty).Trim().ToLowerInvariant();
+
+        bool? invalidated = kind switch
+        {
+            "fact" => await longTerm.InvalidateFactAsync(id, scope, cancellationToken),
+            "entity" => await longTerm.InvalidateEntityAsync(id, scope, cancellationToken),
+            "preference" or "pref" => await longTerm.InvalidatePreferenceAsync(id, scope, cancellationToken),
+            _ => null,
+        };
+
+        return invalidated is null
+            ? ToolJsonContext.Serialize(new { error = $"unknown type '{type}' (expected fact, entity, or preference)" })
+            : ToolJsonContext.Serialize(new { type = kind, id, invalidated = invalidated.Value });
+    }
+
+    [McpServerTool(Name = "memory_supersede"), Description("Supersede a loser long-term node with a winner (fact or preference): closes the loser non-destructively (it leaves live recall) and links it to the winner. Owner-scoped when userId is set — both nodes must belong to the owner.")]
+    public static async Task<string> MemorySupersede(
+        ILongTermMemoryService longTerm,
+        [Description("Node kind: fact or preference")] string type,
+        [Description("The losing node id (will be invalidated)")] string loserId,
+        [Description("The winning node id (kept live)")] string winnerId,
+        [Description("User identifier for owner scoping (optional; null/blank = unscoped/admin)")] string? userId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var scope = string.IsNullOrEmpty(userId) ? null : MemoryScope.For(userId);
+        var kind = (type ?? string.Empty).Trim().ToLowerInvariant();
+
+        bool? superseded = kind switch
+        {
+            "fact" => await longTerm.SupersedeFactAsync(loserId, winnerId, scope, cancellationToken),
+            "preference" or "pref" => await longTerm.SupersedePreferenceAsync(loserId, winnerId, scope, cancellationToken),
+            _ => null,
+        };
+
+        return superseded is null
+            ? ToolJsonContext.Serialize(new { error = $"unknown type '{type}' (expected fact or preference)" })
+            : ToolJsonContext.Serialize(new { type = kind, loserId, winnerId, superseded = superseded.Value });
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Cli/CliCommandsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/CliCommandsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Cli.Commands;
 using AgentMemory.Neo4j.Infrastructure;
@@ -131,6 +132,97 @@ public sealed class CliCommandsTests
         await svc.Received(1).PruneExpiredMemoriesAsync(
             Arg.Is<MemoryScope?>(s => s == null), Arg.Any<CancellationToken>());
     }
+
+    // ── invalidate ───────────────────────────────────────────────────────
+
+    private static InvalidateCommand NewInvalidate(IFactRepository f, IEntityRepository e, IPreferenceRepository p, TextWriter o)
+        => new(f, e, p, o);
+
+    [Fact]
+    public async Task InvalidateCommand_Fact_Scoped_Invalidates_AndReturnsZero()
+    {
+        var (facts, entities, prefs) = LongTermRepos();
+        facts.InvalidateAsync("f1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var exit = await NewInvalidate(facts, entities, prefs, _output).ExecuteAsync("fact", "f1", "alice");
+
+        exit.Should().Be(0);
+        _output.ToString().Should().Contain("Invalidated fact 'f1'").And.Contain("alice");
+        await facts.Received(1).InvalidateAsync(
+            "f1", Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvalidateCommand_Entity_Unscoped_RoutesToEntityRepo()
+    {
+        var (facts, entities, prefs) = LongTermRepos();
+        entities.InvalidateAsync("e1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var exit = await NewInvalidate(facts, entities, prefs, _output).ExecuteAsync("entity", "e1", owner: null);
+
+        exit.Should().Be(0);
+        await entities.Received(1).InvalidateAsync("e1", Arg.Is<MemoryScope?>(s => s == null), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvalidateCommand_NotFound_ReturnsOne()
+    {
+        var (facts, entities, prefs) = LongTermRepos();
+        prefs.InvalidateAsync("p1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var exit = await NewInvalidate(facts, entities, prefs, _output).ExecuteAsync("preference", "p1", owner: null);
+
+        exit.Should().Be(1);
+        _output.ToString().Should().Contain("No matching preference 'p1'");
+    }
+
+    [Theory]
+    [InlineData(null, "id")]
+    [InlineData("fact", null)]
+    [InlineData("widget", "id")]
+    public async Task InvalidateCommand_BadArgs_ReturnsOne_WithoutCallingRepo(string? type, string? id)
+    {
+        var (facts, entities, prefs) = LongTermRepos();
+
+        var exit = await NewInvalidate(facts, entities, prefs, _output).ExecuteAsync(type, id, owner: null);
+
+        exit.Should().Be(1);
+        await facts.DidNotReceive().InvalidateAsync(Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── supersede ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SupersedeCommand_Fact_Scoped_Supersedes_AndReturnsZero()
+    {
+        var (facts, _, prefs) = LongTermRepos();
+        facts.SupersedeAsync("loser", "winner", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var exit = await new SupersedeCommand(facts, prefs, _output).ExecuteAsync("fact", "loser", "winner", "alice");
+
+        exit.Should().Be(0);
+        _output.ToString().Should().Contain("Superseded fact 'loser' with 'winner'").And.Contain("alice");
+        await facts.Received(1).SupersedeAsync(
+            "loser", "winner", Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null, "l", "w")]
+    [InlineData("fact", null, "w")]
+    [InlineData("fact", "l", null)]
+    [InlineData("entity", "l", "w")] // entity is not supersedable
+    public async Task SupersedeCommand_BadArgs_ReturnsOne(string? type, string? loser, string? winner)
+    {
+        var (facts, _, prefs) = LongTermRepos();
+
+        var exit = await new SupersedeCommand(facts, prefs, _output).ExecuteAsync(type, loser, winner, owner: null);
+
+        exit.Should().Be(1);
+        await facts.DidNotReceive().SupersedeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    private static (IFactRepository Facts, IEntityRepository Entities, IPreferenceRepository Preferences) LongTermRepos()
+        => (Substitute.For<IFactRepository>(), Substitute.For<IEntityRepository>(), Substitute.For<IPreferenceRepository>());
 
     private static ConsolidationReport Report(bool dryRun) => new()
     {

--- a/tests/AgentMemory.Tests.Unit/McpServer/MaintenanceToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/MaintenanceToolsTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using FluentAssertions;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.McpServer.Tools;
+using NSubstitute;
+
+namespace AgentMemory.Tests.Unit.McpServer;
+
+public sealed class MaintenanceToolsTests
+{
+    private readonly ILongTermMemoryService _longTerm = Substitute.For<ILongTermMemoryService>();
+
+    // ── memory_invalidate ──
+
+    [Fact]
+    public async Task MemoryInvalidate_Fact_Scoped_RoutesToFact_AndOwnerScopes()
+    {
+        _longTerm.InvalidateFactAsync("f1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var json = await MaintenanceTools.MemoryInvalidate(_longTerm, "fact", "f1", userId: "alice");
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("fact");
+        doc.RootElement.GetProperty("invalidated").GetBoolean().Should().BeTrue();
+        await _longTerm.Received(1).InvalidateFactAsync(
+            "f1", Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemoryInvalidate_Entity_BlankUserId_PassesNullScope()
+    {
+        _longTerm.InvalidateEntityAsync("e1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var json = await MaintenanceTools.MemoryInvalidate(_longTerm, "entity", "e1", userId: "");
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("invalidated").GetBoolean().Should().BeFalse();
+        await _longTerm.Received(1).InvalidateEntityAsync("e1", Arg.Is<MemoryScope?>(s => s == null), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemoryInvalidate_Preference_Routes()
+    {
+        _longTerm.InvalidatePreferenceAsync("p1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        await MaintenanceTools.MemoryInvalidate(_longTerm, "preference", "p1");
+
+        await _longTerm.Received(1).InvalidatePreferenceAsync("p1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemoryInvalidate_UnknownType_ReturnsError_WithoutCallingService()
+    {
+        var json = await MaintenanceTools.MemoryInvalidate(_longTerm, "widget", "x");
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue();
+        await _longTerm.DidNotReceive().InvalidateFactAsync(Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── memory_supersede ──
+
+    [Fact]
+    public async Task MemorySupersede_Fact_Scoped_RoutesAndOwnerScopes()
+    {
+        _longTerm.SupersedeFactAsync("loser", "winner", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var json = await MaintenanceTools.MemorySupersede(_longTerm, "fact", "loser", "winner", userId: "alice");
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("superseded").GetBoolean().Should().BeTrue();
+        await _longTerm.Received(1).SupersedeFactAsync(
+            "loser", "winner", Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemorySupersede_Preference_Routes()
+    {
+        _longTerm.SupersedePreferenceAsync("l", "w", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        await MaintenanceTools.MemorySupersede(_longTerm, "preference", "l", "w");
+
+        await _longTerm.Received(1).SupersedePreferenceAsync("l", "w", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemorySupersede_UnknownType_ReturnsError_WithoutCallingService()
+    {
+        var json = await MaintenanceTools.MemorySupersede(_longTerm, "entity", "l", "w");
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue();
+        await _longTerm.DidNotReceive().SupersedeFactAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
@@ -437,4 +437,58 @@ public sealed class LongTermMemoryServiceTests
 
         await _prefRepo.Received(1).DeleteAsync(Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
     }
+
+    // ── Invalidation & supersession (D5 / D7) delegation ─────────────────
+
+    [Fact]
+    public async Task InvalidateFactAsync_DelegatesToFactRepo_WithScope_AndReturnsResult()
+    {
+        var scope = MemoryScope.For("alice");
+        _factRepo.InvalidateAsync("f1", scope, Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        var sut = CreateSut();
+
+        (await sut.InvalidateFactAsync("f1", scope)).Should().BeTrue();
+        await _factRepo.Received(1).InvalidateAsync("f1", scope, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvalidateEntityAsync_DelegatesToEntityRepo()
+    {
+        _entityRepo.InvalidateAsync("e1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        var sut = CreateSut();
+
+        (await sut.InvalidateEntityAsync("e1")).Should().BeTrue();
+        await _entityRepo.Received(1).InvalidateAsync("e1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvalidatePreferenceAsync_DelegatesToPreferenceRepo()
+    {
+        _prefRepo.InvalidateAsync("p1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        var sut = CreateSut();
+
+        (await sut.InvalidatePreferenceAsync("p1")).Should().BeFalse();
+        await _prefRepo.Received(1).InvalidateAsync("p1", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SupersedeFactAsync_DelegatesToFactRepo_WithBothIdsAndScope()
+    {
+        var scope = MemoryScope.For("alice");
+        _factRepo.SupersedeAsync("loser", "winner", scope, Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        var sut = CreateSut();
+
+        (await sut.SupersedeFactAsync("loser", "winner", scope)).Should().BeTrue();
+        await _factRepo.Received(1).SupersedeAsync("loser", "winner", scope, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SupersedePreferenceAsync_DelegatesToPreferenceRepo()
+    {
+        _prefRepo.SupersedeAsync("loser", "winner", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        var sut = CreateSut();
+
+        (await sut.SupersedePreferenceAsync("loser", "winner")).Should().BeTrue();
+        await _prefRepo.Received(1).SupersedeAsync("loser", "winner", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/AgentMemory.Cli/CliArgs.cs
+++ b/tools/AgentMemory.Cli/CliArgs.cs
@@ -73,6 +73,10 @@ public static class CliHelp
               bootstrap              Create schema constraints and indexes.
               consolidate [--apply]  Run the memory-hygiene pass (dry-run unless --apply).
               conflicts              Detect fact contradictions (detect-only).
+              invalidate --type <fact|entity|preference> --id <id> [--owner <id>]
+                                     Soft-invalidate a node (D5): drops from live recall, kept + as-of-recallable.
+              supersede --type <fact|preference> --loser <id> --winner <id> [--owner <id>]
+                                     Supersede a loser with a winner (D7): non-destructive, links :SUPERSEDED_BY.
               decay [--owner <id>]   Decay-prune memories: soft-invalidate by default (kept + recoverable;
                                      set MemoryDecay:NonDestructive=false to hard-delete). Owner-scoped, or global.
               schema-parity [--upstream-version <v>]

--- a/tools/AgentMemory.Cli/Commands/MemoryCommands.cs
+++ b/tools/AgentMemory.Cli/Commands/MemoryCommands.cs
@@ -1,4 +1,5 @@
 using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Neo4j.Infrastructure;
 using AgentMemory.Neo4j.Schema.Parity;
@@ -118,5 +119,90 @@ public sealed class SchemaParityCommand(TextWriter output)
         var report = SchemaParityVerifier.VerifyDotNet(target, registry);
         output.WriteLine(report.Summary());
         return report.IsCompatible ? 0 : 1;
+    }
+}
+
+/// <summary>
+/// Soft-invalidates a long-term node by id (D5): it leaves live recall but is kept and stays visible to
+/// as-of recall before invalidation. Owner-scoped when <c>--owner</c> is given. Exit 0 if a node was
+/// invalidated, 1 if nothing matched in scope or on a usage error.
+/// <para>Resolves the repositories directly (not <see cref="ILongTermMemoryService"/>) so this ops command
+/// needs no embedding backend — invalidation is a pure id-based write.</para>
+/// </summary>
+public sealed class InvalidateCommand(
+    IFactRepository facts, IEntityRepository entities, IPreferenceRepository preferences, TextWriter output)
+{
+    public async Task<int> ExecuteAsync(string? type, string? id, string? owner, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(type) || string.IsNullOrWhiteSpace(id))
+        {
+            output.WriteLine("error: invalidate requires --type <fact|entity|preference> and --id <id>.");
+            return 1;
+        }
+
+        var scope = string.IsNullOrWhiteSpace(owner) ? null : MemoryScope.For(owner);
+        var kind = type.Trim().ToLowerInvariant();
+        Task<bool>? op = kind switch
+        {
+            "fact" => facts.InvalidateAsync(id, scope, cancellationToken),
+            "entity" => entities.InvalidateAsync(id, scope, cancellationToken),
+            "preference" or "pref" => preferences.InvalidateAsync(id, scope, cancellationToken),
+            _ => null,
+        };
+        if (op is null)
+        {
+            output.WriteLine($"error: unknown --type '{type}' (expected fact|entity|preference).");
+            return 1;
+        }
+
+        var ownerNote = scope is null ? string.Empty : $" (owner '{owner}')";
+        if (await op)
+        {
+            output.WriteLine($"Invalidated {kind} '{id}'{ownerNote}.");
+            return 0;
+        }
+        output.WriteLine($"No matching {kind} '{id}'{ownerNote} to invalidate.");
+        return 1;
+    }
+}
+
+/// <summary>
+/// Supersedes a loser long-term node with a winner (D7): closes the loser non-destructively and links
+/// <c>:SUPERSEDED_BY</c>. Owner-scoped when <c>--owner</c> is given (both nodes must belong to the owner).
+/// Exit 0 if superseded, 1 if nothing matched in scope or on a usage error. Resolves repositories directly
+/// (no embedding backend needed).
+/// </summary>
+public sealed class SupersedeCommand(IFactRepository facts, IPreferenceRepository preferences, TextWriter output)
+{
+    public async Task<int> ExecuteAsync(string? type, string? loser, string? winner, string? owner, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(type) || string.IsNullOrWhiteSpace(loser) || string.IsNullOrWhiteSpace(winner))
+        {
+            output.WriteLine("error: supersede requires --type <fact|preference>, --loser <id>, and --winner <id>.");
+            return 1;
+        }
+
+        var scope = string.IsNullOrWhiteSpace(owner) ? null : MemoryScope.For(owner);
+        var kind = type.Trim().ToLowerInvariant();
+        Task<bool>? op = kind switch
+        {
+            "fact" => facts.SupersedeAsync(loser, winner, scope, cancellationToken),
+            "preference" or "pref" => preferences.SupersedeAsync(loser, winner, scope, cancellationToken),
+            _ => null,
+        };
+        if (op is null)
+        {
+            output.WriteLine($"error: unknown --type '{type}' (expected fact|preference).");
+            return 1;
+        }
+
+        var ownerNote = scope is null ? string.Empty : $" (owner '{owner}')";
+        if (await op)
+        {
+            output.WriteLine($"Superseded {kind} '{loser}' with '{winner}'{ownerNote}.");
+            return 0;
+        }
+        output.WriteLine($"No matching {kind} loser+winner in scope{ownerNote}; nothing superseded.");
+        return 1;
     }
 }

--- a/tools/AgentMemory.Cli/Program.cs
+++ b/tools/AgentMemory.Cli/Program.cs
@@ -1,4 +1,5 @@
 using AgentMemory;                          // meta AddNeo4jAgentMemory
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Cli;
 using AgentMemory.Cli.Commands;
@@ -15,7 +16,7 @@ if (cli.Command is null || string.Equals(cli.Command, "help", StringComparison.O
     return cli.Command is null ? 1 : 0;
 }
 
-var known = new[] { "migrate", "bootstrap", "consolidate", "decay", "conflicts", "schema-parity" };
+var known = new[] { "migrate", "bootstrap", "consolidate", "decay", "conflicts", "schema-parity", "invalidate", "supersede" };
 if (!known.Contains(cli.Command, StringComparer.OrdinalIgnoreCase))
 {
     Console.Error.WriteLine($"error: unknown command '{cli.Command}'.");
@@ -80,6 +81,15 @@ try
             sp.GetRequiredService<IMemoryDecayService>(), output).ExecuteAsync(cli.Get("owner")),
         "conflicts" => await new ConflictsCommand(
             sp.GetRequiredService<IConflictDetectionService>(), output).ExecuteAsync(),
+        "invalidate" => await new InvalidateCommand(
+            sp.GetRequiredService<IFactRepository>(),
+            sp.GetRequiredService<IEntityRepository>(),
+            sp.GetRequiredService<IPreferenceRepository>(), output)
+            .ExecuteAsync(cli.Get("type"), cli.Get("id"), cli.Get("owner")),
+        "supersede" => await new SupersedeCommand(
+            sp.GetRequiredService<IFactRepository>(),
+            sp.GetRequiredService<IPreferenceRepository>(), output)
+            .ExecuteAsync(cli.Get("type"), cli.Get("loser"), cli.Get("winner"), cli.Get("owner")),
         _ => 1,
     };
 }


### PR DESCRIPTION
## Summary
Completes the D5/D7 workstream by surfacing the non-destructive **soft-invalidate** (D5) and **supersession** (D7) writers — previously only on the repositories — across the public API. All operations are non-destructive (kept + as-of-recallable) and R1 owner-scoped.

## Three surfaces
- **`ILongTermMemoryService`**: `InvalidateFactAsync` / `InvalidateEntityAsync` / `InvalidatePreferenceAsync` and `SupersedeFactAsync` / `SupersedePreferenceAsync` (owner-scoped via `MemoryScope`; thin delegations to the repos).
- **`agentmemory` CLI**: `invalidate --type <fact|entity|preference> --id <id> [--owner <id>]` and `supersede --type <fact|preference> --loser <id> --winner <id> [--owner <id>]`. Resolves the repositories directly so this ops command needs no embedding backend (id-based writes only).
- **MCP**: `memory_invalidate` and `memory_supersede` tools (owner-scoped via `userId`).

## Testing
- Unit-tested at every layer: service delegation, CLI routing/exit-codes/bad-args, MCP routing/scoping/error-shape.
- The underlying repo writers (`InvalidateAsync`/`SupersedeAsync`) already have live-Neo4j coverage from D5/D7.
- **2408 unit tests green**; full + Release build clean.
- Also fixed stale MCP tool-count docs (21 → 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)