### PR TITLE
fix(benchmarks): assert result counts in the --smoke self-test

### DIFF
--- a/benchmarks/AgentMemory.Benchmarks/Infrastructure/SmokeTest.cs
+++ b/benchmarks/AgentMemory.Benchmarks/Infrastructure/SmokeTest.cs
@@ -16,21 +16,33 @@ internal static class SmokeTest
         await upsert.UpsertBatch();
         Console.WriteLine("[smoke] BatchUpsert OK (100 entities)");
 
+        // The read paths must return real results — otherwise the self-test is meaningless. Asserting the
+        // counts (not just printing them) is what catches a silently-broken path: e.g. the GraphRAG source
+        // swallows any retrieval exception and returns an EMPTY result, so without this check a broken
+        // hybrid query would still print "OK" and exit 0.
         var vector = new VectorSearchBenchmarks { SeedCount = 200, TopK = 10 };
         await vector.SetupAsync();
         var hits = await vector.SearchByVector();
+        Expect(hits > 0, $"VectorSearch returned {hits} hits over a 200-entity corpus — expected > 0 (vector index empty or query broken?)");
         Console.WriteLine($"[smoke] VectorSearch OK ({hits} hits)");
 
         var decay = new DecayPruneBenchmarks { SeedCount = 200 };
         await decay.SetupAsync();
         var pruned = await decay.PrunePass();
+        Expect(pruned == 0, $"DecayPrune removed {pruned} fresh high-confidence nodes — expected 0 (steady-state assumption violated)");
         Console.WriteLine($"[smoke] DecayPrune OK ({pruned} pruned, expected 0)");
 
         var hybrid = new HybridRetrievalBenchmarks { SeedCount = 200, TopK = 10 };
         await hybrid.SetupAsync();
         var items = await hybrid.HybridRetrieve();
+        Expect(items > 0, $"HybridRetrieve returned {items} items over a 200-node corpus — expected > 0 (index mismatch or swallowed retrieval error?)");
         Console.WriteLine($"[smoke] HybridRetrieve OK ({items} items)");
 
-        Console.WriteLine("[smoke] all four benchmarks executed successfully.");
+        Console.WriteLine("[smoke] all four benchmarks executed and asserted successfully.");
+    }
+
+    private static void Expect(bool condition, string message)
+    {
+        if (!condition) throw new InvalidOperationException($"[smoke] FAILED: {message}");
     }
 }


### PR DESCRIPTION
## What

Follow-up from the post-merge adversarial audit of the just-landed work. The audit confirmed one low-severity defect: the benchmark `--smoke` self-test **printed** the vector/hybrid/decay result counts but never **asserted** them.

`Neo4jGraphRagContextSource.GetContextAsync` wraps retrieval in a catch-all that logs a warning and returns an *empty* result. So if the hybrid (or vector) path ever silently broke — index-name mismatch, schema/driver issue — the smoke test would print `OK (0 items)` and exit `0`, and a benchmark run would time the exception fall-through instead of real retrieval. A self-test that reports green on a broken path isn't doing its job.

## Fix

`SmokeTest` now asserts:
- `VectorSearch` hits **> 0** (200-entity corpus must return results)
- `HybridRetrieve` items **> 0** (the case the swallowed-exception path would zero out)
- `DecayPrune` prunes **exactly 0** (the steady-state design guarantee it relies on)

A failing assertion throws and the process exits non-zero.

## Verification

`dotnet run -c Release --project benchmarks/AgentMemory.Benchmarks -- --smoke` — green:
```
[smoke] VectorSearch OK (10 hits)
[smoke] DecayPrune OK (0 pruned, expected 0)
[smoke] HybridRetrieve OK (10 items)
[smoke] all four benchmarks executed and asserted successfully.
```

Benchmarks-only change (project is outside `AgentMemory.slnx`/CI), so no production code or solution build is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)