### PR TITLE
release: cut 0.1.0-preview.3 (version + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-preview.3] - 2026-06-13
+
 ### Added
 
 - **`IWritableMemoryOwnerContext.BeginOwnerScope(userId)` — host-facing ambient owner scope.** A small `IDisposable` that sets the ambient memory owner (IC8) for the current async flow and restores it on dispose. This is the reliable way to make the LLM-invokable MAF facade tools (`search_memory` / `remember_*`) owner-scoped: because the owner context is `AsyncLocal`-backed, a value set in an *enclosing* scope flows down into the awaited agent run and its tool calls — `using (ownerContext.BeginOwnerScope(userId)) await agent.RunAsync(...)`. (The MAF providers set the owner per turn, but a value set inside their awaited pre-run hook does not propagate back to the framework's later tool calls under the AsyncLocal-singleton default — so the host scope is the correct closure; see `docs/review-2026-06-13-cycle3.md` finding #4.) Unit-tested end-to-end (flows into nested async work, nested scopes restore the outer owner, restored on dispose).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
        and never leaks into non-published projects. Per-package Description/PackageTags live in each
        .csproj. NuGet package IDs default to the (already de-Neo4j-renamed) project names. -->
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('AgentMemory')) and !$(MSBuildProjectName.Contains('.Tests')) and !$(MSBuildProjectName.Contains('.Sample'))">
-    <Version>0.1.0-preview.2</Version>
+    <Version>0.1.0-preview.3</Version>
     <Authors>Jose Luis Latorre Millas</Authors>
     <Company>Jose Luis Latorre Millas</Company>
     <Product>AgentMemory for .NET</Product>


### PR DESCRIPTION
Preps the `v0.1.0-preview.3` release so the repo metadata matches the tag to be pushed.

- `Directory.Build.props`: `Version` `0.1.0-preview.2` → `0.1.0-preview.3`
- `CHANGELOG.md`: cut `[Unreleased]` → `[0.1.0-preview.3] - 2026-06-13` (ships this session's cycle 3–6 + capstone review fixes), fresh empty `[Unreleased]` on top

Verified: `dotnet pack -c Release` produces `AgentMemory.*.0.1.0-preview.3.nupkg`; no stray `0.1.0-preview.2` references remain.

**After merge**, publishing is one tag push (the version is taken from the tag, overriding Directory.Build.props):
```
git checkout main && git pull
git tag v0.1.0-preview.3 && git push origin v0.1.0-preview.3
```
→ `squad-release.yml` packs + pushes all 12 `AgentMemory*` packages to NuGet (needs the corrected `NUGET_API_KEY` secret with a `AgentMemory*` glob + "push new packages" scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)