### PR TITLE
release: date preview.3 changelog to 2026-06-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-preview.3] - 2026-06-13
+## [0.1.0-preview.3] - 2026-06-14
 
 ### Added
 


### PR DESCRIPTION
Dates the `[0.1.0-preview.3]` CHANGELOG entry to the actual release date (2026-06-14). Doc-only; precedes the `v0.1.0-preview.3` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)