### PR TITLE
chore(ci): Node-20→24 action bumps + xUnit1026 fixes + G4 E2E shakedown

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -21,10 +21,10 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: TestResults/*.trx

--- a/.github/workflows/squad-docs.yml
+++ b/.github/workflows/squad-docs.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build docs
         run: |

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check triage script
         id: check-script
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-insider-release.yml
+++ b/.github/workflows/squad-insider-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +116,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -12,7 +12,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build and test
         run: |

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -19,12 +19,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,10 +15,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/tests/AgentMemory.Tests.Integration/ShakedownEndToEndTests.cs
+++ b/tests/AgentMemory.Tests.Integration/ShakedownEndToEndTests.cs
@@ -7,6 +7,7 @@ using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Schema;
 using AgentMemory.Core.Stubs;
 using AgentMemory.Neo4j.Infrastructure;
 using AgentMemory.Tests.Integration.Fixtures;
@@ -96,6 +97,8 @@ public sealed class ShakedownEndToEndTests : IAsyncLifetime
         sp.GetRequiredService<IMigrationRunner>().Should().NotBeNull();
         sp.GetRequiredService<ISchemaBootstrapper>().Should().NotBeNull();
         sp.GetRequiredService<IMemoryExtractionPipeline>().Should().NotBeNull();
+        // G4: custom entity-schema persistence is wired through the meta container too.
+        sp.GetRequiredService<ISchemaManager>().Should().NotBeNull();
     }
 
     [Fact]
@@ -155,6 +158,29 @@ public sealed class ShakedownEndToEndTests : IAsyncLifetime
         await facts.UpsertAsync(NewFact("Alice", "works_at", "Globex"));
         var conflictReport = await conflicts.DetectConflictsAsync();
         conflictReport.FactConflicts.Should().Contain(c => c.Subject == "Alice" && c.Predicate == "works_at");
+    }
+
+    [Fact]
+    public async Task CustomSchema_SavesAndLoadsActiveVersion_ThroughTheMetaContainer()
+    {
+        // G4 end-to-end through the real meta DI: persist a custom entity schema and read the active
+        // version back, exercising Neo4jSchemaManager + SchemaPersistenceQueries against the live DB.
+        using var scope = _provider.CreateScope();
+        var schemas = scope.ServiceProvider.GetRequiredService<ISchemaManager>();
+
+        var schema = SchemaLoader.CreateForTypes(["PATIENT", "DRUG"]) with
+        {
+            Name = "shakedown-medical",
+            Version = "1.0",
+            Description = "Shakedown custom schema"
+        };
+        await schemas.SaveSchemaAsync(schema);
+
+        (await schemas.SchemaExistsAsync("shakedown-medical")).Should().BeTrue();
+        var loaded = await schemas.LoadSchemaAsync("shakedown-medical");
+        loaded.Should().NotBeNull();
+        loaded!.Version.Should().Be("1.0");
+        loaded.GetEntityTypeNames().Should().BeEquivalentTo(["PATIENT", "DRUG"]);
     }
 
     private static Fact NewFact(string subject, string predicate, string obj) => new()

--- a/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
@@ -49,6 +49,7 @@ public sealed class ScopedVectorSearchQueryTests
     {
         var cypher = build(/*hasOwnerFilter*/ true, /*includeShared*/ false, /*topK*/ 50, /*recencyRerank*/ false);
 
+        cypher.Should().Contain(indexName, $"{label} searches its own vector index");
         cypher.Should().Contain("node.owner_id = $ownerId");
         cypher.Should().NotContain("owner_id IS NULL",
             $"{label} owner-only search must exclude shared/global (owner_id IS NULL) rows");
@@ -62,7 +63,9 @@ public sealed class ScopedVectorSearchQueryTests
         // (no node has invalidated_at set) but it is what makes a soft-invalidate disappear from recall.
         foreach (var (scoped, shared, rerank) in new[] { (false, true, false), (true, true, false), (true, false, true) })
         {
-            build(scoped, shared, 50, rerank).Should().Contain("node.invalidated_at IS NULL",
+            var cypher = build(scoped, shared, 50, rerank);
+            cypher.Should().Contain(indexName, $"{label} searches its own vector index");
+            cypher.Should().Contain("node.invalidated_at IS NULL",
                 $"{label} live recall must exclude invalidated nodes (scoped={scoped}, rerank={rerank})");
         }
     }
@@ -87,6 +90,7 @@ public sealed class ScopedVectorSearchQueryTests
     {
         var cypher = build(false, true, 10, /*recencyRerank*/ false);
 
+        cypher.Should().Contain(indexName, $"{label} searches its own vector index");
         cypher.Should().NotContain("$tmpWeight", $"{label} off-path must not blend the recency term");
         cypher.Should().NotContain("sTmp");
         cypher.Should().NotContain("$lambda");
@@ -118,6 +122,7 @@ public sealed class ScopedVectorSearchQueryTests
         // `owner_id IS NULL` clause (which would leak shared/global rows into a private recall).
         var cypher = build(/*hasOwnerFilter*/ true, /*includeShared*/ false, /*topK*/ 50, /*recencyRerank*/ true);
 
+        cypher.Should().Contain(indexName, $"{label} searches its own vector index");
         cypher.Should().Contain("node.owner_id = $ownerId");
         cypher.Should().NotContain("owner_id IS NULL",
             $"{label} owner-only + recency-rerank must exclude shared/global rows");

--- a/tests/AgentMemory.Tests.Unit/Queries/SupersedeQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/SupersedeQueryTests.cs
@@ -74,8 +74,10 @@ public sealed class SupersedeQueryTests
     public void Supersede_AlwaysGuardsSameOwner(string label, Func<bool, string> build)
     {
         // The same-owner guard is unconditional — present in BOTH the scoped and unscoped query shapes.
-        build(true).Should().Contain("coalesce(loser.owner_id, '*') = coalesce(winner.owner_id, '*')");
-        build(false).Should().Contain("coalesce(loser.owner_id, '*') = coalesce(winner.owner_id, '*')");
+        build(true).Should().Contain("coalesce(loser.owner_id, '*') = coalesce(winner.owner_id, '*')",
+            $"{label} scoped supersession must guard against crossing owners");
+        build(false).Should().Contain("coalesce(loser.owner_id, '*') = coalesce(winner.owner_id, '*')",
+            $"{label} unscoped supersession must still guard against crossing owners");
     }
 
     [Theory]


### PR DESCRIPTION
The closing hygiene items: GitHub Actions runtime bumps, xUnit warning cleanup, and bringing the end-to-end shakedown up to date with G4.

## GitHub Actions — off the deprecated Node 20 runtime

GitHub forces Node 24 for JS actions on **2026-06-02** and removes Node 20 on **2026-09-16**. Every official action is bumped to its Node-24 major across all 11 workflows:

| Action | From | To | Uses |
|--------|------|----|------|
| `actions/checkout` | `@v4` | `@v5` | 12 |
| `actions/setup-dotnet` | `@v4` | `@v5` | 2 |
| `actions/upload-artifact` | `@v4` | `@v5` | 1 |
| `actions/github-script` | `@v7` | `@v8` | 7 |

## xUnit1026 — five "unused theory parameter" warnings, fixed not suppressed

- The four `ScopedVectorSearchQueryTests` methods that ignored the `indexName` column now **assert the query embeds its index name** (which it does — a genuine, previously-missing check).
- `Supersede_AlwaysGuardsSameOwner` now uses `label` in its `because` messages, matching its siblings.

Unit build is warning-clean (`xUnit1026 warnings: 0`).

## E2E shakedown — brought current with G4

`ShakedownEndToEndTests` builds the whole stack through the real meta `AddNeo4jAgentMemory` DI container. Updated so the smoke also covers the newly-wired schema persistence:
- `AllTopLevelServices_ResolveFromTheMetaContainer` now also asserts `ISchemaManager` resolves.
- New `CustomSchema_SavesAndLoadsActiveVersion_ThroughTheMetaContainer` saves + loads a custom schema end-to-end through the real container against live Neo4j.

All **3** shakedown tests green locally; affected unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)