### PR TITLE
feat(benchmarks): BenchmarkDotNet harness for hot-path Neo4j operations

### DIFF
--- a/benchmarks/AgentMemory.Benchmarks/AgentMemory.Benchmarks.csproj
+++ b/benchmarks/AgentMemory.Benchmarks/AgentMemory.Benchmarks.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Dev/ops tool, never shipped: not packable, and not bound by the src warnings-as-errors policy. -->
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- BenchmarkDotNet refuses to run a non-optimized build; keep Release optimized (the default). -->
+    <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="Testcontainers.Neo4j" Version="4.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgentMemory.Neo4j\AgentMemory.Neo4j.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.Core\AgentMemory.Core.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.Abstractions\AgentMemory.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/AgentMemory.Benchmarks/BatchUpsertBenchmarks.cs
+++ b/benchmarks/AgentMemory.Benchmarks/BatchUpsertBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Benchmarks.Infrastructure;
+using AgentMemory.Neo4j.Repositories;
+
+namespace AgentMemory.Benchmarks;
+
+/// <summary>
+/// Batch <c>UNWIND</c> upsert throughput: <see cref="Neo4jEntityRepository.UpsertBatchAsync"/> over a
+/// fixed set of <see cref="BatchSize"/> entities (no embeddings — this isolates the UNWIND/MERGE path).
+/// Re-running upserts the same ids, so the working set stays bounded (first call inserts, later calls
+/// match-update); both exercise the full batch statement.
+/// </summary>
+[MemoryDiagnoser]
+public class BatchUpsertBenchmarks
+{
+    [Params(100, 1000)]
+    public int BatchSize { get; set; }
+
+    private Neo4jEntityRepository _entities = null!;
+    private IReadOnlyList<Entity> _batch = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        var db = await BenchmarkNeo4j.GetAsync();
+        await db.CleanAsync();
+        _entities = new Neo4jEntityRepository(db.TransactionRunner, NullLogger<Neo4jEntityRepository>.Instance);
+        _batch = BenchmarkNeo4j.BuildEntities(BatchSize);
+    }
+
+    [Benchmark]
+    public async Task UpsertBatch() => await _entities.UpsertBatchAsync(_batch);
+}

--- a/benchmarks/AgentMemory.Benchmarks/DecayPruneBenchmarks.cs
+++ b/benchmarks/AgentMemory.Benchmarks/DecayPruneBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Benchmarks.Infrastructure;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Neo4j.Services;
+
+namespace AgentMemory.Benchmarks;
+
+/// <summary>
+/// Decay-prune scan cost: <see cref="Neo4jMemoryDecayService.PruneExpiredMemoriesAsync"/> over
+/// <see cref="SeedCount"/> fresh, high-confidence entities. Their retention score (≈ 0.95) is above the
+/// default 0.1 threshold, so every pass scans and scores the whole set but prunes nothing — a stable,
+/// repeatable measurement of the server-side decay scan rather than a one-shot deletion.
+/// </summary>
+[MemoryDiagnoser]
+public class DecayPruneBenchmarks
+{
+    [Params(2000)]
+    public int SeedCount { get; set; }
+
+    private Neo4jMemoryDecayService _decay = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        var db = await BenchmarkNeo4j.GetAsync();
+        await db.CleanAsync();
+        await db.SeedFreshEntitiesAsync(SeedCount);
+        _decay = new Neo4jMemoryDecayService(
+            db.TransactionRunner,
+            new SystemClock(),
+            Options.Create(new MemoryDecayOptions()),
+            NullLogger<Neo4jMemoryDecayService>.Instance);
+    }
+
+    [Benchmark]
+    public async Task<int> PrunePass() => await _decay.PruneExpiredMemoriesAsync();
+}

--- a/benchmarks/AgentMemory.Benchmarks/HybridRetrievalBenchmarks.cs
+++ b/benchmarks/AgentMemory.Benchmarks/HybridRetrievalBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Benchmarks.Infrastructure;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Neo4j.Infrastructure;
+using AgentMemory.Neo4j.Services;
+
+namespace AgentMemory.Benchmarks;
+
+/// <summary>
+/// Hybrid retrieval latency: <see cref="Neo4jGraphRagContextSource.GetContextAsync"/> in
+/// <see cref="GraphRagSearchMode.Hybrid"/> mode (vector + fulltext, score-blended) over a corpus of
+/// <see cref="SeedCount"/> <c>:Knowledge</c> nodes. The query is embedded by the deterministic stub
+/// generator, so no LLM call is on the hot path. Read-only and repeatable.
+/// </summary>
+[MemoryDiagnoser]
+public class HybridRetrievalBenchmarks
+{
+    [Params(2000)]
+    public int SeedCount { get; set; }
+
+    [Params(10)]
+    public int TopK { get; set; }
+
+    private Neo4jGraphRagContextSource _source = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        var db = await BenchmarkNeo4j.GetAsync();
+        await db.CleanAsync();
+        await db.CreateKnowledgeIndexesAsync();
+        await db.SeedKnowledgeAsync(SeedCount);
+
+        var options = Options.Create(new GraphRagOptions
+        {
+            IndexName = "knowledge_vec_idx",
+            FulltextIndexName = "knowledge_ft_idx",
+            SearchMode = GraphRagSearchMode.Hybrid,
+            TopK = TopK,
+            FilterStopWords = false
+        });
+
+        var embeddingGenerator = new StubEmbeddingGenerator(
+            NullLogger<StubEmbeddingGenerator>.Instance, BenchmarkNeo4j.EmbeddingDimensions);
+
+        _source = new Neo4jGraphRagContextSource(
+            db.Driver,
+            embeddingGenerator,
+            options,
+            NullLogger<Neo4jGraphRagContextSource>.Instance);
+    }
+
+    [Benchmark]
+    public async Task<int> HybridRetrieve()
+    {
+        var result = await _source.GetContextAsync(new GraphRagContextRequest
+        {
+            SessionId = "bench",
+            Query = "alpha beta gamma topic",
+            TopK = TopK
+        });
+        return result.Items.Count;
+    }
+}

--- a/benchmarks/AgentMemory.Benchmarks/Infrastructure/BenchmarkConfig.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Infrastructure/BenchmarkConfig.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+namespace AgentMemory.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Runs every benchmark <b>in-process</b> (no per-benchmark child process), which lets all benchmarks
+/// share the single <see cref="BenchmarkNeo4j"/> Testcontainer started on first use. Iteration counts are
+/// kept modest because each operation is a real network round-trip to Neo4j (milliseconds), not a
+/// nanosecond CPU kernel — the goal is comparative latency/throughput, not sub-microsecond precision.
+/// </summary>
+public sealed class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        AddJob(Job.Default
+            .WithToolchain(InProcessEmitToolchain.Instance)
+            .WithWarmupCount(3)
+            .WithIterationCount(8)
+            .WithInvocationCount(16)
+            .WithUnrollFactor(1));
+
+        AddLogger(ConsoleLogger.Default);
+        AddColumnProvider(DefaultColumnProviders.Instance);
+        WithOptions(ConfigOptions.DisableOptimizationsValidator); // tolerate IDE/dev launches; CI never runs this
+    }
+}

--- a/benchmarks/AgentMemory.Benchmarks/Infrastructure/BenchmarkNeo4j.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Infrastructure/BenchmarkNeo4j.cs
@@ -1,0 +1,241 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Neo4j.Infrastructure;
+using Neo4j.Driver;
+using Testcontainers.Neo4j;
+
+namespace AgentMemory.Benchmarks.Infrastructure;
+
+/// <summary>
+/// A single Neo4j Testcontainer shared by every benchmark in the process. BenchmarkDotNet is configured
+/// to run in-process (see <see cref="BenchmarkConfig"/>), so a process-wide singleton is safe and avoids
+/// paying container startup once per benchmark method. Started lazily on first <see cref="GetAsync"/> and
+/// torn down by <c>Program</c> after the run completes.
+/// </summary>
+public sealed class BenchmarkNeo4j : IAsyncDisposable
+{
+    /// <summary>Embedding dimensionality used for the vector indexes and all seeded vectors.</summary>
+    public const int EmbeddingDimensions = 768;
+
+    private const string ContainerUsername = "neo4j";
+    private const string ContainerPassword = "benchpassword";
+
+    private Neo4jContainer _container = null!;
+    private IDriver _driver = null!;
+
+    public IDriver Driver => _driver;
+    public INeo4jTransactionRunner TransactionRunner { get; private set; } = null!;
+
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+    private static BenchmarkNeo4j? _instance;
+
+    /// <summary>Returns the shared instance, starting (and bootstrapping) the container on first call.</summary>
+    public static async Task<BenchmarkNeo4j> GetAsync()
+    {
+        if (_instance is not null) return _instance;
+        await Gate.WaitAsync();
+        try
+        {
+            if (_instance is null)
+            {
+                var db = new BenchmarkNeo4j();
+                await db.StartAsync();
+                _instance = db;
+            }
+            return _instance;
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+
+    /// <summary>Disposes the shared instance, if started. Call once from <c>Program</c> after the run.</summary>
+    public static async Task ShutdownAsync()
+    {
+        if (_instance is not null)
+        {
+            await _instance.DisposeAsync();
+            _instance = null;
+        }
+    }
+
+    private async Task StartAsync()
+    {
+        _container = new Neo4jBuilder("neo4j:5.26")
+            .WithEnvironment("NEO4J_AUTH", $"{ContainerUsername}/{ContainerPassword}")
+            .Build();
+
+        await _container.StartAsync();
+
+        _driver = GraphDatabase.Driver(
+            _container.GetConnectionString(),
+            AuthTokens.Basic(ContainerUsername, ContainerPassword));
+
+        var options = Microsoft.Extensions.Options.Options.Create(new Neo4jOptions
+        {
+            Uri = _container.GetConnectionString(),
+            Username = ContainerUsername,
+            Password = ContainerPassword,
+            Database = "neo4j",
+            EmbeddingDimensions = EmbeddingDimensions
+        });
+
+        var sessionFactory = new DirectSessionFactory(_driver, "neo4j");
+        TransactionRunner = new Neo4jTransactionRunner(sessionFactory, NullLogger<Neo4jTransactionRunner>.Instance);
+
+        var bootstrapper = new SchemaBootstrapper(TransactionRunner, options, NullLogger<SchemaBootstrapper>.Instance);
+        await bootstrapper.BootstrapAsync();
+
+        await using var session = _driver.AsyncSession();
+        await session.RunAsync("CALL db.awaitIndexes(120)");
+    }
+
+    /// <summary>Deletes every node (and its relationships). Each benchmark's GlobalSetup starts from clean.</summary>
+    public async Task CleanAsync()
+    {
+        await using var session = _driver.AsyncSession();
+        await session.RunAsync("MATCH (n) DETACH DELETE n");
+    }
+
+    /// <summary>
+    /// Seeds <paramref name="count"/> <c>:Entity</c> nodes carrying deterministic embeddings, so the
+    /// entity vector index is populated for the vector-search benchmark. Written in chunks via UNWIND.
+    /// </summary>
+    public async Task SeedEntitiesWithEmbeddingsAsync(int count, int chunkSize = 500)
+    {
+        const string cypher = @"
+            UNWIND $items AS item
+            CREATE (e:Entity {
+                id: item.id, name: item.name, type: 'CONCEPT', confidence: 0.9,
+                created_at: datetime(item.createdAt), embedding: item.embedding
+            })";
+
+        await using var session = _driver.AsyncSession();
+        var createdAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero).ToString("O");
+
+        for (var start = 0; start < count; start += chunkSize)
+        {
+            var end = Math.Min(start + chunkSize, count);
+            var items = new List<object>(end - start);
+            for (var i = start; i < end; i++)
+            {
+                items.Add(new
+                {
+                    id = $"bench-entity-{i}",
+                    name = $"entity {i}",
+                    createdAt,
+                    embedding = DeterministicEmbedding.Create(i, EmbeddingDimensions)
+                });
+            }
+            await session.RunAsync(cypher, new { items });
+        }
+    }
+
+    /// <summary>
+    /// Seeds <paramref name="count"/> fresh, high-confidence <c>:Entity</c> nodes for the decay benchmark.
+    /// Recent <c>created_at</c> + confidence 0.95 ⇒ retention score ≈ 0.95, well above the default 0.1
+    /// threshold, so a prune pass scans+scores them all and removes none (a repeatable steady-state run).
+    /// </summary>
+    public async Task SeedFreshEntitiesAsync(int count, int chunkSize = 1000)
+    {
+        const string cypher = @"
+            UNWIND $items AS item
+            CREATE (e:Entity {
+                id: item.id, name: item.name, type: 'CONCEPT', confidence: 0.95,
+                created_at: datetime($now), last_accessed_at: datetime($now), access_count: 1
+            })";
+
+        await using var session = _driver.AsyncSession();
+        var now = DateTimeOffset.UtcNow.ToString("O");
+
+        for (var start = 0; start < count; start += chunkSize)
+        {
+            var end = Math.Min(start + chunkSize, count);
+            var items = new List<object>(end - start);
+            for (var i = start; i < end; i++)
+                items.Add(new { id = $"bench-decay-{i}", name = $"entity {i}" });
+            await session.RunAsync(cypher, new { items, now });
+        }
+    }
+
+    /// <summary>Creates the <c>:Knowledge</c> vector + fulltext indexes used by the hybrid-retrieval benchmark.</summary>
+    public async Task CreateKnowledgeIndexesAsync()
+    {
+        await using var session = _driver.AsyncSession();
+        await session.RunAsync(
+            $"CREATE VECTOR INDEX knowledge_vec_idx IF NOT EXISTS FOR (n:Knowledge) ON (n.embedding) " +
+            $"OPTIONS {{indexConfig: {{`vector.dimensions`: {EmbeddingDimensions}, `vector.similarity_function`: 'cosine'}}}}");
+        await session.RunAsync(
+            "CREATE FULLTEXT INDEX knowledge_ft_idx IF NOT EXISTS FOR (n:Knowledge) ON EACH [n.text]");
+        await session.RunAsync("CALL db.awaitIndexes(120)");
+    }
+
+    /// <summary>Seeds <paramref name="count"/> <c>:Knowledge</c> nodes with text + deterministic embeddings.</summary>
+    public async Task SeedKnowledgeAsync(int count, int chunkSize = 500)
+    {
+        const string cypher = @"
+            UNWIND $items AS item
+            CREATE (k:Knowledge {id: item.id, text: item.text, embedding: item.embedding})";
+
+        await using var session = _driver.AsyncSession();
+        for (var start = 0; start < count; start += chunkSize)
+        {
+            var end = Math.Min(start + chunkSize, count);
+            var items = new List<object>(end - start);
+            for (var i = start; i < end; i++)
+            {
+                items.Add(new
+                {
+                    id = $"bench-knowledge-{i}",
+                    text = $"knowledge node {i} about alpha beta gamma topic {i % 50}",
+                    embedding = DeterministicEmbedding.Create(i, EmbeddingDimensions)
+                });
+            }
+            await session.RunAsync(cypher, new { items });
+        }
+    }
+
+    /// <summary>Builds an in-memory list of <see cref="Entity"/> for the batch-upsert benchmark (no embeddings).</summary>
+    public static IReadOnlyList<Entity> BuildEntities(int count)
+    {
+        var createdAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var list = new List<Entity>(count);
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(new Entity
+            {
+                EntityId = $"bench-upsert-{i}",
+                Name = $"entity {i}",
+                Type = "CONCEPT",
+                Confidence = 0.9,
+                CreatedAtUtc = createdAt
+            });
+        }
+        return list;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_driver is not null) await _driver.DisposeAsync();
+        if (_container is not null) await _container.DisposeAsync();
+    }
+
+    private sealed class DirectSessionFactory : INeo4jSessionFactory
+    {
+        private readonly IDriver _driver;
+        private readonly string _database;
+
+        public DirectSessionFactory(IDriver driver, string database)
+        {
+            _driver = driver;
+            _database = database;
+        }
+
+        public IAsyncSession OpenSession(AccessMode accessMode = AccessMode.Write) =>
+            OpenSession(_database, accessMode);
+
+        public IAsyncSession OpenSession(string database, AccessMode accessMode = AccessMode.Write) =>
+            _driver.AsyncSession(c => c.WithDatabase(database).WithDefaultAccessMode(accessMode));
+    }
+}

--- a/benchmarks/AgentMemory.Benchmarks/Infrastructure/DeterministicEmbedding.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Infrastructure/DeterministicEmbedding.cs
@@ -1,0 +1,34 @@
+namespace AgentMemory.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Produces deterministic, unit-length embedding vectors from an integer seed. Same seed ⇒ same vector,
+/// so a benchmark run is reproducible. Content is meaningless — only the shape/magnitude matters for
+/// exercising the vector index, not semantic relevance.
+/// </summary>
+internal static class DeterministicEmbedding
+{
+    /// <summary>Returns a normalized <c>float[dimensions]</c> derived deterministically from <paramref name="seed"/>.</summary>
+    public static float[] Create(int seed, int dimensions)
+    {
+        // A small LCG seeded by `seed` — avoids Random's nondeterminism across runtimes and needs no shared state.
+        ulong state = unchecked((ulong)seed * 2862933555777941757UL + 3037000493UL);
+        var vector = new float[dimensions];
+        double sumSq = 0;
+        for (var i = 0; i < dimensions; i++)
+        {
+            state = unchecked(state * 6364136223846793005UL + 1442695040888963407UL);
+            // Map the high bits to [-1, 1).
+            var v = (double)(state >> 11) / (1UL << 53) * 2.0 - 1.0;
+            vector[i] = (float)v;
+            sumSq += v * v;
+        }
+
+        var norm = Math.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            var inv = (float)(1.0 / norm);
+            for (var i = 0; i < dimensions; i++) vector[i] *= inv;
+        }
+        return vector;
+    }
+}

--- a/benchmarks/AgentMemory.Benchmarks/Infrastructure/SmokeTest.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Infrastructure/SmokeTest.cs
@@ -1,0 +1,36 @@
+namespace AgentMemory.Benchmarks.Infrastructure;
+
+/// <summary>
+/// A fast, statistics-free self-test: runs each benchmark's GlobalSetup + body once against the shared
+/// Testcontainer (with small corpora) to prove the whole pipeline wires up and executes. Invoked via
+/// <c>--smoke</c>.
+/// </summary>
+internal static class SmokeTest
+{
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("[smoke] starting Neo4j container + schema bootstrap (first run pulls neo4j:5.26)...");
+
+        var upsert = new BatchUpsertBenchmarks { BatchSize = 100 };
+        await upsert.SetupAsync();
+        await upsert.UpsertBatch();
+        Console.WriteLine("[smoke] BatchUpsert OK (100 entities)");
+
+        var vector = new VectorSearchBenchmarks { SeedCount = 200, TopK = 10 };
+        await vector.SetupAsync();
+        var hits = await vector.SearchByVector();
+        Console.WriteLine($"[smoke] VectorSearch OK ({hits} hits)");
+
+        var decay = new DecayPruneBenchmarks { SeedCount = 200 };
+        await decay.SetupAsync();
+        var pruned = await decay.PrunePass();
+        Console.WriteLine($"[smoke] DecayPrune OK ({pruned} pruned, expected 0)");
+
+        var hybrid = new HybridRetrievalBenchmarks { SeedCount = 200, TopK = 10 };
+        await hybrid.SetupAsync();
+        var items = await hybrid.HybridRetrieve();
+        Console.WriteLine($"[smoke] HybridRetrieve OK ({items} items)");
+
+        Console.WriteLine("[smoke] all four benchmarks executed successfully.");
+    }
+}

--- a/benchmarks/AgentMemory.Benchmarks/Program.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Program.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using AgentMemory.Benchmarks;
+using AgentMemory.Benchmarks.Infrastructure;
+using BenchmarkDotNet.Running;
+
+// `--smoke` runs every benchmark's setup + body exactly once against the live container and prints the
+// result. It validates the whole pipeline (container start, schema bootstrap, seeding, each operation)
+// in seconds, without BenchmarkDotNet's statistical machinery — handy in dev/CI-adjacent checks.
+if (args.Contains("--smoke"))
+{
+    try
+    {
+        await SmokeTest.RunAsync();
+        return 0;
+    }
+    finally
+    {
+        await BenchmarkNeo4j.ShutdownAsync();
+    }
+}
+
+// Normal path: hand off to BenchmarkDotNet. The shared Testcontainer is started lazily by the first
+// benchmark's GlobalSetup and torn down here once the run (or a filtered subset) completes.
+try
+{
+    BenchmarkSwitcher
+        .FromAssembly(Assembly.GetExecutingAssembly())
+        .Run(args, new BenchmarkConfig());
+    return 0;
+}
+finally
+{
+    await BenchmarkNeo4j.ShutdownAsync();
+}

--- a/benchmarks/AgentMemory.Benchmarks/README.md
+++ b/benchmarks/AgentMemory.Benchmarks/README.md
@@ -1,0 +1,46 @@
+# AgentMemory Benchmarks
+
+A [BenchmarkDotNet](https://benchmarkdotnet.org/) harness that measures the latency/throughput of the
+hot-path Neo4j operations against a **real** Neo4j 5.26, started automatically via
+[Testcontainers](https://dotnet.testcontainers.org/) (so the only prerequisite is a running Docker engine).
+
+> **Not part of CI or the published packages.** Perf numbers are hardware-sensitive, so this project is
+> intentionally excluded from `AgentMemory.slnx`, the CI gate, and the NuGet meta-package. Run it manually
+> when you want to measure.
+
+## Benchmarks
+
+| Class | Operation measured |
+|-------|--------------------|
+| `BatchUpsertBenchmarks` | `Neo4jEntityRepository.UpsertBatchAsync` — batch `UNWIND`/`MERGE` upsert (100 / 1000 entities) |
+| `VectorSearchBenchmarks` | `Neo4jEntityRepository.SearchByVectorAsync` — entity vector search (top-K 10 / 50 over 2000 embedded entities) |
+| `DecayPruneBenchmarks` | `Neo4jMemoryDecayService.PruneExpiredMemoriesAsync` — server-side decay scan/score over 2000 nodes |
+| `HybridRetrievalBenchmarks` | `Neo4jGraphRagContextSource.GetContextAsync` — hybrid (vector + fulltext) retrieval over 2000 `:Knowledge` nodes |
+
+All benchmarks run **in-process** (one shared Testcontainer for the whole run) and use deterministic,
+LLM-free embeddings, so a run is reproducible and needs no API keys.
+
+## Running
+
+From the repository root, with Docker running:
+
+```bash
+# Run everything (Release is required by BenchmarkDotNet):
+dotnet run -c Release --project benchmarks/AgentMemory.Benchmarks -- --filter '*'
+
+# Run one class:
+dotnet run -c Release --project benchmarks/AgentMemory.Benchmarks -- --filter '*VectorSearch*'
+
+# Fast smoke check (one invocation each, no statistics) — handy to confirm wiring/Docker:
+dotnet run -c Release --project benchmarks/AgentMemory.Benchmarks -- --filter '*' --job Dry
+```
+
+Results (and the BenchmarkDotNet artifacts) are written under `BenchmarkDotNet.Artifacts/`.
+
+## Notes
+
+- The embedding dimensionality (`BenchmarkNeo4j.EmbeddingDimensions`, default **768**) and seed corpus
+  sizes are constants — tweak them to model your own workload.
+- Because Neo4j round-trips are millisecond-scale, the job uses modest warmup/iteration counts; raise them
+  in `BenchmarkConfig` if you need tighter confidence intervals.
+- First run pulls the `neo4j:5.26` image, which can take a minute.

--- a/benchmarks/AgentMemory.Benchmarks/VectorSearchBenchmarks.cs
+++ b/benchmarks/AgentMemory.Benchmarks/VectorSearchBenchmarks.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Benchmarks.Infrastructure;
+using AgentMemory.Neo4j.Repositories;
+
+namespace AgentMemory.Benchmarks;
+
+/// <summary>
+/// Entity vector search latency: <see cref="Neo4jEntityRepository.SearchByVectorAsync"/> against a corpus
+/// of <see cref="SeedCount"/> embedded entities, returning the <see cref="TopK"/> nearest. Read-only, so it
+/// is naturally repeatable.
+/// </summary>
+[MemoryDiagnoser]
+public class VectorSearchBenchmarks
+{
+    [Params(2000)]
+    public int SeedCount { get; set; }
+
+    [Params(10, 50)]
+    public int TopK { get; set; }
+
+    private Neo4jEntityRepository _entities = null!;
+    private float[] _query = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        var db = await BenchmarkNeo4j.GetAsync();
+        await db.CleanAsync();
+        await db.SeedEntitiesWithEmbeddingsAsync(SeedCount);
+        _entities = new Neo4jEntityRepository(db.TransactionRunner, NullLogger<Neo4jEntityRepository>.Instance);
+        _query = DeterministicEmbedding.Create(seed: 424242, BenchmarkNeo4j.EmbeddingDimensions);
+    }
+
+    [Benchmark]
+    public async Task<int> SearchByVector()
+    {
+        var results = await _entities.SearchByVectorAsync(_query, limit: TopK);
+        return results.Count;
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,12 +57,8 @@ The library has been adversarially reviewed end-to-end — **vertically** (per-a
 
 ## Pending work
 
-Nothing here is a bug or regression — it is scoped/deferred work, tracked accurately in
-[`nextsteps.md`](nextsteps.md).
-
-| Item | State | Notes |
-|------|-------|-------|
-| **BenchmarkDotNet harness** | ⏸️ deferred (post-v1) | Perf benchmarks (batch upsert, vector search, decay, hybrid). Hardware-sensitive; intentionally out of CI gating. |
+The previously-deferred v1 items are all now done (see the roadmap below). Nothing tracked here is a bug
+or regression; ongoing scoped work lives in [`nextsteps.md`](nextsteps.md).
 
 ---
 
@@ -71,8 +67,8 @@ Nothing here is a bug or regression — it is scoped/deferred work, tracked accu
 1. ✅ **`schema-check` CLI** — *done* (closed the one half-done v1 item; runtime DB conformance check).
 2. ✅ **S9 — truncation-strategy refactor** — *done* (`ITruncationStrategy` extracted from `MemoryContextAssembler`).
 3. ✅ **G4 — schema-node persistence** — *done* (`ISchemaManager` implemented over versioned `:Schema` nodes).
-4. **Real-world feedback on the preview** — validate the install/usage path; iterate on ergonomics.
-5. **Deferred items as demand warrants** — pick up the benchmark harness if a concrete need surfaces.
+4. ✅ **BenchmarkDotNet harness** — *done* (`benchmarks/AgentMemory.Benchmarks`: batch upsert, vector search, decay, hybrid retrieval against a Testcontainers Neo4j; intentionally out of CI gating and the meta-package).
+5. **Real-world feedback on the preview** — validate the install/usage path; iterate on ergonomics.
 6. **API stabilization → `1.0`** — lock the public surface under SemVer once the preview has soaked.
 
 ---


### PR DESCRIPTION
## What

Adds `benchmarks/AgentMemory.Benchmarks` — a [BenchmarkDotNet](https://benchmarkdotnet.org/) harness that measures the four hot-path operations against a **real** Neo4j 5.26 started automatically via Testcontainers (only prerequisite: a running Docker engine).

| Benchmark | Operation |
|-----------|-----------|
| `BatchUpsertBenchmarks` | `Neo4jEntityRepository.UpsertBatchAsync` — batch `UNWIND`/`MERGE` (100 / 1000) |
| `VectorSearchBenchmarks` | `Neo4jEntityRepository.SearchByVectorAsync` — top-K 10 / 50 over 2000 embedded entities |
| `DecayPruneBenchmarks` | `Neo4jMemoryDecayService.PruneExpiredMemoriesAsync` — server-side decay scan/score over 2000 nodes |
| `HybridRetrievalBenchmarks` | `Neo4jGraphRagContextSource.GetContextAsync` (Hybrid) — vector + fulltext over 2000 `:Knowledge` nodes |

## Design choices

- **In-process toolchain** (`InProcessEmitToolchain`) so a *single* Testcontainer is shared across all four benchmark classes — otherwise BenchmarkDotNet's default per-method child processes would each spin up their own Neo4j.
- **Deterministic, LLM-free embeddings** (`DeterministicEmbedding`) — reproducible runs, no API keys.
- **Decay is measured at steady state**: seeds fresh high-confidence nodes (retention ≈ 0.95 > 0.1 threshold) so each pass scans + scores the whole set but prunes nothing — repeatable, rather than a one-shot deletion that empties the set after iteration 1.
- **`--smoke`** runs each benchmark's setup + body once with small corpora to self-test the whole pipeline in seconds.

## Verification

`dotnet run -c Release --project benchmarks/AgentMemory.Benchmarks -- --smoke` — green locally against a live container:

```
[smoke] BatchUpsert OK (100 entities)
[smoke] VectorSearch OK (10 hits)
[smoke] DecayPrune OK (0 pruned, expected 0)
[smoke] HybridRetrieve OK (10 items)
[smoke] all four benchmarks executed successfully.
```

## Intentionally out of scope

Per the ROADMAP, perf is hardware-sensitive and Docker-dependent, so this project is **deliberately excluded** from `AgentMemory.slnx`, the CI gate, and the NuGet meta-package. It's a manual-run dev/ops tool (run instructions in its `README.md`). ROADMAP updated to mark the harness done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)