### PR TITLE
fix(neo4j): Fact upsert ON MATCH must not clobber stable id or supersession valid_until

### DIFF
--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -25,11 +25,10 @@ public static class FactQueries
                 f.created_at         = datetime($createdAtUtc),
                 f.metadata           = $metadata
             ON MATCH SET
-                f.id                 = $id,
                 f.category           = $category,
                 f.confidence         = $confidence,
-                f.valid_from         = CASE WHEN $validFrom IS NOT NULL THEN datetime($validFrom) ELSE null END,
-                f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE null END,
+                f.valid_from         = CASE WHEN $validFrom IS NOT NULL THEN datetime($validFrom) ELSE f.valid_from END,
+                f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE f.valid_until END,
                 f.source_message_ids = $sourceMessageIds,
                 f.updated_at         = datetime($updatedAtUtc),
                 f.metadata           = $metadata

--- a/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
@@ -52,6 +52,59 @@ public class FactRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpsertAsync_ReUpsertSameTriple_KeepsStableId_SoByIdHandleStillResolves()
+    {
+        var idA = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact
+        {
+            FactId = idA, Subject = "Alice", Predicate = "works_at", Object = "Acme",
+            Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow
+        });
+
+        // Re-extract the SAME triple with a DIFFERENT freshly-generated id (the common re-extraction case).
+        var idB = $"fact-{Guid.NewGuid():N}";
+        var reUpserted = await _repo.UpsertAsync(new Fact
+        {
+            FactId = idB, Subject = "Alice", Predicate = "works_at", Object = "Acme",
+            Confidence = 0.95, CreatedAtUtc = DateTimeOffset.UtcNow
+        });
+
+        // The node must KEEP its original id; the triple MERGE must not rewrite the stable primary key.
+        reUpserted.FactId.Should().Be(idA, "re-upsert of the same triple must not clobber the stable id");
+        (await _repo.GetByIdAsync(idA)).Should().NotBeNull("the original id must still resolve after re-upsert");
+        (await _repo.GetByIdAsync(idB)).Should().BeNull("the discarded second id must never become the node's id");
+        // The by-id handle the caller holds must still work for invalidate.
+        (await _repo.InvalidateAsync(idA, scope: null)).Should().BeTrue("invalidate by the original id must succeed");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ReUpsertSupersededTriple_DoesNotClearValidUntil()
+    {
+        var loserId = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = loserId, Subject = "Alice", Predicate = "lives_in", Object = "Paris", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+        var winnerId = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = winnerId, Subject = "Alice", Predicate = "lives_in", Object = "London", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        // Supersede stamps the loser's valid_until (closes its valid-time window).
+        (await _repo.SupersedeAsync(loserId, winnerId, scope: null)).Should().BeTrue();
+        (await HasValidUntilAsync(loserId)).Should().BeTrue("supersede must close the loser's valid-time window");
+
+        // Re-extract the loser's triple with NO explicit validUntil (the common extraction case).
+        await _repo.UpsertAsync(new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = "Alice", Predicate = "lives_in", Object = "Paris", Confidence = 0.95, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        (await HasValidUntilAsync(loserId)).Should().BeTrue(
+            "re-extracting a superseded triple must NOT clear the valid_until that supersession stamped");
+    }
+
+    private async Task<bool> HasValidUntilAsync(string factId) =>
+        await _fixture.TransactionRunner.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync("MATCH (f:Fact {id: $id}) RETURN f.valid_until IS NOT NULL AS hasVu", new { id = factId });
+            var records = await cursor.ToListAsync();
+            return records.Count > 0 && global::Neo4j.Driver.ValueExtensions.As<bool>(records[0]["hasVu"]);
+        });
+
+    [Fact]
     public async Task GetByIdAsync_ReturnsFact_WhenExists()
     {
         var fact = new Fact

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
@@ -316,11 +316,10 @@ MERGE (f:Fact {subject: $subject, predicate: $predicate, object: $object, owner_
                 f.created_at         = datetime($createdAtUtc),
                 f.metadata           = $metadata
             ON MATCH SET
-                f.id                 = $id,
                 f.category           = $category,
                 f.confidence         = $confidence,
-                f.valid_from         = CASE WHEN $validFrom IS NOT NULL THEN datetime($validFrom) ELSE null END,
-                f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE null END,
+                f.valid_from         = CASE WHEN $validFrom IS NOT NULL THEN datetime($validFrom) ELSE f.valid_from END,
+                f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE f.valid_until END,
                 f.source_message_ids = $sourceMessageIds,
                 f.updated_at         = datetime($updatedAtUtc),
                 f.metadata           = $metadata


### PR DESCRIPTION
Round-2 adversarial audit — **two** defects in the single `FactQueries.Upsert` `ON MATCH SET` clause (it MERGEs on the `subject/predicate/object/owner_key` triple, *not* on `id`):

### 1 — `id` clobber (HIGH)
`ON MATCH SET f.id = $id` rewrote the surviving node's **stable primary key** to the caller's freshly-generated id on every re-extraction of the same triple. The id returned by an earlier `AddFact`/`RememberFact` then no longer resolved, so a later `GetById`/`Invalidate`/`Supersede`/`Delete(oldId)` **silently failed** (null/false). Every other upsert in the repo (Entity/Preference/Relationship, and even `FactQueries.UpsertBatch`) correctly omits the merge key from `ON MATCH SET`. **Fix:** drop `f.id = $id` from `ON MATCH` (it stays only in `ON CREATE`).

### 2 — `valid_until` clobber (MED, bitemporal corruption)
`f.valid_until = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE null END` on MATCH **cleared the `valid_until` that `Supersede` stamps**, every time the (commonly `validUntil`-less) triple was re-extracted — re-opening a superseded fact's valid-time window and corrupting the immutable as-of/audit record (`SearchFactsAsOf` filters on `valid_until IS NULL OR valid_until > asOf`). **Fix:** `ELSE f.valid_from` / `ELSE f.valid_until` (preserve existing; an explicit incoming value still updates).

## Tests (live Neo4j)
- Re-upsert of the same triple with a *new* id → node keeps the **original** id; `GetById(oldId)` resolves, `GetById(newId)` is null, `Invalidate(oldId)` succeeds.
- Re-upsert of a *superseded* triple with no `validUntil` → its `valid_until` stays set.
- Cypher snapshot regenerated (content-only change to `FactQueries.Upsert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)