### PR TITLE
fix: five audit-confirmed correctness defects (Truncated flag, datetime, lat/lon, MCP status, base URL)

### DIFF
--- a/src/AgentMemory.Abstractions/Domain/Context/MemoryContext.cs
+++ b/src/AgentMemory.Abstractions/Domain/Context/MemoryContext.cs
@@ -66,6 +66,13 @@ public sealed record MemoryContext
     public required DateTimeOffset AssembledAtUtc { get; init; }
 
     /// <summary>
+    /// True when the configured context budget forced items (or the GraphRAG block) to be dropped while
+    /// assembling this context. False when everything fit within the budget (or no budget was configured).
+    /// Surfaced to callers via <c>RecallResult.Truncated</c>.
+    /// </summary>
+    public bool Truncated { get; init; }
+
+    /// <summary>
     /// Additional metadata.
     /// </summary>
     public IReadOnlyDictionary<string, object> Metadata { get; init; } =

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -234,7 +234,8 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             RelevantFacts = new MemoryContextSection<Fact> { Items = facts },
             SimilarTraces = new MemoryContextSection<ReasoningTrace> { Items = traces },
             GraphRagContext = graphRagContext,
-            BlendMode = blendMode
+            BlendMode = blendMode,
+            Truncated = truncated
         };
 
         _logger.LogDebug(
@@ -305,6 +306,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         // past the configured token/char limit. (Relevant messages are not part of the temporal
         // snapshot, so they pass through as empty.)
         var budget = _options.ContextBudget;
+        bool truncated = false;
         if (budget.MaxTokens.HasValue || budget.MaxCharacters.HasValue)
         {
             var fitted = ApplyBudget(
@@ -315,6 +317,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             preferences = fitted.Preferences;
             facts = fitted.Facts;
             traces = fitted.Traces;
+            truncated = fitted.Truncated;
         }
 
         var context = new MemoryContext
@@ -327,6 +330,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             RelevantPreferences = new MemoryContextSection<Preference> { Items = preferences },
             RelevantFacts = new MemoryContextSection<Fact> { Items = facts },
             SimilarTraces = new MemoryContextSection<ReasoningTrace> { Items = traces },
+            Truncated = truncated,
             // "asOf" retained as the valid-time alias for backward compatibility; both clocks recorded.
             Metadata = new Dictionary<string, object>
             {

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -112,7 +112,8 @@ public sealed class MemoryService : IMemoryService
         {
             Context = context,
             TotalItemsRetrieved = totalItems,
-            EstimatedTokenCount = estimatedTokens
+            EstimatedTokenCount = estimatedTokens,
+            Truncated = context.Truncated
         };
     }
 
@@ -146,6 +147,7 @@ public sealed class MemoryService : IMemoryService
         {
             Context = context,
             TotalItemsRetrieved = totalItems,
+            Truncated = context.Truncated,
             // "asOf" retained as the valid-time alias for backward compatibility; both clocks recorded.
             Metadata = new Dictionary<string, object>
             {

--- a/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
@@ -45,7 +45,11 @@ public sealed class WikimediaEnrichmentService : IEnrichmentService
             var client = _httpClientFactory.CreateClient(ClientName);
             var title = Uri.EscapeDataString(entityName.Replace(' ', '_'));
             var lang = _options.WikipediaLanguage;
-            var url = $"https://{lang}.wikipedia.org/api/rest_v1/page/summary/{title}";
+            // Honor the configured base URL (the default contains the {lang} token + /api/rest_v1 suffix),
+            // so a mirror / internal caching proxy / non-default REST host actually takes effect. Building
+            // from the literal previously ignored WikipediaBaseUrl entirely despite it being validated.
+            var baseUrl = _options.WikipediaBaseUrl.Replace("{lang}", lang).TrimEnd('/');
+            var url = $"{baseUrl}/page/summary/{title}";
 
             using var response = await client.GetAsync(url, ct).ConfigureAwait(false);
 

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -23,8 +23,21 @@ public sealed class AdvancedMemoryTools
         [Description("Status of the call: Pending, Success, Error, Failure, Timeout, or Cancelled (default: Success)")] string status = "Success",
         CancellationToken cancellationToken = default)
     {
-        if (!Enum.TryParse<ToolCallStatus>(status, ignoreCase: true, out var toolStatus))
+        // Only an OMITTED status defaults to Success. An unrecognized value (a typo like "failed", or a
+        // numeric string) must NOT be silently coerced to Success — that would invert the recorded outcome
+        // of a tool call in durable provenance. Return an error payload (matching MaintenanceTools' style).
+        ToolCallStatus toolStatus;
+        if (string.IsNullOrWhiteSpace(status))
+        {
             toolStatus = ToolCallStatus.Success;
+        }
+        else if (!Enum.TryParse(status, ignoreCase: true, out toolStatus) || !Enum.IsDefined(toolStatus))
+        {
+            return ToolJsonContext.Serialize(new
+            {
+                error = $"unknown status '{status}' (expected one of: Pending, Success, Error, Failure, Timeout, Cancelled)"
+            });
+        }
 
         var toolCall = await reasoningMemory.RecordToolCallAsync(
             stepId, toolName, input, output, toolStatus,

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -98,7 +98,12 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                     new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() });
             }
 
-            return node is not null ? MapToEntity(node, entity.Embedding) : entity;
+            // The `node` was captured from the MERGE BEFORE the geospatial location was written in a
+            // separate query, so MapToEntity finds no `location` property and yields null coords. Carry the
+            // caller-supplied (and now-persisted) coordinates onto the returned object so it matches DB state.
+            return node is not null
+                ? MapToEntity(node, entity.Embedding) with { Latitude = entity.Latitude, Longitude = entity.Longitude }
+                : entity;
         }, cancellationToken);
     }
 
@@ -335,12 +340,16 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                     new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() });
             }
 
-            var embeddingMap = entities.ToDictionary(e => e.EntityId, e => e.Embedding);
+            // Records were read before embeddings/location were written, so carry the caller-supplied
+            // embedding AND coordinates onto each returned object so it reflects persisted state (see UpsertAsync).
+            var byId = entities.ToDictionary(e => e.EntityId);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 var id   = node["id"].As<string>();
-                return MapToEntity(node, embeddingMap.TryGetValue(id, out var emb) ? emb : null);
+                if (!byId.TryGetValue(id, out var src))
+                    return MapToEntity(node, null);
+                return MapToEntity(node, src.Embedding) with { Latitude = src.Latitude, Longitude = src.Longitude };
             }).ToList();
         }, cancellationToken);
     }

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
@@ -224,9 +224,12 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
             Name = node["name"].As<string>(),
             Version = node.Properties.TryGetValue("version", out var v) ? v?.As<string>() : null,
             ConfigJson = node.Properties.TryGetValue("config", out var c) ? c?.As<string>() : null,
-            CreatedAtUtc = node.Properties.TryGetValue("created_at", out var ca) && ca is not null
-                ? DateTimeOffset.Parse(ca.As<string>(), null, System.Globalization.DateTimeStyles.RoundtripKind)
-                : DateTimeOffset.UtcNow
+            // Read the native temporal via the shared helper (handles the driver's ZonedDateTime) rather
+            // than As<string>()+Parse, which throws FormatException on a named-zone value like
+            // "2024-01-02T03:04:05[Europe/Madrid]" produced when the server's db.temporal.timezone is a
+            // named zone. ReadDateTimeOffset(null) falls back to UtcNow, matching the old absent-key path.
+            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(
+                node.Properties.TryGetValue("created_at", out var ca) ? ca : null)
         };
     }
 
@@ -258,7 +261,8 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
             SourceMessageIds = node.Properties.TryGetValue("source_message_ids", out var sm)
                 ? sm.As<IList<object>>().Select(v => v.ToString()!).ToList()
                 : Array.Empty<string>(),
-            CreatedAtUtc = DateTimeOffset.Parse(node["created_at"].As<string>(), null, System.Globalization.DateTimeStyles.RoundtripKind),
+            // Native temporal via the shared helper (robust to ZonedDateTime named zones; see MapToExtractor).
+            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(node["created_at"]),
             Metadata = DeserializeMetadata(node.Properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
         };
     }

--- a/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
@@ -235,11 +235,16 @@ public class EntityRepositoryIntegrationTests : IAsyncLifetime
     {
         const double lat = 48.8566, lon = 2.3522; // Paris
         var id = $"entity-{Guid.NewGuid():N}";
-        await _repo.UpsertAsync(new Entity
+        var returned = await _repo.UpsertAsync(new Entity
         {
             EntityId = id, Name = "Paris HQ", Type = "Location",
             Confidence = 0.9, Latitude = lat, Longitude = lon, CreatedAtUtc = DateTimeOffset.UtcNow
         });
+
+        // The RETURNED object (not just a later re-read) must carry the coordinates that were persisted —
+        // the node is captured from the MERGE before the location is written, so this guards that regression.
+        returned.Latitude.Should().BeApproximately(lat, 1e-6);
+        returned.Longitude.Should().BeApproximately(lon, 1e-6);
 
         var read = await _repo.GetByIdAsync(id);
         read!.Latitude.Should().BeApproximately(lat, 1e-6);
@@ -256,11 +261,17 @@ public class EntityRepositoryIntegrationTests : IAsyncLifetime
         const double lat = 40.7128, lon = -74.0060; // New York
         var withLoc = $"entity-{Guid.NewGuid():N}";
         var withoutLoc = $"entity-{Guid.NewGuid():N}";
-        await _repo.UpsertBatchAsync(new[]
+        var returned = await _repo.UpsertBatchAsync(new[]
         {
             new Entity { EntityId = withLoc, Name = "NYC Office", Type = "Location", Confidence = 0.9, Latitude = lat, Longitude = lon, CreatedAtUtc = DateTimeOffset.UtcNow },
             new Entity { EntityId = withoutLoc, Name = "No Coords", Type = "Concept", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow },
         });
+
+        // The RETURNED objects must carry coords (with-loc) / null (without-loc), matching persisted state.
+        var returnedWithLoc = returned.Single(e => e.EntityId == withLoc);
+        returnedWithLoc.Latitude.Should().BeApproximately(lat, 1e-6);
+        returnedWithLoc.Longitude.Should().BeApproximately(lon, 1e-6);
+        returned.Single(e => e.EntityId == withoutLoc).Latitude.Should().BeNull();
 
         var read = await _repo.GetByIdAsync(withLoc);
         read!.Latitude.Should().BeApproximately(lat, 1e-6);

--- a/tests/AgentMemory.Tests.Unit/Enrichment/WikimediaEnrichmentServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/WikimediaEnrichmentServiceTests.cs
@@ -107,6 +107,26 @@ public sealed class WikimediaEnrichmentServiceTests
     }
 
     [Fact]
+    public async Task Enrich_UsesConfiguredBaseUrl_WhenOverridden()
+    {
+        // The configured WikipediaBaseUrl (with the {lang} token) must actually drive the request — e.g. a
+        // mirror or internal caching proxy. Previously the host was hardcoded and the option was ignored.
+        var handler = new MockHttpMessageHandler(ValidWikipediaResponse);
+        var options = new EnrichmentOptions
+        {
+            WikipediaLanguage = "de",
+            WikipediaBaseUrl = "https://wiki-proxy.internal/{lang}/rest_v1"
+        };
+        var sut = CreateSut(handler, options);
+
+        await sut.EnrichEntityAsync("London", "City");
+
+        var uri = handler.LastRequest!.RequestUri!.ToString();
+        uri.Should().StartWith("https://wiki-proxy.internal/de/rest_v1/page/summary/");
+        uri.Should().NotContain("wikipedia.org");
+    }
+
+    [Fact]
     public async Task Enrich_CancellationToken_Honored()
     {
         using var cts = new CancellationTokenSource();

--- a/tests/AgentMemory.Tests.Unit/McpServer/AdvancedMemoryToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/AdvancedMemoryToolsTests.cs
@@ -73,6 +73,44 @@ public sealed class AdvancedMemoryToolsTests
     }
 
     [Fact]
+    public async Task MemoryRecordToolCall_UnknownStatus_ReturnsError_AndRecordsNothing()
+    {
+        // A typo like "failed" (not a ToolCallStatus member) must NOT be silently coerced to Success and
+        // written to durable provenance — it returns an error payload and records nothing.
+        var result = await AdvancedMemoryTools.MemoryRecordToolCall(
+            _reasoningMemory, "step-1", "my_tool", "{}", status: "failed");
+
+        JsonDocument.Parse(result).RootElement.GetProperty("error").GetString()
+            .Should().Contain("unknown status 'failed'");
+
+        await _reasoningMemory.DidNotReceive().RecordToolCallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<ToolCallStatus>(), Arg.Any<long?>(), Arg.Any<string?>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MemoryRecordToolCall_OmittedStatus_DefaultsToSuccess()
+    {
+        var toolCall = new ToolCall
+        {
+            ToolCallId = "tc-2", StepId = "step-1", ToolName = "my_tool",
+            ArgumentsJson = "{}", Status = ToolCallStatus.Success
+        };
+        _reasoningMemory.RecordToolCallAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<ToolCallStatus>(), Arg.Any<long?>(), Arg.Any<string?>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(toolCall);
+
+        await AdvancedMemoryTools.MemoryRecordToolCall(_reasoningMemory, "step-1", "my_tool", "{}", status: " ");
+
+        await _reasoningMemory.Received(1).RecordToolCallAsync(
+            "step-1", "my_tool", "{}", null, ToolCallStatus.Success,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task MemoryRecordToolCall_ParsesStatusEnum()
     {
         var toolCall = new ToolCall

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
@@ -336,6 +336,30 @@ public sealed class MemoryContextAssemblerTests
     }
 
     [Fact]
+    public async Task AssembleContextAsync_SetsTruncatedFlag_OnlyWhenBudgetDropsItems()
+    {
+        // The MemoryContext.Truncated flag (surfaced as RecallResult.Truncated, read by MCP clients) must
+        // reflect whether budget truncation actually dropped context — it used to be permanently false.
+        var oldMsg = CreateMessage("old", "1234567890", _fixedTime.AddHours(-1));
+        var newMsg = CreateMessage("new", "ABCDEFGHIJ", _fixedTime);
+        _shortTerm
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(new[] { oldMsg, newMsg }));
+
+        var overBudget = await CreateSut(options: Options.Create(new MemoryOptions
+        {
+            ContextBudget = new ContextBudget { MaxCharacters = 11, TruncationStrategy = TruncationStrategy.OldestFirst }
+        })).AssembleContextAsync(CreateRequest(queryEmbedding: new float[1536]));
+        overBudget.Truncated.Should().BeTrue("the budget forced an item to be dropped");
+
+        var withinBudget = await CreateSut(options: Options.Create(new MemoryOptions
+        {
+            ContextBudget = new ContextBudget { MaxCharacters = 100_000, TruncationStrategy = TruncationStrategy.OldestFirst }
+        })).AssembleContextAsync(CreateRequest(queryEmbedding: new float[1536]));
+        withinBudget.Truncated.Should().BeFalse("everything fit within the budget");
+    }
+
+    [Fact]
     public async Task AssembleContextAsync_EnforcesBudgetLowestScoreFirst()
     {
         // Items are assumed ordered by score descending; lowest score (last) is dropped first


### PR DESCRIPTION
Five independent, **audit-confirmed** correctness defects from the full-repo bug hunt, each fixed with a test. (The high-severity LLM-extractor bug and the chunker infinite-loop bug ship as their own PRs.)

### 1. `RecallResult.Truncated` was permanently `false` — MEDIUM
The assembler computed a `truncated` flag from the budget pass but only logged it; `MemoryContext` had no carrier and `MemoryService` never set `RecallResult.Truncated`. The documented flag — serialized to MCP clients by the `memory_search` / `memory_get_context` tools — therefore **always reported `false`**, even when `OldestFirst`/`Proportional`/etc. actively dropped context. Added `MemoryContext.Truncated`, set it in both the live and as-of assemble paths, propagated it to `RecallResult`.

### 2. Extractor repo crashes on named-zone timestamps — MEDIUM
`Neo4jExtractorRepository.MapToExtractor`/`MapToEntity` read `created_at` via `As<string>()` + `DateTimeOffset.Parse`, which throws `FormatException` on a named-zone temporal like `…[Europe/Madrid]` (produced when the server's `db.temporal.timezone` is a named zone). Routed both through the shared `Neo4jDateTimeHelper.ReadDateTimeOffset` like every other repository.

### 3. Entity upsert returns null lat/lon despite persisting them — LOW
The `node` is captured from the `MERGE` **before** the location `point()` is written, so the returned `Entity` had null coords. `UpsertAsync`/`UpsertBatchAsync` now carry the caller-supplied (and persisted) coordinates onto the returned object.

### 4. MCP `record_tool_call` silently records bad status as `Success` — LOW
An unknown status (a typo like `"failed"`, or a numeric string) was coerced to `Success`, **inverting** the recorded outcome in durable provenance. Now only an *omitted* status defaults to `Success`; an unrecognized value returns an `error` payload (matching `MaintenanceTools`) and records nothing.

### 5. `WikipediaBaseUrl` option ignored — LOW
`WikimediaEnrichmentService` hardcoded the host despite `WikipediaBaseUrl` being a validated option, so a mirror / internal proxy had no effect. Now builds the URL from the option (with `{lang}` substitution); default behaviour is byte-for-byte unchanged.

## Tests

- Assembler `Truncated` true (over budget) / false (within budget).
- MCP unknown-status → `error` payload + records nothing; omitted/blank → `Success`.
- Wikipedia honors an overridden base URL (request URI hits the proxy, not `wikipedia.org`).
- Entity upsert **return value** carries lat/lon — single + batch (live Neo4j).
- Full unit suite **2537** green; affected integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)