### PR TITLE
fix(core): wire D3 ranking context + guard as-of recall on empty embedding

### DIFF
--- a/src/AgentMemory.Core/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Core/ServiceCollectionExtensions.cs
@@ -85,7 +85,11 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<IClock>(),
             sp.GetRequiredService<IOptions<MemoryOptions>>(),
             sp.GetRequiredService<ILogger<MemoryContextAssembler>>(),
-            rankingContext: null,
+            // Hand the assembler the SAME AsyncLocal ranking context the long-term repositories read
+            // (registered above as both IMemoryRankingContext and IWritableMemoryRankingContext). Without
+            // this the assembler can never publish the D3 per-request query intent, so RecallOptions.Intent
+            // (Latest/Analog) is silently inert in every DI-wired deployment.
+            rankingContext: sp.GetService<IWritableMemoryRankingContext>(),
             truncationStrategies: sp.GetServices<ITruncationStrategy>()));
         services.TryAddScoped<IMemoryService, MemoryService>();
 

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -275,6 +275,13 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         var queryEmbedding = request.QueryEmbedding
             ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken);
 
+        // Vector searches require a non-empty embedding. A blank query, or a transient embedding-generation
+        // failure (degrades to an empty vector), would otherwise issue a zero-dimension vector query which
+        // the index REJECTS — throwing instead of returning empty. Mirror the live AssembleContextAsync
+        // guard so temporal recall degrades gracefully to recent messages + empty semantic sections.
+        bool hasEmbedding = queryEmbedding is { Length: > 0 };
+        static Task<IReadOnlyList<T>> Empty<T>() => Task.FromResult<IReadOnlyList<T>>(Array.Empty<T>());
+
         // D6 clock mapping: the transaction clock ($systemAsOf) bounds every record's existence, so
         // messages, entities, preferences, and traces — which have no valid-time window — observe only
         // systemAsOf. Facts additionally observe the valid-time clock ($validAsOf) for their validity
@@ -282,17 +289,21 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         var recentTask = _shortTerm.GetRecentMessagesAsOfAsync(
             request.SessionId, systemAsOf, recallOpts.MaxRecentMessages, cancellationToken);
 
-        var entitiesTask = _longTerm.SearchEntitiesAsOfAsync(
-            queryEmbedding, systemAsOf, recallOpts.MaxEntities, minScore, scope, cancellationToken);
+        var entitiesTask = hasEmbedding
+            ? _longTerm.SearchEntitiesAsOfAsync(queryEmbedding, systemAsOf, recallOpts.MaxEntities, minScore, scope, cancellationToken)
+            : Empty<Entity>();
 
-        var preferencesTask = _longTerm.SearchPreferencesAsOfAsync(
-            queryEmbedding, systemAsOf, recallOpts.MaxPreferences, minScore, scope, cancellationToken);
+        var preferencesTask = hasEmbedding
+            ? _longTerm.SearchPreferencesAsOfAsync(queryEmbedding, systemAsOf, recallOpts.MaxPreferences, minScore, scope, cancellationToken)
+            : Empty<Preference>();
 
-        var factsTask = _longTerm.SearchFactsAsOfAsync(
-            queryEmbedding, validAsOf, recallOpts.MaxFacts, minScore, scope, systemAsOf, cancellationToken);
+        var factsTask = hasEmbedding
+            ? _longTerm.SearchFactsAsOfAsync(queryEmbedding, validAsOf, recallOpts.MaxFacts, minScore, scope, systemAsOf, cancellationToken)
+            : Empty<Fact>();
 
-        var tracesTask = _reasoning.SearchSimilarTracesAsOfAsync(
-            queryEmbedding, systemAsOf, null, recallOpts.MaxTraces, minScore, scope, cancellationToken);
+        var tracesTask = hasEmbedding
+            ? _reasoning.SearchSimilarTracesAsOfAsync(queryEmbedding, systemAsOf, null, recallOpts.MaxTraces, minScore, scope, cancellationToken)
+            : Empty<ReasoningTrace>();
 
         await Task.WhenAll(recentTask, entitiesTask, preferencesTask, factsTask, tracesTask);
 

--- a/tests/AgentMemory.Tests.Unit/Services/AssemblerRankingContextDiWiringTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/AssemblerRankingContextDiWiringTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core;
+using NSubstitute;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// Guards that the DI-resolved <see cref="IMemoryContextAssembler"/> is wired with the AsyncLocal ranking
+/// context the long-term repositories read — i.e. that the D3 per-request query intent (Latest/Analog)
+/// actually reaches ranking in a real container. The bug this guards: the factory passed
+/// <c>rankingContext: null</c>, so <c>RecallOptions.Intent</c> was silently inert in every deployment, and
+/// the existing assembler unit test could not catch it (it constructs the assembler by hand with a context).
+/// </summary>
+public sealed class AssemblerRankingContextDiWiringTests
+{
+    [Fact]
+    public async Task DiResolvedAssembler_PublishesQueryIntentRanking_IntoTheContextRepositoriesRead()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentMemoryCore(_ => { });
+
+        // Replace the layer services (Core's real impls need repositories that aren't registered here) with
+        // mocks so the assembler resolves; the embedding orchestrator returns a non-empty vector so the
+        // long-term searches actually run.
+        var shortTerm = Substitute.For<IShortTermMemoryService>();
+        shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        var reasoning = Substitute.For<IReasoningMemoryService>();
+        reasoning.SearchSimilarTracesAsync(Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(Array.Empty<ReasoningTrace>()));
+        var embed = Substitute.For<IEmbeddingOrchestrator>();
+        embed.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(new float[] { 1f }));
+        var longTerm = Substitute.For<ILongTermMemoryService>();
+        longTerm.SearchEntitiesAsync(Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Entity>>(Array.Empty<Entity>()));
+        longTerm.SearchPreferencesAsync(Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Preference>>(Array.Empty<Preference>()));
+
+        services.Replace(ServiceDescriptor.Scoped(_ => shortTerm));
+        services.Replace(ServiceDescriptor.Scoped(_ => reasoning));
+        services.Replace(ServiceDescriptor.Scoped(_ => embed));
+        services.Replace(ServiceDescriptor.Scoped(_ => longTerm));
+
+        var provider = services.BuildServiceProvider();
+        var rankingContext = provider.GetRequiredService<IMemoryRankingContext>();
+
+        // Capture what the repositories WOULD read (the ambient ranking) at the moment the assembler issues
+        // the long-term fact search.
+        MemoryRankingOptions? observedDuringSearch = null;
+        longTerm.SearchFactsAsync(Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                observedDuringSearch = rankingContext.Current;
+                return Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>());
+            });
+
+        using var scope = provider.CreateScope();
+        var assembler = scope.ServiceProvider.GetRequiredService<IMemoryContextAssembler>();
+
+        await assembler.AssembleContextAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "q",
+            Options = new RecallOptions { Intent = RankingIntent.Latest }
+        });
+
+        observedDuringSearch.Should().NotBeNull(
+            "the DI-wired assembler must publish the per-request intent into the ranking context the repositories read");
+        observedDuringSearch!.EffectiveRecencyWeight.Should().BeGreaterThan(0, "Latest raises the recency weight");
+        rankingContext.Current.Should().BeNull("the override must be reset after the long-term searches, never leaking");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
@@ -547,6 +547,32 @@ public sealed class MemoryContextAssemblerTests
         result.RelevantEntities.Items.Should().HaveCount(1);
     }
 
+    [Fact]
+    public async Task AssembleContextAsOfAsync_EmptyEmbedding_SkipsVectorSearches_InsteadOfThrowing()
+    {
+        // A blank query (or a transient embed failure) yields an empty vector; like the live path, the
+        // as-of path must skip the semantic searches rather than issue a zero-dimension vector query that
+        // the index rejects (which would throw instead of degrading to recent messages + empty sections).
+        _shortTerm
+            .GetRecentMessagesAsOfAsync(Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+
+        var sut = CreateSut();
+
+        var result = await sut.AssembleContextAsOfAsync(
+            new RecallRequest { SessionId = "s", Query = "", QueryEmbedding = Array.Empty<float>() }, _fixedTime);
+
+        await _longTerm.DidNotReceive().SearchEntitiesAsOfAsync(
+            Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _longTerm.DidNotReceive().SearchFactsAsOfAsync(
+            Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>());
+        await _reasoning.DidNotReceive().SearchSimilarTracesAsOfAsync(
+            Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+
+        result.RelevantEntities.Items.Should().BeEmpty();
+        result.RelevantFacts.Items.Should().BeEmpty();
+    }
+
     // ---- Helpers ----
 
     private static Entity CreateEntity(string id, string name, DateTimeOffset createdAt) => new()


### PR DESCRIPTION
Two round-2 recall-correctness defects (MEDIUM):

### 1 — D3 query-intent ranking was dead in production
The only DI registration of `IMemoryContextAssembler` passed **`rankingContext: null`**, so the assembler never published `RecallOptions.Intent` (`Latest`/`Analog`) into the AsyncLocal the long-term repositories read. `Intent` therefore had **zero** end-to-end effect — an opt-in public feature silently disabled in every DI-wired deployment.

*(This is the exact `rankingContext: null` the S9 refactor carried forward as "pre-existing, out of scope" — now fixed properly.)*

**Fix:** pass `sp.GetService<IWritableMemoryRankingContext>()` — the same `DefaultMemoryRankingContext` singleton the repos read via `IMemoryRankingContext`.

**Why the existing test missed it:** `MemoryContextAssemblerTests` constructs the assembler **by hand** with a real ranking context (the exact wiring DI refused to do), so it passed while the shipped path was broken. Added a **DI-resolution** test that recalls with `Intent=Latest` and asserts the repositories observe a non-null ranking with `EffectiveRecencyWeight > 0`.

### 2 — as-of recall throws on an empty embedding
`AssembleContextAsOfAsync` lacked the live path's `hasEmbedding` guard, so a blank query — or a transient embedding-generation failure (degrades to an empty vector) — issued a **zero-dimension** vector query that the index **rejects**, throwing a Neo4j dimension-mismatch instead of degrading gracefully like `AssembleContextAsync`.

**Fix:** gate each `*AsOfAsync` vector search on `hasEmbedding` (recent messages still flow). Added a test asserting no vector search is issued for an empty embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)