### PR TITLE
refactor(core): extract ITruncationStrategy from MemoryContextAssembler (S9)

### DIFF
--- a/src/AgentMemory.Core/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Core/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using AgentMemory.Abstractions.Services;
 using AgentMemory.Core.Extraction;
 using AgentMemory.Core.Resolution;
 using AgentMemory.Core.Services;
+using AgentMemory.Core.Services.Budgeting;
 using AgentMemory.Core.Stubs;
 
 namespace AgentMemory.Core;
@@ -63,6 +64,15 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IShortTermMemoryService, ShortTermMemoryService>();
         services.TryAddScoped<ILongTermMemoryService, LongTermMemoryService>();
         services.TryAddScoped<IReasoningMemoryService, ReasoningMemoryService>();
+
+        // Context-budget truncation strategies (S9). Registered as an enumerable so a consumer can add or
+        // replace a strategy for a given TruncationStrategy value; the assembler always falls back to its
+        // four built-ins, so these registrations are an override surface rather than a requirement.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITruncationStrategy, OldestFirstTruncationStrategy>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITruncationStrategy, LowestScoreFirstTruncationStrategy>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITruncationStrategy, ProportionalTruncationStrategy>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ITruncationStrategy, FailTruncationStrategy>());
+
         // GraphRAG is an optional source: resolve it with GetService so memory-only consumers
         // (who never call AddGraphRagAdapter) don't fail to construct the assembler. When the
         // GraphRAG adapter IS registered, that instance (incl. any observability decorator) is used.
@@ -74,7 +84,9 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<IEmbeddingOrchestrator>(),
             sp.GetRequiredService<IClock>(),
             sp.GetRequiredService<IOptions<MemoryOptions>>(),
-            sp.GetRequiredService<ILogger<MemoryContextAssembler>>()));
+            sp.GetRequiredService<ILogger<MemoryContextAssembler>>(),
+            rankingContext: null,
+            truncationStrategies: sp.GetServices<ITruncationStrategy>()));
         services.TryAddScoped<IMemoryService, MemoryService>();
 
         // Role interfaces (ISP): bind each to the same scoped IMemoryService instance so consumers

--- a/src/AgentMemory.Core/Services/Budgeting/ContextBudgetEstimator.cs
+++ b/src/AgentMemory.Core/Services/Budgeting/ContextBudgetEstimator.cs
@@ -1,0 +1,66 @@
+using AgentMemory.Abstractions.Domain;
+
+namespace AgentMemory.Core.Services.Budgeting;
+
+/// <summary>
+/// Character-cost estimation primitives shared by <see cref="MemoryContextAssembler"/> and the
+/// <see cref="ITruncationStrategy"/> implementations. These are pure functions over the assembled
+/// memory sections; the numbers are deliberately cheap approximations (≈4 chars per token) used only
+/// to keep an assembled context within its configured budget, never for billing or exact accounting.
+/// </summary>
+internal static class ContextBudgetEstimator
+{
+    /// <summary>Sum of the estimated character cost of every item in a section.</summary>
+    internal static int EstimateChars<T>(IReadOnlyList<T> items) =>
+        items.Sum(EstimateItemChars);
+
+    /// <summary>Estimated character cost of a single domain item.</summary>
+    internal static int EstimateItemChars<T>(T item) => item switch
+    {
+        // Every item costs at least 1 char so that budget truncation always makes forward progress —
+        // an empty-content message/preference must still reduce the running total when removed,
+        // otherwise the victim loop could churn through zero-cost items without nearing the budget.
+        Message m => Math.Max(1, m.Content.Length),
+        Entity e => (e.Name?.Length ?? 0) + (e.Description?.Length ?? 0) + 10,
+        Fact f => f.Subject.Length + f.Predicate.Length + f.Object.Length + 4,
+        Preference p => Math.Max(1, p.PreferenceText.Length),
+        ReasoningTrace t => t.Task.Length + (t.Outcome?.Length ?? 0) + 10,
+        _ => 50
+    };
+
+    /// <summary>
+    /// Keep the longest prefix of <paramref name="items"/> whose combined estimated cost does not exceed
+    /// <c>currentChars * ratio</c>. Used by the proportional truncation strategy to shrink each section
+    /// by the same fraction.
+    /// </summary>
+    internal static IReadOnlyList<T> TrimToRatio<T>(IReadOnlyList<T> items, int currentChars, double ratio)
+    {
+        if (items.Count == 0) return items;
+        int targetChars = (int)(currentChars * ratio);
+        int runningChars = 0;
+        int keepCount = 0;
+        foreach (var item in items)
+        {
+            int itemChars = EstimateItemChars(item);
+            if (runningChars + itemChars > targetChars) break;
+            runningChars += itemChars;
+            keepCount++;
+        }
+        return items.Take(keepCount).ToList();
+    }
+
+    /// <summary>
+    /// Truncates <paramref name="text"/> to at most <paramref name="budget"/> UTF-16 char units without
+    /// splitting a surrogate pair (a non-BMP character such as an emoji occupies 2 char units; slicing
+    /// between them would emit an orphaned surrogate). Backs the cut off by one when it lands on a low
+    /// surrogate.
+    /// </summary>
+    internal static string TruncateToCharBudget(string text, int budget)
+    {
+        if (budget >= text.Length) return text;
+        if (budget <= 0) return string.Empty;
+        // If the cut index sits on the low (second) half of a surrogate pair, back off so the pair stays whole.
+        if (char.IsLowSurrogate(text[budget])) budget--;
+        return text[..budget];
+    }
+}

--- a/src/AgentMemory.Core/Services/Budgeting/FailTruncationStrategy.cs
+++ b/src/AgentMemory.Core/Services/Budgeting/FailTruncationStrategy.cs
@@ -1,0 +1,21 @@
+using AgentMemory.Abstractions.Exceptions;
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.Core.Services.Budgeting;
+
+/// <summary>
+/// <see cref="TruncationStrategy.Fail"/> — refuse to truncate. Throws a <see cref="MemoryError"/> carrying
+/// the over-budget totals so the caller can surface a hard limit rather than silently dropping context.
+/// </summary>
+internal sealed class FailTruncationStrategy : ITruncationStrategy
+{
+    public TruncationStrategy Strategy => TruncationStrategy.Fail;
+
+    public TruncationResult Truncate(TruncationInput input) =>
+        throw MemoryError.Create(
+                $"Context budget exceeded: {input.TotalCharacters} chars (limit {input.MaxCharacters}).")
+            .WithCode(MemoryErrorCodes.ContextBudgetExceeded)
+            .WithMetadata("totalChars", input.TotalCharacters)
+            .WithMetadata("maxChars", input.MaxCharacters)
+            .Build();
+}

--- a/src/AgentMemory.Core/Services/Budgeting/ITruncationStrategy.cs
+++ b/src/AgentMemory.Core/Services/Budgeting/ITruncationStrategy.cs
@@ -1,0 +1,47 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.Core.Services.Budgeting;
+
+/// <summary>
+/// A pluggable policy for fitting an over-budget set of assembled memory sections within a character
+/// limit. Each strategy maps to one <see cref="TruncationStrategy"/> value; the assembler dispatches to
+/// the matching strategy when the assembled context exceeds its <see cref="ContextBudget"/>.
+/// <para>Strategies are pure (stateless) and registered in DI as an enumerable, so a consumer can replace
+/// or add a strategy for a given <see cref="Strategy"/> value without subclassing the assembler.</para>
+/// </summary>
+internal interface ITruncationStrategy
+{
+    /// <summary>The budget strategy this implementation handles.</summary>
+    TruncationStrategy Strategy { get; }
+
+    /// <summary>Reduce the sections in <paramref name="input"/> until they fit the character budget.</summary>
+    TruncationResult Truncate(TruncationInput input);
+}
+
+/// <summary>
+/// The over-budget assembled sections plus the budget context a strategy needs. <see cref="TotalCharacters"/>
+/// is the estimated cost of all sections (recomputed by victim strategies from the lists; used directly by
+/// the proportional strategy for its shrink ratio).
+/// </summary>
+internal sealed record TruncationInput(
+    int MaxCharacters,
+    int TotalCharacters,
+    IReadOnlyList<Message> Recent,
+    IReadOnlyList<Message> Relevant,
+    IReadOnlyList<Entity> Entities,
+    IReadOnlyList<Preference> Preferences,
+    IReadOnlyList<Fact> Facts,
+    IReadOnlyList<ReasoningTrace> Traces,
+    string? GraphRag);
+
+/// <summary>The sections after truncation. Always considered truncated (the assembler only invokes a
+/// strategy once the within-budget early-return has been ruled out).</summary>
+internal sealed record TruncationResult(
+    IReadOnlyList<Message> Recent,
+    IReadOnlyList<Message> Relevant,
+    IReadOnlyList<Entity> Entities,
+    IReadOnlyList<Preference> Preferences,
+    IReadOnlyList<Fact> Facts,
+    IReadOnlyList<ReasoningTrace> Traces,
+    string? GraphRag);

--- a/src/AgentMemory.Core/Services/Budgeting/ProportionalTruncationStrategy.cs
+++ b/src/AgentMemory.Core/Services/Budgeting/ProportionalTruncationStrategy.cs
@@ -1,0 +1,32 @@
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.Core.Services.Budgeting;
+
+/// <summary>
+/// <see cref="TruncationStrategy.Proportional"/> — shrink every section (and the GraphRAG block) by the same
+/// fraction <c>maxChars / totalChars</c>, keeping the longest in-budget prefix of each. Preserves the
+/// relative mix of sources rather than removing items globally.
+/// </summary>
+internal sealed class ProportionalTruncationStrategy : ITruncationStrategy
+{
+    public TruncationStrategy Strategy => TruncationStrategy.Proportional;
+
+    public TruncationResult Truncate(TruncationInput input)
+    {
+        double ratio = (double)input.MaxCharacters / input.TotalCharacters;
+
+        var trimmedRecent = ContextBudgetEstimator.TrimToRatio(input.Recent, ContextBudgetEstimator.EstimateChars(input.Recent), ratio);
+        var trimmedRelevant = ContextBudgetEstimator.TrimToRatio(input.Relevant, ContextBudgetEstimator.EstimateChars(input.Relevant), ratio);
+        var trimmedEntities = ContextBudgetEstimator.TrimToRatio(input.Entities, ContextBudgetEstimator.EstimateChars(input.Entities), ratio);
+        var trimmedPreferences = ContextBudgetEstimator.TrimToRatio(input.Preferences, ContextBudgetEstimator.EstimateChars(input.Preferences), ratio);
+        var trimmedFacts = ContextBudgetEstimator.TrimToRatio(input.Facts, ContextBudgetEstimator.EstimateChars(input.Facts), ratio);
+        var trimmedTraces = ContextBudgetEstimator.TrimToRatio(input.Traces, ContextBudgetEstimator.EstimateChars(input.Traces), ratio);
+
+        string? trimmedGraphRag = input.GraphRag is null
+            ? null
+            : ContextBudgetEstimator.TruncateToCharBudget(input.GraphRag, (int)(input.GraphRag.Length * ratio));
+
+        return new TruncationResult(trimmedRecent, trimmedRelevant, trimmedEntities,
+            trimmedPreferences, trimmedFacts, trimmedTraces, trimmedGraphRag);
+    }
+}

--- a/src/AgentMemory.Core/Services/Budgeting/VictimTruncationStrategy.cs
+++ b/src/AgentMemory.Core/Services/Budgeting/VictimTruncationStrategy.cs
@@ -1,0 +1,130 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.Core.Services.Budgeting;
+
+/// <summary>
+/// Base for the "remove one worst item at a time until within budget" strategies. Concrete subclasses
+/// decide which item is "worst" via <see cref="IsWorse"/>; GraphRAG (a single opaque string) is dropped
+/// only once every section item has been removed.
+/// </summary>
+internal abstract class VictimTruncationStrategy : ITruncationStrategy
+{
+    /// <inheritdoc/>
+    public abstract TruncationStrategy Strategy { get; }
+
+    /// <summary>True when <paramref name="candidate"/> should be removed before <paramref name="current"/>.</summary>
+    protected abstract bool IsWorse(Victim candidate, Victim current);
+
+    /// <summary>A removal candidate: identifies one item in one section plus the keys used to rank it.</summary>
+    protected readonly record struct Victim(int Section, int Index, int Chars, DateTimeOffset Timestamp, double ScoreRank);
+
+    public TruncationResult Truncate(TruncationInput input)
+    {
+        var recentList = input.Recent.ToList();
+        var relevantList = input.Relevant.ToList();
+        var entityList = input.Entities.ToList();
+        var prefList = input.Preferences.ToList();
+        var factList = input.Facts.ToList();
+        var traceList = input.Traces.ToList();
+        var graphRag = input.GraphRag;
+
+        int totalChars = ContextBudgetEstimator.EstimateChars(recentList) + ContextBudgetEstimator.EstimateChars(relevantList)
+            + ContextBudgetEstimator.EstimateChars(entityList) + ContextBudgetEstimator.EstimateChars(prefList)
+            + ContextBudgetEstimator.EstimateChars(factList) + ContextBudgetEstimator.EstimateChars(traceList)
+            + (graphRag?.Length ?? 0);
+
+        while (totalChars > input.MaxCharacters)
+        {
+            var victim = SelectVictim(recentList, relevantList, entityList, prefList, factList, traceList);
+            if (victim is null)
+            {
+                // No section items remain — drop the GraphRAG block last.
+                if (graphRag != null) { totalChars -= graphRag.Length; graphRag = null; continue; }
+                break;
+            }
+
+            totalChars -= victim.Value.Chars;
+            RemoveVictim(victim.Value, recentList, relevantList, entityList, prefList, factList, traceList);
+        }
+
+        return new TruncationResult(recentList, relevantList, entityList, prefList, factList, traceList, graphRag);
+    }
+
+    private Victim? SelectVictim(
+        List<Message> recent,
+        List<Message> relevant,
+        List<Entity> entities,
+        List<Preference> preferences,
+        List<Fact> facts,
+        List<ReasoningTrace> traces)
+    {
+        Victim? worst = null;
+
+        void Consider(int section, int index, int count, int chars, DateTimeOffset timestamp)
+        {
+            // Sections arrive best-score-first; map position to a [0,1] relevance proxy
+            // (1.0 = best in section, 0.0 = worst). A singleton is treated as best-in-section.
+            double scoreRank = count <= 1 ? 1.0 : (double)(count - 1 - index) / (count - 1);
+            var candidate = new Victim(section, index, chars, timestamp, scoreRank);
+            if (worst is null || IsWorse(candidate, worst.Value))
+                worst = candidate;
+        }
+
+        for (int i = 0; i < recent.Count; i++) Consider(0, i, recent.Count, ContextBudgetEstimator.EstimateItemChars(recent[i]), recent[i].TimestampUtc);
+        for (int i = 0; i < relevant.Count; i++) Consider(1, i, relevant.Count, ContextBudgetEstimator.EstimateItemChars(relevant[i]), relevant[i].TimestampUtc);
+        for (int i = 0; i < entities.Count; i++) Consider(2, i, entities.Count, ContextBudgetEstimator.EstimateItemChars(entities[i]), entities[i].CreatedAtUtc);
+        for (int i = 0; i < preferences.Count; i++) Consider(3, i, preferences.Count, ContextBudgetEstimator.EstimateItemChars(preferences[i]), preferences[i].CreatedAtUtc);
+        for (int i = 0; i < facts.Count; i++) Consider(4, i, facts.Count, ContextBudgetEstimator.EstimateItemChars(facts[i]), facts[i].CreatedAtUtc);
+        for (int i = 0; i < traces.Count; i++) Consider(5, i, traces.Count, ContextBudgetEstimator.EstimateItemChars(traces[i]), traces[i].StartedAtUtc);
+
+        return worst;
+    }
+
+    private static void RemoveVictim(
+        Victim victim,
+        List<Message> recent,
+        List<Message> relevant,
+        List<Entity> entities,
+        List<Preference> preferences,
+        List<Fact> facts,
+        List<ReasoningTrace> traces)
+    {
+        switch (victim.Section)
+        {
+            case 0: recent.RemoveAt(victim.Index); break;
+            case 1: relevant.RemoveAt(victim.Index); break;
+            case 2: entities.RemoveAt(victim.Index); break;
+            case 3: preferences.RemoveAt(victim.Index); break;
+            case 4: facts.RemoveAt(victim.Index); break;
+            case 5: traces.RemoveAt(victim.Index); break;
+        }
+    }
+}
+
+/// <summary>
+/// <see cref="TruncationStrategy.OldestFirst"/> — remove the globally oldest item (by timestamp) across all
+/// sections first; ties broken by lowest relevance.
+/// </summary>
+internal sealed class OldestFirstTruncationStrategy : VictimTruncationStrategy
+{
+    public override TruncationStrategy Strategy => TruncationStrategy.OldestFirst;
+
+    protected override bool IsWorse(Victim candidate, Victim current) =>
+        candidate.Timestamp < current.Timestamp
+        || (candidate.Timestamp == current.Timestamp && candidate.ScoreRank < current.ScoreRank);
+}
+
+/// <summary>
+/// <see cref="TruncationStrategy.LowestScoreFirst"/> — remove the globally lowest-relevance item first, using
+/// each item's rank within its repo-sorted (best-score-first) section as the score proxy; ties broken by
+/// oldest timestamp.
+/// </summary>
+internal sealed class LowestScoreFirstTruncationStrategy : VictimTruncationStrategy
+{
+    public override TruncationStrategy Strategy => TruncationStrategy.LowestScoreFirst;
+
+    protected override bool IsWorse(Victim candidate, Victim current) =>
+        candidate.ScoreRank < current.ScoreRank
+        || (candidate.ScoreRank == current.ScoreRank && candidate.Timestamp < current.Timestamp);
+}

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
-using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Services.Budgeting;
 
 namespace AgentMemory.Core.Services;
 
@@ -20,10 +20,12 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
     private readonly IClock _clock;
     private readonly MemoryOptions _options;
     private readonly IWritableMemoryRankingContext? _rankingContext;
+    private readonly IReadOnlyDictionary<TruncationStrategy, ITruncationStrategy> _truncationStrategies;
     private readonly ILogger<MemoryContextAssembler> _logger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MemoryContextAssembler"/> class.
+    /// Initializes a new instance of the <see cref="MemoryContextAssembler"/> class with the built-in
+    /// context-budget truncation strategies.
     /// </summary>
     public MemoryContextAssembler(
         IShortTermMemoryService shortTerm,
@@ -35,6 +37,29 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         IOptions<MemoryOptions> options,
         ILogger<MemoryContextAssembler> logger,
         IWritableMemoryRankingContext? rankingContext = null)
+        : this(shortTerm, longTerm, reasoning, graphRag, embeddingOrchestrator, clock, options, logger,
+            rankingContext, truncationStrategies: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a custom set of <see cref="ITruncationStrategy"/> implementations
+    /// (the DI path). Any supplied strategy overrides the built-in default for its
+    /// <see cref="ITruncationStrategy.Strategy"/> value; the four built-ins always remain present as a
+    /// fallback (so <see cref="TruncationStrategy.OldestFirst"/> is guaranteed for the unknown-strategy
+    /// default). <paramref name="truncationStrategies"/> null ⇒ built-ins only.
+    /// </summary>
+    internal MemoryContextAssembler(
+        IShortTermMemoryService shortTerm,
+        ILongTermMemoryService longTerm,
+        IReasoningMemoryService reasoning,
+        IGraphRagContextSource? graphRag,
+        IEmbeddingOrchestrator embeddingOrchestrator,
+        IClock clock,
+        IOptions<MemoryOptions> options,
+        ILogger<MemoryContextAssembler> logger,
+        IWritableMemoryRankingContext? rankingContext,
+        IEnumerable<ITruncationStrategy>? truncationStrategies)
     {
         _shortTerm = shortTerm;
         _longTerm = longTerm;
@@ -44,7 +69,28 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         _clock = clock;
         _options = options.Value;
         _rankingContext = rankingContext;
+        _truncationStrategies = BuildStrategyMap(truncationStrategies);
         _logger = logger;
+    }
+
+    // Start from the four built-in strategies (so the OldestFirst fallback is always available even when
+    // DI passes an empty enumerable), then let any injected strategy override the default for its key.
+    private static IReadOnlyDictionary<TruncationStrategy, ITruncationStrategy> BuildStrategyMap(
+        IEnumerable<ITruncationStrategy>? injected)
+    {
+        var map = new Dictionary<TruncationStrategy, ITruncationStrategy>
+        {
+            [TruncationStrategy.OldestFirst] = new OldestFirstTruncationStrategy(),
+            [TruncationStrategy.LowestScoreFirst] = new LowestScoreFirstTruncationStrategy(),
+            [TruncationStrategy.Proportional] = new ProportionalTruncationStrategy(),
+            [TruncationStrategy.Fail] = new FailTruncationStrategy(),
+        };
+
+        if (injected is not null)
+            foreach (var strategy in injected)
+                map[strategy.Strategy] = strategy;
+
+        return map;
     }
 
     /// <inheritdoc/>
@@ -169,12 +215,12 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
                 ApplyBudget(budget, recentMessages, relevantMessages, entities, preferences, facts, traces, graphRagContext);
         }
 
-        int estimatedChars = EstimateChars(recentMessages)
-            + EstimateChars(relevantMessages)
-            + EstimateChars(entities)
-            + EstimateChars(preferences)
-            + EstimateChars(facts)
-            + EstimateChars(traces)
+        int estimatedChars = ContextBudgetEstimator.EstimateChars(recentMessages)
+            + ContextBudgetEstimator.EstimateChars(relevantMessages)
+            + ContextBudgetEstimator.EstimateChars(entities)
+            + ContextBudgetEstimator.EstimateChars(preferences)
+            + ContextBudgetEstimator.EstimateChars(facts)
+            + ContextBudgetEstimator.EstimateChars(traces)
             + (graphRagContext?.Length ?? 0);
 
         var context = new MemoryContext
@@ -343,233 +389,27 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         int maxChars = budget.MaxCharacters
             ?? (budget.MaxTokens.HasValue ? budget.MaxTokens.Value * 4 : int.MaxValue);
 
-        int totalChars = EstimateChars(recent) + EstimateChars(relevant)
-            + EstimateChars(entities) + EstimateChars(preferences)
-            + EstimateChars(facts) + EstimateChars(traces)
+        int totalChars = ContextBudgetEstimator.EstimateChars(recent) + ContextBudgetEstimator.EstimateChars(relevant)
+            + ContextBudgetEstimator.EstimateChars(entities) + ContextBudgetEstimator.EstimateChars(preferences)
+            + ContextBudgetEstimator.EstimateChars(facts) + ContextBudgetEstimator.EstimateChars(traces)
             + (graphRagContext?.Length ?? 0);
 
         if (totalChars <= maxChars)
             return new AssembledSections(recent, relevant, entities, preferences, facts, traces, graphRagContext, false);
 
-        return budget.TruncationStrategy switch
-        {
-            TruncationStrategy.Fail =>
-                throw MemoryError.Create($"Context budget exceeded: {totalChars} chars (limit {maxChars}).")
-                    .WithCode(MemoryErrorCodes.ContextBudgetExceeded)
-                    .WithMetadata("totalChars", totalChars)
-                    .WithMetadata("maxChars", maxChars)
-                    .Build(),
+        var strategy = ResolveStrategy(budget.TruncationStrategy);
+        var result = strategy.Truncate(new TruncationInput(
+            maxChars, totalChars, recent, relevant, entities, preferences, facts, traces, graphRagContext));
 
-            TruncationStrategy.OldestFirst =>
-                FitByVictim(maxChars, BudgetVictimStrategy.OldestFirst, recent, relevant, entities, preferences, facts, traces, graphRagContext),
-
-            TruncationStrategy.LowestScoreFirst =>
-                FitByVictim(maxChars, BudgetVictimStrategy.LowestScoreFirst, recent, relevant, entities, preferences, facts, traces, graphRagContext),
-
-            TruncationStrategy.Proportional =>
-                TruncateProportional(maxChars, totalChars, recent, relevant, entities, preferences, facts, traces, graphRagContext),
-
-            _ => FitByVictim(maxChars, BudgetVictimStrategy.OldestFirst, recent, relevant, entities, preferences, facts, traces, graphRagContext)
-        };
+        return new AssembledSections(
+            result.Recent, result.Relevant, result.Entities, result.Preferences,
+            result.Facts, result.Traces, result.GraphRag, Truncated: true);
     }
 
-    private enum BudgetVictimStrategy
-    {
-        /// <summary>Remove the globally oldest item (by timestamp) across all sections first.</summary>
-        OldestFirst,
-
-        /// <summary>Remove the globally lowest-relevance item first, using each item's rank within its
-        /// repo-sorted (best-score-first) section as the score proxy — repositories return scored results
-        /// sorted by descending similarity, so trailing positions correspond to the lowest scores.</summary>
-        LowestScoreFirst
-    }
-
-    /// <summary>A removal candidate: identifies one item in one section plus the keys used to rank it.</summary>
-    private readonly record struct Victim(int Section, int Index, int Chars, DateTimeOffset Timestamp, double ScoreRank);
-
-    /// <summary>
-    /// Fit the assembled sections within <paramref name="maxChars"/> by repeatedly removing the single
-    /// "worst" item according to <paramref name="strategy"/> until within budget. GraphRAG (a single
-    /// opaque string) is dropped only once every section item has been removed.
-    /// </summary>
-    private static AssembledSections FitByVictim(
-        int maxChars,
-        BudgetVictimStrategy strategy,
-        IReadOnlyList<Message> recent,
-        IReadOnlyList<Message> relevant,
-        IReadOnlyList<Entity> entities,
-        IReadOnlyList<Preference> preferences,
-        IReadOnlyList<Fact> facts,
-        IReadOnlyList<ReasoningTrace> traces,
-        string? graphRag)
-    {
-        var recentList = recent.ToList();
-        var relevantList = relevant.ToList();
-        var entityList = entities.ToList();
-        var prefList = preferences.ToList();
-        var factList = facts.ToList();
-        var traceList = traces.ToList();
-
-        int totalChars = EstimateChars(recentList) + EstimateChars(relevantList)
-            + EstimateChars(entityList) + EstimateChars(prefList)
-            + EstimateChars(factList) + EstimateChars(traceList)
-            + (graphRag?.Length ?? 0);
-
-        while (totalChars > maxChars)
-        {
-            var victim = SelectVictim(strategy, recentList, relevantList, entityList, prefList, factList, traceList);
-            if (victim is null)
-            {
-                // No section items remain — drop the GraphRAG block last.
-                if (graphRag != null) { totalChars -= graphRag.Length; graphRag = null; continue; }
-                break;
-            }
-
-            totalChars -= victim.Value.Chars;
-            RemoveVictim(victim.Value, recentList, relevantList, entityList, prefList, factList, traceList);
-        }
-
-        return new AssembledSections(recentList, relevantList, entityList, prefList, factList, traceList, graphRag, true);
-    }
-
-    private static Victim? SelectVictim(
-        BudgetVictimStrategy strategy,
-        List<Message> recent,
-        List<Message> relevant,
-        List<Entity> entities,
-        List<Preference> preferences,
-        List<Fact> facts,
-        List<ReasoningTrace> traces)
-    {
-        Victim? worst = null;
-
-        void Consider(int section, int index, int count, int chars, DateTimeOffset timestamp)
-        {
-            // Sections arrive best-score-first; map position to a [0,1] relevance proxy
-            // (1.0 = best in section, 0.0 = worst). A singleton is treated as best-in-section.
-            double scoreRank = count <= 1 ? 1.0 : (double)(count - 1 - index) / (count - 1);
-            var candidate = new Victim(section, index, chars, timestamp, scoreRank);
-            if (worst is null || IsWorse(strategy, candidate, worst.Value))
-                worst = candidate;
-        }
-
-        for (int i = 0; i < recent.Count; i++) Consider(0, i, recent.Count, EstimateItemChars(recent[i]), recent[i].TimestampUtc);
-        for (int i = 0; i < relevant.Count; i++) Consider(1, i, relevant.Count, EstimateItemChars(relevant[i]), relevant[i].TimestampUtc);
-        for (int i = 0; i < entities.Count; i++) Consider(2, i, entities.Count, EstimateItemChars(entities[i]), entities[i].CreatedAtUtc);
-        for (int i = 0; i < preferences.Count; i++) Consider(3, i, preferences.Count, EstimateItemChars(preferences[i]), preferences[i].CreatedAtUtc);
-        for (int i = 0; i < facts.Count; i++) Consider(4, i, facts.Count, EstimateItemChars(facts[i]), facts[i].CreatedAtUtc);
-        for (int i = 0; i < traces.Count; i++) Consider(5, i, traces.Count, EstimateItemChars(traces[i]), traces[i].StartedAtUtc);
-
-        return worst;
-    }
-
-    private static bool IsWorse(BudgetVictimStrategy strategy, Victim candidate, Victim current) => strategy switch
-    {
-        // Oldest timestamp loses first; ties broken by lowest relevance.
-        BudgetVictimStrategy.OldestFirst =>
-            candidate.Timestamp < current.Timestamp
-            || (candidate.Timestamp == current.Timestamp && candidate.ScoreRank < current.ScoreRank),
-
-        // Lowest relevance loses first; ties broken by oldest timestamp.
-        BudgetVictimStrategy.LowestScoreFirst =>
-            candidate.ScoreRank < current.ScoreRank
-            || (candidate.ScoreRank == current.ScoreRank && candidate.Timestamp < current.Timestamp),
-
-        _ => false
-    };
-
-    private static void RemoveVictim(
-        Victim victim,
-        List<Message> recent,
-        List<Message> relevant,
-        List<Entity> entities,
-        List<Preference> preferences,
-        List<Fact> facts,
-        List<ReasoningTrace> traces)
-    {
-        switch (victim.Section)
-        {
-            case 0: recent.RemoveAt(victim.Index); break;
-            case 1: relevant.RemoveAt(victim.Index); break;
-            case 2: entities.RemoveAt(victim.Index); break;
-            case 3: preferences.RemoveAt(victim.Index); break;
-            case 4: facts.RemoveAt(victim.Index); break;
-            case 5: traces.RemoveAt(victim.Index); break;
-        }
-    }
-
-    private static AssembledSections TruncateProportional(
-        int maxChars,
-        int totalChars,
-        IReadOnlyList<Message> recent,
-        IReadOnlyList<Message> relevant,
-        IReadOnlyList<Entity> entities,
-        IReadOnlyList<Preference> preferences,
-        IReadOnlyList<Fact> facts,
-        IReadOnlyList<ReasoningTrace> traces,
-        string? graphRag)
-    {
-        double ratio = (double)maxChars / totalChars;
-
-        var trimmedRecent = TrimToRatio(recent, EstimateChars(recent), ratio);
-        var trimmedRelevant = TrimToRatio(relevant, EstimateChars(relevant), ratio);
-        var trimmedEntities = TrimToRatio(entities, EstimateChars(entities), ratio);
-        var trimmedPreferences = TrimToRatio(preferences, EstimateChars(preferences), ratio);
-        var trimmedFacts = TrimToRatio(facts, EstimateChars(facts), ratio);
-        var trimmedTraces = TrimToRatio(traces, EstimateChars(traces), ratio);
-
-        string? trimmedGraphRag = graphRag is null
-            ? null
-            : TruncateToCharBudget(graphRag, (int)(graphRag.Length * ratio));
-
-        return new AssembledSections(trimmedRecent, trimmedRelevant, trimmedEntities,
-            trimmedPreferences, trimmedFacts, trimmedTraces, trimmedGraphRag, true);
-    }
-
-    /// <summary>
-    /// Truncates <paramref name="text"/> to at most <paramref name="budget"/> UTF-16 char units without
-    /// splitting a surrogate pair (a non-BMP character such as an emoji occupies 2 char units; slicing
-    /// between them would emit an orphaned surrogate). Backs the cut off by one when it lands on a low
-    /// surrogate.
-    /// </summary>
-    internal static string TruncateToCharBudget(string text, int budget)
-    {
-        if (budget >= text.Length) return text;
-        if (budget <= 0) return string.Empty;
-        // If the cut index sits on the low (second) half of a surrogate pair, back off so the pair stays whole.
-        if (char.IsLowSurrogate(text[budget])) budget--;
-        return text[..budget];
-    }
-
-    private static IReadOnlyList<T> TrimToRatio<T>(IReadOnlyList<T> items, int currentChars, double ratio)
-    {
-        if (items.Count == 0) return items;
-        int targetChars = (int)(currentChars * ratio);
-        int runningChars = 0;
-        int keepCount = 0;
-        foreach (var item in items)
-        {
-            int itemChars = EstimateItemChars(item);
-            if (runningChars + itemChars > targetChars) break;
-            runningChars += itemChars;
-            keepCount++;
-        }
-        return items.Take(keepCount).ToList();
-    }
-
-    private static int EstimateChars<T>(IReadOnlyList<T> items) =>
-        items.Sum(EstimateItemChars);
-
-    private static int EstimateItemChars<T>(T item) => item switch
-    {
-        // Every item costs at least 1 char so that budget truncation always makes forward progress —
-        // an empty-content message/preference must still reduce the running total when removed,
-        // otherwise the victim loop could churn through zero-cost items without nearing the budget.
-        Message m => Math.Max(1, m.Content.Length),
-        Entity e => (e.Name?.Length ?? 0) + (e.Description?.Length ?? 0) + 10,
-        Fact f => f.Subject.Length + f.Predicate.Length + f.Object.Length + 4,
-        Preference p => Math.Max(1, p.PreferenceText.Length),
-        ReasoningTrace t => t.Task.Length + (t.Outcome?.Length ?? 0) + 10,
-        _ => 50
-    };
+    // Dispatch to the requested strategy, falling back to OldestFirst for any value without a registered
+    // strategy — preserving the original switch's default arm. OldestFirst is always present (BuildStrategyMap).
+    private ITruncationStrategy ResolveStrategy(TruncationStrategy strategy) =>
+        _truncationStrategies.TryGetValue(strategy, out var resolved)
+            ? resolved
+            : _truncationStrategies[TruncationStrategy.OldestFirst];
 }

--- a/tests/AgentMemory.Tests.Unit/Services/Budgeting/TruncationStrategyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/Budgeting/TruncationStrategyTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Core.Services.Budgeting;
+
+namespace AgentMemory.Tests.Unit.Services.Budgeting;
+
+/// <summary>
+/// S9 — direct unit tests for the individual <see cref="ITruncationStrategy"/> implementations extracted
+/// from <c>MemoryContextAssembler</c>. These exercise each policy in isolation; the assembler-level budget
+/// behaviour is also covered end-to-end by <c>MemoryContextAssemblerTests</c> (the regression guarantee
+/// that this extraction is behaviour-preserving).
+/// </summary>
+public sealed class TruncationStrategyTests
+{
+    private static readonly DateTimeOffset T0 = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static Message Msg(string id, int contentLen, DateTimeOffset ts) => new()
+    {
+        MessageId = id,
+        ConversationId = "c",
+        SessionId = "s",
+        Role = "user",
+        Content = new string('x', contentLen),
+        TimestampUtc = ts
+    };
+
+    private static TruncationInput Input(
+        int maxChars,
+        IReadOnlyList<Message>? recent = null,
+        IReadOnlyList<Message>? relevant = null,
+        string? graphRag = null)
+    {
+        recent ??= Array.Empty<Message>();
+        relevant ??= Array.Empty<Message>();
+        int total = ContextBudgetEstimator.EstimateChars(recent)
+            + ContextBudgetEstimator.EstimateChars(relevant)
+            + (graphRag?.Length ?? 0);
+        return new TruncationInput(
+            maxChars, total, recent, relevant,
+            Array.Empty<Entity>(), Array.Empty<Preference>(), Array.Empty<Fact>(),
+            Array.Empty<ReasoningTrace>(), graphRag);
+    }
+
+    // ── Strategy ⇒ enum mapping ──────────────────────────────────────────────
+
+    [Fact]
+    public void EachStrategy_MapsToItsEnumValue()
+    {
+        new OldestFirstTruncationStrategy().Strategy.Should().Be(TruncationStrategy.OldestFirst);
+        new LowestScoreFirstTruncationStrategy().Strategy.Should().Be(TruncationStrategy.LowestScoreFirst);
+        new ProportionalTruncationStrategy().Strategy.Should().Be(TruncationStrategy.Proportional);
+        new FailTruncationStrategy().Strategy.Should().Be(TruncationStrategy.Fail);
+    }
+
+    // ── Fail ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Fail_Throws_ContextBudgetExceeded_WithTotals()
+    {
+        var input = Input(maxChars: 5, recent: new[] { Msg("a", 10, T0) });
+
+        var act = () => new FailTruncationStrategy().Truncate(input);
+
+        act.Should().Throw<MemoryException>()
+            .Where(e => e.Code == MemoryErrorCodes.ContextBudgetExceeded)
+            .Where(e => e.Metadata.ContainsKey("totalChars") && e.Metadata.ContainsKey("maxChars"));
+    }
+
+    // ── OldestFirst ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OldestFirst_RemovesOldestItemFirst()
+    {
+        var older = Msg("older", 10, T0);
+        var newer = Msg("newer", 10, T0.AddHours(1));
+        // 20 chars total, budget 12 ⇒ exactly one item must be dropped.
+        var result = new OldestFirstTruncationStrategy().Truncate(Input(maxChars: 12, recent: new[] { older, newer }));
+
+        result.Recent.Should().ContainSingle().Which.MessageId.Should().Be("newer");
+    }
+
+    // ── LowestScoreFirst ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void LowestScoreFirst_RemovesTrailing_LowestRelevance_First()
+    {
+        // best-score-first ordering: index 0 = best (scoreRank 1.0), index 1 = worst (scoreRank 0.0).
+        // Give the BEST item the OLDER timestamp so an oldest-first policy would behave differently —
+        // this isolates the score-driven choice.
+        var best = Msg("best", 10, T0);              // oldest, but highest relevance
+        var worst = Msg("worst", 10, T0.AddHours(1)); // newest, but lowest relevance
+        var result = new LowestScoreFirstTruncationStrategy().Truncate(Input(maxChars: 12, relevant: new[] { best, worst }));
+
+        result.Relevant.Should().ContainSingle().Which.MessageId.Should().Be("best");
+    }
+
+    // ── Proportional ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Proportional_ShrinksSection_AndGraphRag_ByRatio()
+    {
+        // recent: 4 × 10 chars = 40; graphRag 20 chars; total 60; budget 30 ⇒ ratio 0.5.
+        var recent = new[] { Msg("0", 10, T0), Msg("1", 10, T0), Msg("2", 10, T0), Msg("3", 10, T0) };
+        var input = Input(maxChars: 30, recent: recent, graphRag: new string('g', 20));
+
+        var result = new ProportionalTruncationStrategy().Truncate(input);
+
+        // target per section = 40 * 0.5 = 20 chars ⇒ keep 2 messages (10+10).
+        result.Recent.Should().HaveCount(2);
+        // graphRag trimmed to floor(20 * 0.5) = 10 chars.
+        result.GraphRag.Should().HaveLength(10);
+    }
+
+    [Fact]
+    public void Proportional_NullGraphRag_StaysNull()
+    {
+        var input = Input(maxChars: 10, recent: new[] { Msg("0", 10, T0), Msg("1", 10, T0) }, graphRag: null);
+
+        var result = new ProportionalTruncationStrategy().Truncate(input);
+
+        result.GraphRag.Should().BeNull();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTruncationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTruncationTests.cs
@@ -1,11 +1,12 @@
 using FluentAssertions;
-using AgentMemory.Core.Services;
+using AgentMemory.Core.Services.Budgeting;
 
 namespace AgentMemory.Tests.Unit.Services;
 
 /// <summary>
 /// cycle-5 #5 — proportional GraphRAG truncation must not split a UTF-16 surrogate pair (e.g. an emoji),
-/// which would emit an orphaned surrogate.
+/// which would emit an orphaned surrogate. The logic now lives in <see cref="ContextBudgetEstimator"/>
+/// (S9 extraction).
 /// </summary>
 public sealed class MemoryContextAssemblerTruncationTests
 {
@@ -16,7 +17,7 @@ public sealed class MemoryContextAssemblerTruncationTests
     [InlineData("hello", -5, "")]
     public void TruncateToCharBudget_Ascii(string input, int budget, string expected)
     {
-        MemoryContextAssembler.TruncateToCharBudget(input, budget).Should().Be(expected);
+        ContextBudgetEstimator.TruncateToCharBudget(input, budget).Should().Be(expected);
     }
 
     [Fact]
@@ -26,9 +27,9 @@ public sealed class MemoryContextAssemblerTruncationTests
         const string text = "😀world";
 
         // Cutting at 2 keeps the whole emoji.
-        MemoryContextAssembler.TruncateToCharBudget(text, 2).Should().Be("😀");
+        ContextBudgetEstimator.TruncateToCharBudget(text, 2).Should().Be("😀");
         // Cutting at 1 would split the pair — must back off to 0 (drop the half-emoji) rather than orphan it.
-        MemoryContextAssembler.TruncateToCharBudget(text, 1).Should().Be("");
+        ContextBudgetEstimator.TruncateToCharBudget(text, 1).Should().Be("");
     }
 
     [Fact]
@@ -38,7 +39,7 @@ public sealed class MemoryContextAssemblerTruncationTests
 
         for (int budget = 0; budget <= text.Length + 1; budget++)
         {
-            var result = MemoryContextAssembler.TruncateToCharBudget(text, budget);
+            var result = ContextBudgetEstimator.TruncateToCharBudget(text, budget);
             // A well-formed UTF-16 string has no high surrogate that isn't immediately followed by a low one,
             // and no low surrogate that isn't immediately preceded by a high one.
             for (int i = 0; i < result.Length; i++)


### PR DESCRIPTION
## What

Extracts the inline context-budget truncation `switch` out of `MemoryContextAssembler` into a small, individually-testable strategy set under a new `AgentMemory.Core.Services.Budgeting` namespace (internal to Core).

## Why

`MemoryContextAssembler` had grown to 575 lines, ~200 of which were the budget-fitting machinery (victim selection, proportional trimming, char estimation) inlined as private static methods. S9 (from `docs/ROADMAP.md`) separates that concern so each truncation policy is a named class, individually unit-testable, and overridable via DI.

## How

- **`ContextBudgetEstimator`** — char-cost primitives (`EstimateChars`/`EstimateItemChars`/`TrimToRatio`/`TruncateToCharBudget`) shared by the assembler and strategies. The cycle-5 surrogate-pair-safe truncation is preserved **verbatim**.
- **`ITruncationStrategy`** + `TruncationInput`/`TruncationResult` records.
- **`FailTruncationStrategy`**, **`OldestFirstTruncationStrategy`** / **`LowestScoreFirstTruncationStrategy`** (sharing a `VictimTruncationStrategy` base), **`ProportionalTruncationStrategy`** — one class per `TruncationStrategy` enum value.
- The assembler resolves a strategy from an injected `IReadOnlyDictionary<TruncationStrategy, ITruncationStrategy>` (four built-ins, overlaid by any DI-supplied strategy) and dispatches. Unknown values still fall back to `OldestFirst`, matching the old `switch`'s default arm.
- **Public ctor unchanged** (built-ins only); a new **internal** ctor takes the strategy set for the DI path. Strategies are registered via `TryAddEnumerable`, so a consumer can override one without subclassing the assembler.

## Behaviour-preserving

- All **2502** unit tests pass, including the end-to-end budget regression suite in `MemoryContextAssemblerTests` (OldestFirst / LowestScoreFirst / Proportional / Fail / drop-GraphRAG / as-of) — the guarantee that this is a pure refactor.
- Adds `TruncationStrategyTests` exercising each strategy in isolation.
- Assembler shrinks 575 → ~410 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)