### PR TITLE
fix(core): embedding back-fill must make forward progress (infinite-loop guard)

### DIFF
--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -299,12 +299,16 @@ public sealed class MemoryService : IMemoryService
         do
         {
             page = await _entityRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            int embeddedThisPage = 0;
             foreach (var entity in page.Items)
             {
                 var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, ct);
                 await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, ct);
                 total++;
+                if (embedding.Length > 0) embeddedThisPage++;
             }
+
+            if (StalledOnPage(page.Items.Count, embeddedThisPage, "Entity")) break;
         } while (page.HasNextPage);
 
         _logger.LogInformation("Back-filled embeddings for {Count} Entity nodes.", total);
@@ -318,12 +322,16 @@ public sealed class MemoryService : IMemoryService
         do
         {
             page = await _factRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            int embeddedThisPage = 0;
             foreach (var fact in page.Items)
             {
                 var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, ct);
                 await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, ct);
                 total++;
+                if (embedding.Length > 0) embeddedThisPage++;
             }
+
+            if (StalledOnPage(page.Items.Count, embeddedThisPage, "Fact")) break;
         } while (page.HasNextPage);
 
         _logger.LogInformation("Back-filled embeddings for {Count} Fact nodes.", total);
@@ -337,16 +345,39 @@ public sealed class MemoryService : IMemoryService
         do
         {
             page = await _preferenceRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            int embeddedThisPage = 0;
             foreach (var pref in page.Items)
             {
                 var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, ct);
                 await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, ct);
                 total++;
+                if (embedding.Length > 0) embeddedThisPage++;
             }
+
+            if (StalledOnPage(page.Items.Count, embeddedThisPage, "Preference")) break;
         } while (page.HasNextPage);
 
         _logger.LogInformation("Back-filled embeddings for {Count} Preference nodes.", total);
         return total;
+    }
+
+    // Forward-progress guard for the predicate-paged backfill loops (GetPageWithoutEmbedding has no cursor:
+    // it re-selects `WHERE embedding IS NULL LIMIT n`). A node only leaves that set once it acquires a
+    // non-empty embedding; the orchestrator degrades to an EMPTY vector on generation failure and the repo
+    // deliberately skips writing an empty embedding (keeping the node re-queueable). So if a page returns
+    // nodes but NONE were embedded, the remaining null nodes are un-embeddable this run (bad key / dimension
+    // mismatch / provider outage) — stop instead of looping forever on the identical page.
+    private bool StalledOnPage(int pageItemCount, int embeddedThisPage, string label)
+    {
+        if (pageItemCount > 0 && embeddedThisPage == 0)
+        {
+            _logger.LogWarning(
+                "Embedding back-fill for {Label} made no progress on a page of {Count} node(s) — embedding " +
+                "generation is failing; stopping the back-fill to avoid an unbounded retry loop.",
+                label, pageItemCount);
+            return true;
+        }
+        return false;
     }
 
     private async Task UpdateAccessTimestampsAsync(MemoryContext context, CancellationToken cancellationToken)

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
@@ -212,6 +212,28 @@ public sealed class MemoryServiceBatchTests
     }
 
     [Fact]
+    public async Task GenerateEmbeddingsBatchAsync_PersistentEmbeddingFailure_StopsInsteadOfLoopingForever()
+    {
+        // The page query has no cursor: it re-selects `WHERE embedding IS NULL LIMIT n`, and the repo skips
+        // writing an empty embedding, so a persistently-failing page is re-returned every iteration with
+        // hasNextPage=true. Without the forward-progress guard this loops forever; this test must TERMINATE.
+        var entities = new List<Entity>
+        {
+            new() { EntityId = "e1", Name = "London", Type = "LOCATION", Confidence = 1.0, CreatedAtUtc = FixedTime }
+        };
+        _entityRepo.GetPageWithoutEmbeddingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<Entity>(entities, hasNextPage: true)); // always "more", never advances
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Array.Empty<float>())); // persistent generation failure ⇒ empty vector
+
+        var sut = CreateSut();
+        var count = await sut.GenerateEmbeddingsBatchAsync("Entity", batchSize: 100);
+
+        count.Should().Be(1, "the single stalled page is processed once, then the back-fill stops");
+        await _entityRepo.Received(1).GetPageWithoutEmbeddingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GenerateEmbeddingsBatchAsync_Fact_UsesSpoTripleAsEmbeddingText()
     {
         var fact = new Fact


### PR DESCRIPTION
Round-2 adversarial audit — **HIGH**. The three `Backfill*EmbeddingsAsync` loops (`GenerateEmbeddingsBatchAsync`) page on a **cursorless** predicate query:

```cypher
MATCH (e:Entity) WHERE e.embedding IS NULL RETURN e LIMIT $limit
```

Forward progress depends entirely on each processed node acquiring a non-null embedding so it drops out of the `WHERE embedding IS NULL` set. But two deliberate behaviors collide:
- `EmbeddingOrchestrator.EmbedAsync` degrades to `Array.Empty<float>()` on **any** generator exception.
- `UpdateEmbeddingAsync` deliberately **skips** writing an empty embedding (keeps the node re-queueable, doesn't poison it with `[]`).

So under a **persistent** failure (bad API key, embedding-dimension mismatch, sustained provider outage, rate-limiting) a full page of un-embeddable nodes is re-fetched identically every iteration with `HasNextPage=true` → the `do…while` **never terminates**, hammering the embedding provider and Neo4j indefinitely. This is exactly the condition a back-fill runs under (a DB full of un-embedded nodes + misconfigured embeddings).

## Fix
A forward-progress guard (`StalledOnPage`) breaks the loop when a page returns nodes but **none** were embedded this pass — the remaining nulls are un-embeddable this run. Applied to all three loops (Entity/Fact/Preference); logs a warning on stall.

## Test
`GetPageWithoutEmbedding` returns a non-empty page with `hasNextPage=true` **forever** and `EmbedAsync` returns `Array.Empty<float>()`; `GenerateEmbeddingsBatchAsync` must **terminate** (processes one page, then stops). Without the guard this test would hang. (Completes in ms.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)