### PR TITLE
feat(di): meta AddNeo4jAgentMemory forwards configureStore + multi-store docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Meta-package `AddNeo4jAgentMemory` now forwards a `configureStore` delegate.** The one-line `AgentMemory` registration gained an optional 4th parameter, `Action<MemoryStoreOptions>? configureStore`, so the application/memory-store isolation tier (R1b) — e.g. `MemoryStorageStrategy.DatabasePerApplication`, which routes each `ApplicationId` to its own auto-provisioned Neo4j database (Enterprise/AuraDB) — can be configured without dropping down to the `AgentMemory.Neo4j` registration. Backward-compatible (optional, appended last; `SharedDatabase` default unchanged). Documented in `docs/getting-started.md` §3.4 ("Multiple databases & instances"), with a new `deploy/docker-compose.enterprise.yml` (Enterprise + APOC + GDS) for local multi-store/analytics testing.
+
 ## [0.1.0-preview.3] - 2026-06-14
 
 ### Added

--- a/deploy/docker-compose.enterprise.yml
+++ b/deploy/docker-compose.enterprise.yml
@@ -1,0 +1,34 @@
+# Neo4j 5 ENTERPRISE for local multi-store / analytics development.
+#
+# Use this (instead of docker-compose.dev.yml) when you want to exercise:
+#   - MemoryStorageStrategy.DatabasePerApplication  (CREATE DATABASE per ApplicationId — Enterprise only)
+#   - the optional AgentMemory.Analytics package     (PageRank / Louvain — needs the GDS plugin)
+#
+# By setting NEO4J_ACCEPT_LICENSE_AGREEMENT=eval you accept the Neo4j Enterprise *evaluation* licence
+# (dev/test only). For production use a commercial licence or Neo4j AuraDB.
+#
+#   docker compose -f deploy/docker-compose.enterprise.yml up -d
+#   # Browser: http://localhost:7474   Bolt: bolt://localhost:7687   auth: neo4j / devpassword
+
+services:
+  neo4j:
+    image: neo4j:5.26-enterprise
+    container_name: agent-memory-neo4j-enterprise
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: "eval"
+      NEO4J_AUTH: neo4j/devpassword
+      # APOC (general procedures) + Graph Data Science (required by AgentMemory.Analytics).
+      NEO4J_PLUGINS: '["apoc","graph-data-science"]'
+      # GDS procedures must be allow-listed and unrestricted to run.
+      NEO4J_dbms_security_procedures_unrestricted: "gds.*,apoc.*"
+      NEO4J_dbms_security_procedures_allowlist: "gds.*,apoc.*"
+    volumes:
+      - neo4j-enterprise-data:/data
+      - neo4j-enterprise-logs:/logs
+
+volumes:
+  neo4j-enterprise-data:
+  neo4j-enterprise-logs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,54 @@ await bootstrapper.BootstrapAsync();
 
 `ISchemaBootstrapper` is registered by `AddNeo4jAgentMemory()` — resolve it from the DI container rather than instantiating it directly.
 
+### 3.4 Multiple databases & instances (multi-tenant)
+
+The data model is three tiers — **store ⊃ owner ⊃ session**. How you isolate tenants depends on whether you want *logical* or *physical* separation, and whether your tenants share one Neo4j or live on different ones.
+
+#### Default — one database, logical isolation (Neo4j Community)
+Out of the box the strategy is `SharedDatabase`: a single database, with tenants isolated by `owner_id` / `MemoryScope`. Pass a `userId` on recall/extraction (or set the ambient owner context) and a tenant only sees their own + shared memories. **No extra setup — this is the recommended starting point** and works on Community Edition.
+
+#### A database per application (Neo4j Enterprise / AuraDB)
+For *physical* isolation, switch to `DatabasePerApplication`: each `ApplicationId` routes to its **own** Neo4j database (`<prefix><appId>`, default prefix `mem-`), which the library **creates and schema-bootstraps automatically on first use** — you never run `CREATE DATABASE` by hand. (Requires Enterprise or AuraDB; Community supports a single user database.)
+
+```csharp
+using AgentMemory.Neo4j.Infrastructure;
+
+builder.Services.AddNeo4jAgentMemory(
+    configureMemory: _ => { },
+    configureNeo4j: neo4j =>
+    {
+        neo4j.Uri = "neo4j+s://xxxx.databases.neo4j.io"; // or bolt://localhost:7687
+        neo4j.Username = "neo4j";
+        neo4j.Password = "...";
+    },
+    configureStore: store =>
+    {
+        store.Strategy       = MemoryStorageStrategy.DatabasePerApplication;
+        store.DatabasePrefix = "mem-";   // database name = mem-<sanitized-appId>
+        store.AutoProvision  = true;     // CREATE DATABASE + bootstrap on first touch
+    });
+```
+
+> The meta-package `AddNeo4jAgentMemory(configureMemory, configureNeo4j, configureLlm, configureStore)` forwards `configureStore`; the `AgentMemory.Neo4j` registration `AddNeo4jAgentMemory(configureNeo4j, configureStore)` accepts it directly.
+
+**Route per request** by setting the ambient store context — it's `AsyncLocal`-backed, so concurrent requests don't cross:
+
+```csharp
+var storeCtx = sp.GetRequiredService<IWritableMemoryStoreContext>();
+storeCtx.ApplicationId = "tenant-acme";   // → database "mem-tenant-acme"; null → the default database
+```
+
+The Microsoft Agent Framework providers do this for you automatically from the agent session's `application_id` state key.
+
+#### Separate Neo4j *instances* (different servers/clusters)
+The store tier routes across **databases within one instance**, not across instances — a DI container binds one `Neo4jOptions` (one URI/driver). To target genuinely separate servers (e.g. dev vs prod, or a dedicated cluster per large tenant):
+
+- **Run separate host processes / DI containers**, one `AddNeo4jAgentMemory` each — simplest for environment separation or one-Neo4j-per-tenant; or
+- **Register your own `INeo4jSessionFactory` / `INeo4jDriverFactory`** (both are `TryAdd`, so yours wins) to pick the driver/URI per `ApplicationId` — for routing a single app across multiple instances.
+
+> Local Enterprise for testing `DatabasePerApplication`: use [`deploy/docker-compose.enterprise.yml`](../deploy/docker-compose.enterprise.yml) (Enterprise image + accepted eval license + APOC & GDS plugins).
+
 ---
 
 ## 4. First Memory Store

--- a/src/AgentMemory/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory/ServiceCollectionExtensions.cs
@@ -21,18 +21,25 @@ public static class ServiceCollectionExtensions
     /// <param name="configureMemory">Configures core memory options.</param>
     /// <param name="configureNeo4j">Configures Neo4j connection options.</param>
     /// <param name="configureLlm">Optional: configures LLM extraction options.</param>
+    /// <param name="configureStore">
+    /// Optional: configures the application / memory-store isolation tier (R1b) — e.g.
+    /// <c>MemoryStorageStrategy.DatabasePerApplication</c> to route each <c>ApplicationId</c> to its own
+    /// Neo4j database (requires Enterprise/AuraDB). Defaults to <c>SharedDatabase</c> (single database,
+    /// owner-scoped), which reproduces the original single-store behavior.
+    /// </param>
     public static IServiceCollection AddNeo4jAgentMemory(
         this IServiceCollection services,
         Action<MemoryOptions> configureMemory,
         Action<NeoInfra.Neo4jOptions> configureNeo4j,
-        Action<LlmExtractionOptions>? configureLlm = null)
+        Action<LlmExtractionOptions>? configureLlm = null,
+        Action<NeoInfra.MemoryStoreOptions>? configureStore = null)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configureMemory);
         ArgumentNullException.ThrowIfNull(configureNeo4j);
 
         services.AddAgentMemoryCore(configureMemory);
-        NeoInfra.ServiceCollectionExtensions.AddNeo4jAgentMemory(services, configureNeo4j);
+        NeoInfra.ServiceCollectionExtensions.AddNeo4jAgentMemory(services, configureNeo4j, configureStore);
         services.AddLlmExtraction(configureLlm);
 
         return services;

--- a/tests/AgentMemory.Tests.Unit/MetaPackage/MetaPackageDiRegistrationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/MetaPackage/MetaPackageDiRegistrationTests.cs
@@ -15,7 +15,8 @@ public sealed class MetaPackageDiRegistrationTests
     private static IServiceCollection BuildServices(
         Action<MemoryOptions>? configureMemory = null,
         Action<Neo4jOptions>? configureNeo4j = null,
-        Action<LlmExtractionOptions>? configureLlm = null)
+        Action<LlmExtractionOptions>? configureLlm = null,
+        Action<MemoryStoreOptions>? configureStore = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -23,7 +24,8 @@ public sealed class MetaPackageDiRegistrationTests
         services.AddNeo4jAgentMemory(
             configureMemory ?? (_ => { }),
             configureNeo4j  ?? (_ => { }),
-            configureLlm);
+            configureLlm,
+            configureStore);
 
         return services;
     }
@@ -110,6 +112,23 @@ public sealed class MetaPackageDiRegistrationTests
         var opts = provider.GetRequiredService<IOptions<MemoryStoreOptions>>();
         opts.Value.Strategy.Should().Be(MemoryStorageStrategy.SharedDatabase);
         opts.Value.DefaultDatabase.Should().BeEmpty(); // empty ⇒ inherit Neo4jOptions.Database
+    }
+
+    [Fact]
+    public void AddNeo4jAgentMemory_ConfigureStore_ForwardsToStoreOptions()
+    {
+        // The meta one-liner must forward the store delegate so DatabasePerApplication can be configured
+        // without dropping down to the AgentMemory.Neo4j registration directly.
+        var services = BuildServices(configureStore: o =>
+        {
+            o.Strategy = MemoryStorageStrategy.DatabasePerApplication;
+            o.DatabasePrefix = "tenant-";
+        });
+        var provider = services.BuildServiceProvider();
+
+        var opts = provider.GetRequiredService<IOptions<MemoryStoreOptions>>();
+        opts.Value.Strategy.Should().Be(MemoryStorageStrategy.DatabasePerApplication);
+        opts.Value.DatabasePrefix.Should().Be("tenant-");
     }
 
     [Fact]


### PR DESCRIPTION
Implements both follow-ups from the multi-database discussion.

### 1. Meta-package forwards the store delegate
`AgentMemory`'s one-liner `AddNeo4jAgentMemory` dropped the R1b store-tier delegate, so `DatabasePerApplication` could only be configured via the lower-level `AgentMemory.Neo4j` registration. Added an optional **4th** parameter `Action<MemoryStoreOptions>? configureStore` (appended last → backward-compatible) and forwarded it. Now the one-liner can route each `ApplicationId` to its own auto-provisioned Neo4j database (Enterprise/AuraDB).

### 2. Docs
- `docs/getting-started.md` **§3.4 "Multiple databases & instances"** — logical `owner_id` isolation (Community default) vs `DatabasePerApplication` (Enterprise/Aura, auto-provisioned) vs genuinely separate instances (separate containers or a custom session factory).
- `deploy/docker-compose.enterprise.yml` — Enterprise image + accepted eval licence + APOC & GDS plugins, for local multi-store/analytics testing.

### Test
`MetaPackageDiRegistrationTests.AddNeo4jAgentMemory_ConfigureStore_ForwardsToStoreOptions` — asserts the store delegate reaches `MemoryStoreOptions` (strategy + prefix). Meta tests: 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)