### PR TITLE
fix(extraction): guard streaming chunker against Overlap >= ChunkSize (infinite loop / OOM)

### DIFF
--- a/src/AgentMemory.Abstractions/Options/StreamingExtractionOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/StreamingExtractionOptions.cs
@@ -54,4 +54,24 @@ public sealed class StreamingExtractionOptions
             ChunkSize = DefaultTokenChunkSize,
             Overlap = DefaultTokenOverlap
         };
+
+    /// <summary>
+    /// Validates that the chunking parameters can make forward progress. <see cref="ChunkSize"/> must be
+    /// positive and <see cref="Overlap"/> must be non-negative and STRICTLY less than <see cref="ChunkSize"/>;
+    /// otherwise the chunker's cursor never advances, producing an infinite loop and unbounded memory growth.
+    /// Called at the start of chunking so a misconfiguration fails fast with a clear message.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">When <see cref="ChunkSize"/> is ≤ 0 or <see cref="Overlap"/> is &lt; 0.</exception>
+    /// <exception cref="ArgumentException">When <see cref="Overlap"/> is ≥ <see cref="ChunkSize"/>.</exception>
+    public void Validate()
+    {
+        if (ChunkSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(ChunkSize), ChunkSize, "ChunkSize must be a positive integer.");
+        if (Overlap < 0)
+            throw new ArgumentOutOfRangeException(nameof(Overlap), Overlap, "Overlap must be non-negative.");
+        if (Overlap >= ChunkSize)
+            throw new ArgumentException(
+                $"Overlap ({Overlap}) must be strictly less than ChunkSize ({ChunkSize}); otherwise chunking cannot advance.",
+                nameof(Overlap));
+    }
 }

--- a/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
+++ b/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
@@ -32,6 +32,7 @@ public sealed class StreamingExtractor : IStreamingExtractor
         StreamingExtractionOptions? options = null)
     {
         var opts = options ?? new StreamingExtractionOptions();
+        opts.Validate(); // fail fast on Overlap >= ChunkSize / ChunkSize <= 0 (would otherwise spin forever)
         return opts.ChunkByTokens
             ? TextChunker.ChunkByTokens(text, opts.ChunkSize, opts.Overlap)
             : TextChunker.ChunkByChars(text, opts.ChunkSize, opts.Overlap, opts.SplitOnSentences);

--- a/src/AgentMemory.Core/Extraction/Streaming/TextChunker.cs
+++ b/src/AgentMemory.Core/Extraction/Streaming/TextChunker.cs
@@ -69,7 +69,11 @@ internal static class TextChunker
                 IsLast = end >= text.Length
             });
 
-            start = end < text.Length ? end - overlap : end;
+            // Always advance by at least one char so the loop can never spin in place (defense in depth —
+            // StreamingExtractor.ChunkDocument already rejects overlap >= chunkSize, but a direct internal
+            // caller could still pass a degenerate combination). Math.Max keeps the intended overlap when
+            // it makes real forward progress.
+            start = end < text.Length ? Math.Max(start + 1, end - overlap) : end;
             chunkIndex++;
         }
 
@@ -134,7 +138,8 @@ internal static class TextChunker
                 IsLast = endTokenIdx >= tokens.Count
             });
 
-            tokenIdx = endTokenIdx < tokens.Count ? endTokenIdx - overlap : endTokenIdx;
+            // Always advance by at least one token (see ChunkByChars note) so the loop cannot spin in place.
+            tokenIdx = endTokenIdx < tokens.Count ? Math.Max(tokenIdx + 1, endTokenIdx - overlap) : endTokenIdx;
             chunkIndex++;
         }
 

--- a/tests/AgentMemory.Tests.Unit/Extraction/Streaming/StreamingExtractorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/Streaming/StreamingExtractorTests.cs
@@ -35,6 +35,49 @@ public sealed class StreamingExtractorTests
         chunks[0].IsLast.Should().BeTrue();
     }
 
+    // ── ChunkDocument validation: reject configs the chunker can't advance through ──
+
+    [Theory]
+    [InlineData(100, 100)] // Overlap == ChunkSize
+    [InlineData(100, 150)] // Overlap > ChunkSize
+    public void ChunkDocument_OverlapNotLessThanChunkSize_ThrowsFastInsteadOfLooping(int chunkSize, int overlap)
+    {
+        var sut = CreateSut();
+        var opts = new StreamingExtractionOptions { ChunkSize = chunkSize, Overlap = overlap };
+
+        var act = () => sut.ChunkDocument(new string('a', 500), opts);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*less than ChunkSize*");
+    }
+
+    [Fact]
+    public void ChunkDocument_NonPositiveChunkSize_Throws()
+    {
+        var sut = CreateSut();
+        var act = () => sut.ChunkDocument(new string('a', 500), new StreamingExtractionOptions { ChunkSize = 0 });
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ChunkDocument_NegativeOverlap_Throws()
+    {
+        var sut = CreateSut();
+        var act = () => sut.ChunkDocument(new string('a', 500), new StreamingExtractionOptions { ChunkSize = 100, Overlap = -1 });
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ChunkDocument_ValidOverlap_StillChunksLongText()
+    {
+        var sut = CreateSut();
+        var chunks = sut.ChunkDocument(
+            new string('a', 500),
+            new StreamingExtractionOptions { ChunkSize = 100, Overlap = 20, SplitOnSentences = false });
+
+        chunks.Should().HaveCountGreaterThan(1);
+        chunks[^1].IsLast.Should().BeTrue();
+    }
+
     [Fact]
     public void ChunkDocument_UsesTokenChunker_WhenChunkByTokensTrue()
     {

--- a/tests/AgentMemory.Tests.Unit/Extraction/Streaming/TextChunkerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/Streaming/TextChunkerTests.cs
@@ -37,6 +37,32 @@ public sealed class TextChunkerTests
         result[0].IsLast.Should().BeTrue();
     }
 
+    // Defense in depth: StreamingExtractor.ChunkDocument rejects overlap >= chunkSize, but the chunker
+    // itself must still never spin in place if called directly with a degenerate combination. If the
+    // forward-progress clamp were missing, these tests would hang (the loop never terminates).
+
+    [Fact]
+    public void ChunkByChars_OverlapEqualsChunkSize_TerminatesAndIsBounded()
+    {
+        var text = new string('a', 50);
+        var result = TextChunker.ChunkByChars(text, chunkSize: 10, overlap: 10, splitOnSentences: false);
+
+        result.Should().NotBeEmpty();
+        result.Count.Should().BeLessThanOrEqualTo(text.Length); // advances ≥ 1 char per chunk
+        result[^1].IsLast.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ChunkByTokens_OverlapEqualsChunkSize_Terminates()
+    {
+        var text = string.Join(' ', Enumerable.Range(0, 50).Select(i => $"t{i}"));
+        var result = TextChunker.ChunkByTokens(text, chunkSize: 5, overlap: 5);
+
+        result.Should().NotBeEmpty();
+        result.Count.Should().BeLessThanOrEqualTo(60); // bounded: advances ≥ 1 token per chunk
+        result[^1].IsLast.Should().BeTrue();
+    }
+
     [Fact]
     public void ChunkByChars_LongText_ReturnsMultipleChunks()
     {


### PR DESCRIPTION
## Severity: MEDIUM — found by the full-repo adversarial audit, reproduced

`TextChunker.ChunkByChars` / `ChunkByTokens` advance the cursor by `end - overlap`. When `Overlap >= ChunkSize`, `end - overlap <= start`, so the cursor never moves forward (or moves backward) — the `while` loop **never terminates** and the chunk list grows until the process hangs / OOMs. `StreamingExtractionOptions` exposed `ChunkSize`/`Overlap` as plain settable ints with no invariant, and `StreamingExtractor` passed them straight through. A caller setting e.g. `ChunkSize=200, Overlap=200` (a plausible mistake) hangs the host.

The audit reproduced the exact loop logic: `overlap == chunkSize` resets the cursor every iteration → non-terminating; `overlap > chunkSize` walks the cursor negative; `chunkSize <= 0` never advances.

## Fix (two layers)

1. **Fail fast** — `StreamingExtractionOptions.Validate()` rejects `ChunkSize <= 0`, `Overlap < 0`, and `Overlap >= ChunkSize` with a clear message. `StreamingExtractor.ChunkDocument` (the single chokepoint both `ExtractStreamingAsync` and `ExtractAsync` route through) calls it before chunking.
2. **Defense in depth** — both `TextChunker` loops now advance by `Math.Max(cursor + 1, end - overlap)`, so even a direct internal caller can never spin in place. The intended overlap is preserved whenever it makes real forward progress, so valid configs are byte-for-byte unchanged.

## Tests

- `ChunkDocument` throws on `Overlap >= ChunkSize` (== and >), non-positive `ChunkSize`, and negative `Overlap`; still chunks valid long text.
- `TextChunker` terminates and stays bounded under `overlap == chunkSize` for both the char and token paths — these would **hang** without the clamp (they complete in ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)