### PR TITLE
docs: reconcile drift with shipped code (counts, versions, statuses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Internalized retrieval layer providing:
 - graph-enriched context retrieval with custom traversal patterns
 
 ### 6. MCP layer
-A .NET MCP server exposing 21 memory tools, 6 resources, and 3 prompts to external MCP clients (Claude Desktop, etc.) via stdio and HTTP transports.
+A .NET MCP server exposing 25 memory tools, 6 resources, and 3 prompts to external MCP clients (Claude Desktop, etc.) via stdio and HTTP transports.
 
 ### 7. Observability layer
 OpenTelemetry decorators for:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,7 +96,7 @@ Agent Memory for .NET is a **native .NET implementation of graph-native persiste
 │  │   configuration options — IGeocodingService,                │   │
 │  │   IEnrichmentService added Phase 5)                         │   │
 │  │                                                              │   │
-│  │  One approved external dep: M.E.AI.Abstractions 10.4.1      │   │
+│  │  One approved external dep: M.E.AI.Abstractions 10.5.1      │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -128,7 +128,7 @@ graph TD
 | Attribute | Value |
 |---|---|
 | **Purpose** | Domain contracts — all models, interfaces, and configuration types shared across the system |
-| **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.4.1 (approved, D-AR2-1) — .NET 9 BCL otherwise |
+| **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.5.1 (approved, D-AR2-1) — .NET 9 BCL otherwise |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK, any MCP SDK, any NuGet package **except** Microsoft.Extensions.AI.Abstractions |
 | **Key types** | 45 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, ReasoningTrace, ReasoningStep, ToolCall, etc.), 37 service interfaces, 11 repository interfaces, 15 configuration types (incl. `MemoryRankingOptions`), 11 enums (incl. `MemoryProfile`, `RankingIntent`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
 
@@ -145,7 +145,7 @@ AgentMemory.Abstractions.Options       — configuration records
 | Attribute | Value |
 |---|---|
 | **Purpose** | Orchestration — service implementations, extraction pipeline, context assembly, stubs |
-| **Dependencies** | Abstractions (project ref), Microsoft.Extensions.AI.Abstractions 10.4.1, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5, FuzzySharp |
+| **Dependencies** | Abstractions (project ref), Microsoft.Extensions.AI.Abstractions 10.5.1, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5, FuzzySharp |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK |
 | **Key types** | SystemClock, GuidIdGenerator, StubEmbeddingGenerator, EmbeddingOrchestrator, StubExtractionPipeline, StubEntityExtractor, StubFactExtractor, StubPreferenceExtractor, StubRelationshipExtractor, StubEntityResolver |
 
@@ -154,7 +154,7 @@ AgentMemory.Abstractions.Options       — configuration records
 | Attribute | Value |
 |---|---|
 | **Purpose** | Persistence — Neo4j repository implementations, Cypher queries, schema management, driver infrastructure |
-| **Dependencies** | Abstractions (project ref), Core (project ref), Neo4j.Driver 6.0.0, Microsoft.Extensions.AI.Abstractions 10.4.1, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5 |
+| **Dependencies** | Abstractions (project ref), Core (project ref), Neo4j.Driver 6.0.0, Microsoft.Extensions.AI.Abstractions 10.5.1, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5 |
 | **MUST NOT reference** | Microsoft.Agents.* |
 | **Key types** | Neo4jDriverFactory, Neo4jSessionFactory, Neo4jTransactionRunner, SchemaBootstrapper, MigrationRunner, Neo4jOptions, ServiceCollectionExtensions |
 
@@ -165,7 +165,7 @@ AgentMemory.Abstractions.Options       — configuration records
 | Attribute | Value |
 |---|---|
 | **Purpose** | Thin adapter layer exposing memory capabilities to Microsoft Agent Framework |
-| **Dependencies** | Abstractions (project ref), Core (project ref), Neo4j (project ref), Microsoft.Agents.AI.Abstractions 1.1.0, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5 |
+| **Dependencies** | Abstractions (project ref), Core (project ref), Neo4j (project ref), Microsoft.Agents.AI.Abstractions 1.9.0, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5 |
 | **MUST NOT reference** | Business logic — act only as a type mapper and adapter |
 | **Key types** | `Neo4jMemoryContextProvider` (extends `AIContextProvider`), `Neo4jChatMessageStore`, `Neo4jMicrosoftMemoryFacade`, `MafTypeMapper` (bidirectional `ChatMessage` ↔ `Message` mapping), `MemoryToolFactory` (6 tools), `AgentTraceRecorder` |
 | **Core responsibility** | Bridge between Microsoft Agent Framework lifecycle (`ProvideAIContextAsync`, `StoreAIContextAsync`) and Neo4j memory persistence |
@@ -316,8 +316,11 @@ All adapter packages have shipped. The table below was the original roadmap; `Ag
 | `:ReasoningStep` | `ReasoningStep` | `id`, `trace_id`, `step_number`, `thought`, `action`, `observation`, `embedding`, `metadata` |
 | `:ToolCall` | `ToolCall` | `id`, `step_id`, `tool_name`, `arguments`, `result`, `status`, `duration_ms`, `error`, `metadata` |
 | `:Tool` | *(aggregate)* | `name`, `created_at`, `total_calls` |
+| `:Extractor` | `ExtractorModel` | `id`, `name`, `version`, `config`, `created_at` — extraction provenance (upstream-parity node) |
+| `:ConsolidationRun` | *(audit)* | `id`, `kind`, `ran_at`, `dry_run`, `candidate_count`, `actions_taken` — memory-hygiene audit trail written when a consolidation run is applied (PR #113) |
+| `:Schema` | `SchemaModel` | `id`, `name`, `version`, `config` — custom-schema persistence; label + indexes declared by `SchemaBootstrapper` (the node-CRUD repository is a decided P2 omission, see `docs/schema.md`) |
 
-> **Note:** Entity-to-entity relationships use `RELATED_TO` via Neo4j native relationships (not a separate `:MemoryRelationship` node). The `Relationship` domain type maps to `RELATED_TO` relationship properties.
+> **Note:** `SchemaConstants.NodeLabels` defines all 12 labels above. Entity-to-entity relationships use `RELATED_TO` via Neo4j native relationships (not a separate `:MemoryRelationship` node). The `Relationship` domain type maps to `RELATED_TO` relationship properties.
 
 ### 4.2 Relationship Types
 
@@ -440,7 +443,7 @@ These rules are inviolable. Violation of any rule is a blocking review finding.
 **Enforcement:** Code review gates on all PRs, plus automated CI guards — **B1** via `AbstractionsContractGuardTests` and **B2–B6/B8** via `PackageBoundaryGuardTests` (both compiled-reference and `.csproj` scans). These run as unit tests in the Squad CI workflow on every PR. (**B7** — "no business logic in adapters" — remains a review-only rule.)
 
 **Current Verification (as of Gap Closure Sprint + MEAI adoption D-AR2-1):**
-- ✅ Abstractions .csproj: one `<PackageReference>` — `Microsoft.Extensions.AI.Abstractions` 10.4.1 (approved, B1)
+- ✅ Abstractions .csproj: one `<PackageReference>` — `Microsoft.Extensions.AI.Abstractions` 10.5.1 (approved, B1)
 - ✅ Core .csproj: FuzzySharp + M.E.AI.Abstractions + M.E.DI/Logging/Options (no Neo4j.Driver, no framework SDKs)
 - ✅ Neo4j .csproj: Neo4j.Driver 6.0.0 + M.E.DI/Logging/Options (no Microsoft.Agents.*, no MCP SDK)
 - ✅ `grep` for `Microsoft.Agents` across `src/AgentMemory.Neo4j/` returns zero matches
@@ -516,7 +519,7 @@ This approach:
 
 ### 6.6 MAF Version Context
 
-The upstream `neo4j-maf-provider` was built for **MAF 0.3** (pre-GA). Our Phase 3 MAF adapter targets the current **MAF 1.1.0** API surface. The reference project remains useful as architectural inspiration but is not referenced as a package dependency.
+The upstream `neo4j-maf-provider` was built for **MAF 0.3** (pre-GA). Our Phase 3 MAF adapter targets the current **MAF 1.9.0** API surface. The reference project remains useful as architectural inspiration but is not referenced as a package dependency.
 
 ---
 
@@ -592,8 +595,8 @@ Each package exists to prevent a specific unwanted transitive dependency from re
 | 4 | **Enrichment** | M.E.Http, M.E.Caching.Memory | Abstractions | **HTTP isolation.** Wikimedia/Nominatim enrichment requires HttpClient infrastructure and caching. Consumers who don't need external entity enrichment don't inherit these. |
 | 5 | **Extraction.AzureLanguage** | Azure.AI.TextAnalytics 5.3.0 | Abstractions | **Azure SDK firewall.** Azure.AI.TextAnalytics pulls Azure.Core, Azure.Identity, and their transitive graph. Users of LLM extraction should never see these. |
 | 6 | **Extraction.Llm** | M.E.AI.Abstractions | Abstractions, Core | **LLM extraction alternative.** Uses IChatClient for structured extraction. Separated from AzureLanguage so users choose one backend without pulling the other. |
-| 7 | **AgentFramework** | Microsoft.Agents.AI.Abstractions 1.1.0 | Abstractions, Core | **MAF firewall.** Non-MAF users (MCP hosts, standalone apps) should never see Microsoft.Agents.* in their dependency tree. |
-| 8 | **SemanticKernel** | Microsoft.SemanticKernel.Abstractions | Abstractions, Core | **SK firewall.** SK-specific integration layer — only SK users pay this cost. |
+| 7 | **AgentFramework** | Microsoft.Agents.AI.Abstractions 1.9.0 | Abstractions, Core | **MAF firewall.** Non-MAF users (MCP hosts, standalone apps) should never see Microsoft.Agents.* in their dependency tree. |
+| 8 | **SemanticKernel** | Microsoft.SemanticKernel 1.74.0 | Abstractions, Core | **SK firewall.** SK-specific integration layer — only SK users pay this cost (the full SK package, not just contracts). |
 | 9 | **McpServer** | ModelContextProtocol 1.2.0, M.E.Hosting | Abstractions | **MCP SDK firewall.** Only relevant for MCP server deployments. Library consumers never inherit MCP protocol overhead. |
 | 10 | **Observability** | OpenTelemetry.Api 1.12.0 | Abstractions, Core | **OTel opt-in.** Observability is additive, not mandatory. Consumers who don't export traces shouldn't reference OTel. |
 

--- a/docs/bitemporal-memory-assessment.md
+++ b/docs/bitemporal-memory-assessment.md
@@ -3,6 +3,8 @@
 > **Status:** Design / discussion document. **No code is changed by this document.**
 > **Date:** 2026-06-07 (revised after live-upstream re-verification + the decay-vs-deletion debate)
 > **Scope:** (1) Does agent-memory-dotnet have *full bitemporal* support? (2) What would "full bitemporal" add? (3) The harder question raised by upstream issue #42 and the moltbook post: is **decay/forgetting** actually *better* than bitemporal — and is forgetting **dangerous**? (4) What I would do, and what I'd want *my* memory to do. (5) A ready-to-file upstream issue.
+>
+> **✅ UPDATE (shipped since this draft):** The transaction-time clock is **no longer dead**. `InvalidateAsync` (soft-invalidate) and `SupersedeAsync` (contradiction→supersession) now **write** `invalidated_at` (+ `valid_until` for facts) and link `(loser)-[:SUPERSEDED_BY]->(winner)`, with `SchemaConstants.Properties.InvalidatedAt` declared and two-clock `RecallAsOfAsync` live. Decay is **non-destructive by default** (no `DETACH DELETE`). Implemented + verified live 2026-06-13 (D5/D7). The "transaction clock is dead / written by nothing" statements below (§1, §3, §9, §12) are the **pre-implementation problem statement** — kept for historical context; see the CHANGELOG and `review-2026-06-13-cycle*.md` for the shipped surface.
 
 ---
 
@@ -200,6 +202,8 @@ In one line: **I'd want decay as a dial on *recall*, bitemporal as the *ledger*,
 ---
 
 ## 12. Phased plan
+
+> **✅ All phases below shipped (D1–D7, verified live 2026-06-13).** Phase 1 = D1 recency re-ranker; Phase 2 = non-destructive decay-by-default; Phase 3 = `InvalidateAsync`/`SupersedeAsync` transaction-clock writer; Phase 4 = two-clock `RecallAsOfAsync(validAsOf, systemAsOf)`; Phase 5 = opt-in contradiction→supersession. The table is the original plan, kept for context.
 
 | Phase | Scope | Risk | Parity |
 |---|---|---|---|

--- a/docs/decay-improvement-proposal.md
+++ b/docs/decay-improvement-proposal.md
@@ -3,6 +3,8 @@
 > **Status:** Design proposal / discussion. **No code is changed by this document.**
 > **Date:** 2026-06-07
 > **Companions:** [`bitemporal-memory-assessment.md`](./bitemporal-memory-assessment.md) (the storage substrate — invalidate-not-delete) and [`upstream-issue-memory-decay-bitemporal.md`](./upstream-issue-memory-decay-bitemporal.md) (the upstream issue). This doc is about the **retrieval/relevance** side: *which kind of decay should we actually build?*
+>
+> **✅ UPDATE (shipped since this draft):** The D-series proposed here **landed and was verified live (2026-06-12/13)** — D1 recency re-ranker, D2 structural hop-decay (`structScore = score·γ^hops`), D3 query-intent presets, non-destructive decay-by-default, and the GDS `AgentMemory.Analytics` package. The §3 "reality check" table below is the **pre-implementation problem statement** — see §11 for the implemented design and the CHANGELOG for the shipped surface.
 
 ---
 
@@ -46,7 +48,7 @@ Seven families, two axes: **what** they down-weight, and **destructive vs non-de
 
 | Family | Current state in agent-memory-dotnet | Verdict |
 |---|---|---|
-| **Structural** | A `GraphRetriever` walks `MATCH path = (seed)-[:RELATED_TO*1..2]-(related)` and **computes `length(path) AS hops`** — but orders `score DESC, hops ASC` and applies **no per-hop decay**. Only `RELATED_TO` is traversed; `ABOUT`/`MENTIONS`/`SAME_AS`/`TOUCHED` are written but never walked multi-hop. No GDS/PageRank (deferred in docs). | 🟠 **Almost there — the hop distance is computed then discarded** |
+| **Structural** | **✅ Done (opt-in, D2).** `GraphRetriever.BuildTraversalCypher` now emits `structScore = score · γ^hops` and orders by it when `StructuralDecayGamma < 1.0`; off by default (γ=1.0, where `hops` remains a tiebreaker only). Only `RELATED_TO` is traversed; `ABOUT`/`MENTIONS`/`SAME_AS`/`TOUCHED` are written but not walked multi-hop. GDS/PageRank now ships as the opt-in `AgentMemory.Analytics` package. | ✅ **Done (opt-in) — see §11** |
 | **Retrieval (temporal)** | Search ranks **purely on vector cosine** (`ORDER BY score DESC`). The ACT-R retention score is computed but **never blended into ranking**. | 🔴 Missing |
 | **Importance** | `confidence` exists; not used as a retrieval modulator. | 🔴 Missing |
 | **Representation** | Long-trace summarization is **detect-only** (counts candidates, doesn't summarize). | ⚪ Not built (safe) |

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,7 +9,7 @@
 
 ## 1. Domain Model Overview
 
-The domain model comprises **31 domain types** organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, and configuration. All domain types are defined in `AgentMemory.Abstractions`.
+The domain model comprises **45 domain records** (plus 11 enums) organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, ranking, conflict detection, consolidation, and configuration. All domain types are defined in `AgentMemory.Abstractions`. (Counts are enforced by `AbstractionsContractGuardTests`.)
 
 ### Key Design Decisions
 
@@ -322,7 +322,7 @@ LLM-based extraction is implemented via `AgentMemory.Extraction.Llm`:
 All service interfaces are defined in `AgentMemory.Abstractions.Services`.
 
 This catalog is authoritative: it lists every interface in `AgentMemory.Abstractions.Services`
-(**29 total**), which is the count `architecture.md §3.1` refers to.
+(**37 total**), which is the count `architecture.md §3.1` and `AbstractionsContractGuardTests` enforce.
 
 | # | Interface | Purpose | Key Methods |
 |---|---|---|---|
@@ -331,7 +331,7 @@ This catalog is authoritative: it lists every interface in `AgentMemory.Abstract
 | 3 | `IMemoryIngestion` | Write role: add messages, extract & persist | `AddMessageAsync`, `AddMessagesAsync`, `ExtractAndPersistAsync`, `ExtractFromSessionAsync`, `ExtractFromConversationAsync` |
 | 4 | `IMemoryMaintenance` | Upkeep role: clear sessions, backfill embeddings | `ClearSessionAsync`, `GenerateEmbeddingsBatchAsync` |
 | 5 | `IShortTermMemoryService` | Conversation and message operations | `AddConversationAsync`, `AddMessageAsync`, `AddMessagesAsync`, `GetRecentMessagesAsync`, `GetRecentMessagesAsOfAsync`, `GetConversationMessagesAsync`, `SearchMessagesAsync`, `ClearSessionAsync` |
-| 6 | `ILongTermMemoryService` | Entity, fact, preference, relationship operations (incl. point-in-time search) | `AddEntityAsync`, `GetEntitiesByNameAsync`, `SearchEntitiesAsync`, `SearchEntitiesAsOfAsync`, `AddPreferenceAsync`, `GetPreferencesByCategoryAsync`, `SearchPreferencesAsync`, `SearchPreferencesAsOfAsync`, `DeletePreferenceAsync`, `AddFactAsync`, `GetFactsBySubjectAsync`, `SearchFactsAsync`, `SearchFactsAsOfAsync`, `AddRelationshipAsync`, `GetEntityRelationshipsAsync` |
+| 6 | `ILongTermMemoryService` | Entity, fact, preference, relationship operations (incl. point-in-time search + D5/D7 invalidate/supersede) | `AddEntityAsync`, `RecordEntityFeedbackAsync`, `GetEntitiesByNameAsync`, `SearchEntitiesAsync`, `SearchEntitiesAsOfAsync`, `InvalidateEntityAsync`, `AddPreferenceAsync`, `GetPreferencesByCategoryAsync`, `SearchPreferencesAsync`, `SearchPreferencesAsOfAsync`, `DeletePreferenceAsync`, `InvalidatePreferenceAsync`, `SupersedePreferenceAsync`, `AddFactAsync`, `GetFactsBySubjectAsync`, `SearchFactsAsync`, `SearchFactsAsOfAsync`, `InvalidateFactAsync`, `SupersedeFactAsync`, `AddRelationshipAsync`, `GetEntityRelationshipsAsync` |
 | 7 | `IReasoningMemoryService` | Trace, step, and tool call operations | `StartTraceAsync`, `AddStepAsync`, `RecordToolCallAsync`, `CompleteTraceAsync`, `GetTraceWithStepsAsync`, `ListTracesAsync`, `SearchSimilarTracesAsync` |
 | 8 | `IMemoryContextAssembler` | Context orchestration across all layers | `AssembleContextAsync`, `AssembleContextAsOfAsync` |
 | 9 | `IMemoryQueryFacade` | Render-ready search/command facade for adapters (tools, SK plugin) | `SearchMemoryAsync`, `RememberPreferenceAsync`, `RememberFactAsync`, `RecallPreferencesAsync`, `SearchKnowledgeAsync`, `FindSimilarTasksAsync` |
@@ -355,6 +355,14 @@ This catalog is authoritative: it lists every interface in `AgentMemory.Abstract
 | 27 | `ISessionIdGenerator` | Session-id strategy (per-conversation/day/user) | `GenerateSessionId` |
 | 28 | `IClock` | Testable time abstraction | `UtcNow` |
 | 29 | `IIdGenerator` | Testable ID generation | `GenerateId` |
+| 30 | `IConsolidationService` | Memory-hygiene consolidation (dedup/collapse), dry-run by default (PR #113) | `ConsolidateAsync` |
+| 31 | `IConflictDetectionService` | Detect (and optionally resolve) contradicting facts | `DetectFactContradictionsAsync`, `ResolveFactContradictionsAsync` |
+| 32 | `IMemoryOwnerContext` | Ambient owner/user id for the current scope (IC8, read) | `UserId` |
+| 33 | `IWritableMemoryOwnerContext` | Writable owner context — adapters set it per request/agent run | `UserId` (set) |
+| 34 | `IMemoryStoreContext` | Ambient application/memory-store id (R1b store tier, read) | `ApplicationId` |
+| 35 | `IWritableMemoryStoreContext` | Writable store context — route the store per scope | `ApplicationId` (set) |
+| 36 | `IMemoryRankingContext` | Ambient per-request ranking intent (D3, read) | `Intent` |
+| 37 | `IWritableMemoryRankingContext` | Writable ranking context — set by the assembler per recall | `Intent` (set) |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ The browser UI is available at `http://localhost:7474`.
 dotnet add package AgentMemory
 ```
 
-This pulls in `Abstractions`, `Core`, `Neo4j`, and `Extraction.Llm` in one reference.
+This pulls in `Abstractions`, `Core`, `Neo4j`, `Extraction.Llm`, `Observability`, `Enrichment`, and `Extraction.AzureLanguage` in one reference (the last three are inert until wired via the opt-in `WithObservability`, `WithEnrichment`, and `WithAzureLanguageExtraction` registration methods).
 
 ### Option B — Individual packages
 

--- a/docs/nextsteps.md
+++ b/docs/nextsteps.md
@@ -10,7 +10,7 @@
 | 4 – HIGH | S | NuGet Release Prep | CHANGELOG, CONTRIBUTING, semver, .csproj metadata, CI publish workflow | 80% | — | — | CHANGELOG + CONTRIBUTING exist; shared packaging metadata (v0.1.0-preview.1, MIT, README, SourceLink) + tag-gated `squad-release.yml` pack/push added 2026-06-05. Remaining: add `NUGET_API_KEY` secret and push a `v*` tag to publish. |
 | 1 – HIGH | F | Multi-user / multi-store isolation (R1/R1b) | owner_id + MemoryScope (optional shared) across all recall/lookup/GraphRAG/trace/relationship/AsOf paths; MAF/MCP/SK identity; owner indexes + migrations 0002/0003; per-application store tier (AsyncLocal context). | 100% | — | Memory_Review_and_Implementation_Plan.md | I1–I9 + IC1–IC6 on `remediation/analysis-review-hardening`; verified by Neo4j integration tests. Deferred (tracked in plan): entity-resolution sharing, IMemoryQueryFacade tool surface (IC8), session-clear owner-scoping. |
 | 5 – MED | F | Streaming Extraction | IStreamingExtractor (chunk/overlap/cross-chunk dedup) — built + unit-tested + **now DI-registered** in AddAgentMemoryCore (2026-06-06). Pure text→entities helper; owner stamping via PersistenceStage/ExtractionRequest.UserId. | 100% | — | — | Was held until R1 isolation landed; interface name IStreamingExtractor is final (not IStreamingExtractionPipeline). |
-| 6 – MED |  | CLI Tool | `dotnet tool` with `migrate` + `schema-check` commands | 0% | — | — | v1 scope only |
+| 6 – MED | F | CLI Tool | `agentmemory` dotnet tool: migrate, bootstrap, consolidate, decay, conflicts, schema-parity, invalidate, supersede | 100% | — | Memory_Review_and_Implementation_Plan.md | Shipped 2026-06-13 (`tools/AgentMemory.Cli`); verified end-to-end vs live Neo4j. The v1-spec `schema-check` (runtime DB conformance) was *not* shipped — `schema-parity` (static upstream-snapshot compatibility) is the closest; see the open item below. |
 | 7 – MED | F | GDS Support | Optional AgentMemory.Analytics package, GDS PageRank + community detection | 100% | — | — | Shipped 2026-06-13. `AddGdsMemoryAnalytics()`; `IMemoryPageRankService` + `IMemoryCommunityService` over an owner-scoped Cypher projection; graceful no-op without the GDS plugin. Validated by unit + live GDS-enabled integration tests. Not in the meta-package (opt-in). |
 | 8 – MED |  | BenchmarkDotNet Harness | Perf benchmarks for batch ops, vector search, decay, hybrid retrieval | 0% | — | — | — |
 | 9 – MED |  | S9 Truncation Refactor | Extract truncation strategies from MemoryContextAssembler | 0% | — | — | Low priority architectural cleanup |
@@ -51,9 +51,9 @@ All six implementation phases are complete. The gap-closure sprint (Waves A–C)
 
 Concretely:
 
-- **Packages:** `AgentMemory.Abstractions`, `.Core`, `.Neo4j`, `.AgentFramework`, `.Extraction.Llm`, `.Extraction.AzureLanguage`, `.Enrichment`, `.Observability`, `.McpServer`, `.SemanticKernel`, plus the `AgentMemory` meta-package.
+- **Packages:** `AgentMemory.Abstractions`, `.Core`, `.Neo4j`, `.AgentFramework`, `.Extraction.Llm`, `.Extraction.AzureLanguage`, `.Enrichment`, `.Observability`, `.McpServer`, `.SemanticKernel`, `.Analytics` (opt-in GDS), plus the `AgentMemory` meta-package.
 - **Architecture:** Strict ports-and-adapters layering, zero boundary violations, zero circular dependencies.
-- **Persistence:** Native Neo4j `datetime()` for all timestamps, 145+ centralised Cypher constants, MigrationRunner with versioned `.cypher` files.
+- **Persistence:** Native Neo4j `datetime()` for all timestamps, 133 centralised Cypher constants, MigrationRunner with versioned `.cypher` files.
 - **Search:** Vector (5 indexes + reasoning-step index), fulltext BM25 (3 indexes), hybrid (vector + BM25), and graph multi-hop traversal.
 - **Memory features:** Temporal point-in-time recall (`RecallAsOfAsync`), exponential memory decay (`MemoryDecayService`), multi-extractor merge strategies (five modes), batch UNWIND upserts.
 - **Agent integrations:** Microsoft Agent Framework, Semantic Kernel, MCP server (25 tools, 6 resources, 3 prompts).
@@ -81,9 +81,9 @@ This is not a single-dimension result. The two codebases are competitive on diff
 | **Batch upsert** | UNWIND-based bulk entity and fact upsert. Python has no batch API. |
 | **Migration versioning** | `MigrationRunner` with versioned `.cypher` files tracks schema evolution. Python has no migration system. |
 | **Multi-extractor merge strategies** | Five modes (Union, Intersection, Confidence, Cascade, FirstSuccess). Python is single-extractor only. |
-| **Schema richness** | 14 extra node properties, three extra relationship types, three fulltext indexes, one extra vector index beyond Python's schema. |
-| **Architecture rigour** | Strict ports-and-adapters across eleven packages, verified zero-violation dependency graph. Python is monolithic (one package, fifteen modules, no enforced boundaries). |
-| **Cypher centralisation** | 145 typed constants in thirteen domain files. Python has 99 in a single `queries.py`. |
+| **Schema richness** | 14 extra node properties, five extra relationship types, three fulltext indexes, one extra vector index beyond Python's schema. |
+| **Architecture rigour** | Strict ports-and-adapters across twelve packages, verified zero-violation dependency graph. Python is monolithic (one package, fifteen modules, no enforced boundaries). |
+| **Cypher centralisation** | 133 typed constants in thirteen domain files. Python has 99 in a single `queries.py`. |
 
 ### 2b. Where .NET is at Parity
 
@@ -220,6 +220,8 @@ Priority is ordered by strategic execution dependencies. Publishing with incorre
 ---
 
 ### Step 6 — CLI Tool (scoped v1: `migrate` + `schema-check`) + GDS Support (parallel)
+
+> **✅ Both shipped (2026-06-13).** The CLI delivered well beyond the v1 scope — `agentmemory` ships migrate, bootstrap, consolidate, decay, conflicts, schema-parity, invalidate, supersede (the planned `schema-check` runtime-conformance command was *not* built; `schema-parity` is a static upstream-snapshot check instead). GDS shipped as the opt-in `AgentMemory.Analytics` package. See the status tracker (row 6 / row 7). The planning text below is the original plan, kept for context.
 
 These two items are additive and independent. Neither blocks the other or any release. They can be worked in parallel by different engineers.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -19,7 +19,7 @@
 | Vector indexes | 5 | 6 (+reasoning_step_embedding_idx) | ✅ All 5 Python indexes present |
 | Point indexes | 1 | 1 | ✅ Match |
 | Fulltext indexes | 0 | 3 | 🔵 .NET extension |
-| Relationship types | 15 | 18 (+3 extras) | ✅ All 15 Python types present |
+| Relationship types | 15 | 20 (+5 extras) | ✅ All 15 Python types present (+SUPERSEDED_BY, +TOUCHED, +HAS_FACT, +HAS_PREFERENCE, +IN_SESSION) |
 | Relationship properties | 27 props | 27 of 27 | ✅ All 27 Python relationship properties written |
 | Property naming (snake_case) | — | All correct | ✅ Match |
 | Datetime storage | Native `datetime()` | Native `datetime()` | ✅ Match |
@@ -283,6 +283,8 @@ Not in Python. Used by .NET to track applied schema migrations.
 | 16 | `HAS_FACT` | → | `Conversation` | `Fact` | — | Conversation → Fact convenience link |
 | 17 | `HAS_PREFERENCE` | → | `Conversation` | `Preference` | — | Conversation → Preference convenience link |
 | 18 | `IN_SESSION` | → | `ReasoningTrace` | `Conversation` | — | Reverse of HAS_TRACE for bidirectional traversal |
+| 19 | `SUPERSEDED_BY` | → | `Fact`/`Preference` | `Fact`/`Preference` | — | D7 contradiction→supersession: links a soft-invalidated loser to its winner (non-destructive; mirrors upstream `supersede_preference`) |
+| 20 | `TOUCHED` | → | `ReasoningStep` | `Entity` | `recorded_at` (datetime) | Reasoning-step → Entity audit edge (matches Python `(:ReasoningStep)-[:TOUCHED]->(:Entity)`) |
 
 ### 2.7 RELATED_TO — .NET Extra Properties
 
@@ -757,7 +759,7 @@ C# Domain Model (PascalCase) → Repository Cypher (snake_case) → Neo4j (snake
 | Node labels | 11 | 12 | +1 | Migration (.NET infra) |
 | Node properties (Python set) | 73 | 73 of 73 | 0 | ✅ All properties written (G1, G2 resolved) |
 | Node properties (.NET extras) | — | +14 | +14 | See §8.1 |
-| Relationship types | 15 | 18 | +3 | HAS_FACT, HAS_PREFERENCE, IN_SESSION |
+| Relationship types | 15 | 20 | +5 | SUPERSEDED_BY, TOUCHED, HAS_FACT, HAS_PREFERENCE, IN_SESSION |
 | Relationship properties (Python set) | 27 | 27 of 27 | 0 | ✅ All properties written (G3 resolved) |
 | Relationship properties (.NET extras) | — | +5 | +5 | RELATED_TO extras (§8.3) |
 | Constraints | 9 | 10 | +1 | extractor_name |


### PR DESCRIPTION
Adversarial docs-vs-code review (4 scanners → verified) found **18 confirmed drift items** — all docs-only; the code is correct, the docs lagged the cycle-3–6 + multi-store work. Fixed in 8 files:

| Doc | Fix |
|-----|-----|
| `design.md` | service interfaces 29→**37** (+8 rows); domain types 31→**45 records** (11 enums); ILongTermMemoryService row gains the D5/D7 invalidate/supersede methods |
| `architecture.md` | M.E.AI.Abstractions 10.4.1→**10.5.1**; MAF/Agents.AI 1.1.0→**1.9.0**; SK `Abstractions`→`Microsoft.SemanticKernel 1.74.0`; +3 node labels (Extractor, ConsolidationRun, Schema → **12**) |
| `schema.md` | relationship types 18→**20** (+SUPERSEDED_BY, +TOUCHED) + both count tables |
| `README.md` | MCP tools 21→**25** |
| `getting-started.md` | meta-package lists all **7** bundled packages (was 4) |
| `nextsteps.md` | CLI row 0%→**shipped** (8 commands; flags that spec'd `schema-check` was *not* built); +Analytics; Cypher constants 145→**133** |
| `bitemporal-*` / `decay-*` | "✅ shipped since this draft" banners (D1–D7 / invalidate-supersede are live); fixed the stale reality-check + phased-plan rows |

All numbers cross-checked against `AbstractionsContractGuardTests` / `SchemaConstants` / the csproj versions / the `[McpServerTool]` count. **No code change.** Historical `review-*.md`/`archive/*` docs and the design.md mermaid diagram intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)