### PR TITLE
fix(extraction): propagate caller cancellation instead of swallowing it

### DIFF
--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -206,10 +206,10 @@ internal sealed class ExtractionStage : IExtractionStage
             return Array.Empty<T>();
 
         if (extractors.Count == 1)
-            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName);
+            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName, cancellationToken);
 
         var tasks = extractors
-            .Select(e => ExtractSafeAsync(() => extractFn(e), extractorTypeName))
+            .Select(e => ExtractSafeAsync(() => extractFn(e), extractorTypeName, cancellationToken))
             .ToList();
         await Task.WhenAll(tasks);
 
@@ -229,11 +229,16 @@ internal sealed class ExtractionStage : IExtractionStage
 
     private async Task<IReadOnlyList<T>> ExtractSafeAsync<T>(
         Func<Task<IReadOnlyList<T>>> extractor,
-        string extractorTypeName)
+        string extractorTypeName,
+        CancellationToken ct)
     {
         try
         {
             return await extractor();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // Honor caller cancellation — do not mask it as an empty result.
         }
         catch (Exception ex)
         {

--- a/src/AgentMemory.Core/Extraction/ExtractorBase.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractorBase.cs
@@ -53,6 +53,10 @@ public abstract class ExtractorBase<T>
         {
             return await ExtractCoreAsync(messages, ct);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // Honor caller cancellation — do not mask it as a successful empty result.
+        }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "{ExtractorType} extraction failed; returning empty list.", GetType().Name);

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -71,6 +71,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                         await _entityRepository.CreateExtractedFromRelationshipAsync(
                             entityToSave.EntityId, msgId, cancellationToken: cancellationToken);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex,
@@ -81,6 +82,7 @@ internal sealed class PersistenceStage : IPersistenceStage
 
                 _logger.LogDebug("Persisted entity '{Name}' (id={Id}).", entityToSave.Name, entityToSave.EntityId);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error persisting entity '{Name}'.", name);
@@ -120,6 +122,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                         await _factRepository.CreateExtractedFromRelationshipAsync(
                             fact.FactId, msgId, cancellationToken);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex,
@@ -131,6 +134,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                 persistedFactCount++;
                 _logger.LogDebug("Persisted fact '{S} {P} {O}'.", fact.Subject, fact.Predicate, fact.Object);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger.LogError(ex,
@@ -170,6 +174,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                         await _preferenceRepository.CreateExtractedFromRelationshipAsync(
                             preference.PreferenceId, msgId, cancellationToken);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex,
@@ -181,6 +186,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                 persistedPrefCount++;
                 _logger.LogDebug("Persisted preference in category '{Category}'.", preference.Category);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error persisting preference '{Text}'.", extracted.PreferenceText);
@@ -230,6 +236,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                     "Persisted relationship '{Src}-{Type}->{Tgt}'.",
                     extracted.SourceEntity, extracted.RelationshipType, extracted.TargetEntity);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger.LogError(ex,

--- a/tests/AgentMemory.Tests.Unit/Extraction/ExtractorBaseCancellationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/ExtractorBaseCancellationTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Core.Extraction;
+
+namespace AgentMemory.Tests.Unit.Extraction;
+
+/// <summary>
+/// Round-2 fix: extraction must propagate caller cancellation instead of swallowing it and reporting a
+/// "successful" empty result. Genuine (non-cancellation) failures still degrade to empty for resilience.
+/// </summary>
+public sealed class ExtractorBaseCancellationTests
+{
+    private sealed class CoreThrows : ExtractorBase<ExtractedEntity>
+    {
+        private readonly Exception _toThrow;
+        public CoreThrows(Exception toThrow) : base(NullLogger.Instance) => _toThrow = toThrow;
+        protected override Task<IReadOnlyList<ExtractedEntity>> ExtractCoreAsync(
+            IReadOnlyList<Message> messages, CancellationToken ct) => throw _toThrow;
+    }
+
+    private static IReadOnlyList<Message> OneMessage() => new[]
+    {
+        new Message
+        {
+            MessageId = "m", ConversationId = "c", SessionId = "s",
+            Role = "user", Content = "hi", TimestampUtc = DateTimeOffset.UtcNow
+        }
+    };
+
+    [Fact]
+    public async Task ExtractAsync_CallerCancelled_RethrowsOperationCanceled_NotEmpty()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var sut = new CoreThrows(new OperationCanceledException(cts.Token));
+
+        var act = () => sut.ExtractAsync(OneMessage(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a cancelled extraction must surface OperationCanceledException, not a 'successful' empty list");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_GenuineFailure_DegradesToEmpty()
+    {
+        var sut = new CoreThrows(new InvalidOperationException("boom"));
+
+        var result = await sut.ExtractAsync(OneMessage(), CancellationToken.None);
+
+        result.Should().BeEmpty("a non-cancellation failure still degrades to empty (resilience preserved)");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_SpuriousCancellation_WithUncancelledToken_DegradesToEmpty()
+    {
+        // An OperationCanceledException whose token is NOT cancellation-requested (e.g. a client-side HTTP
+        // timeout) is a failure to degrade, not a caller cancellation — the `when (ct.IsCancellationRequested)`
+        // filter must let it fall through to the resilient empty path.
+        var sut = new CoreThrows(new OperationCanceledException());
+
+        var result = await sut.ExtractAsync(OneMessage(), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Round-2 adversarial audit — **MEDIUM**. The extraction pipeline's blanket `catch (Exception)` blocks **swallowed `OperationCanceledException`** and converted a cancelled/timed-out extraction into a "successful" empty (or partial) result. So a `CancellationToken` passed to `IMemoryService.ExtractAndPersistAsync` (or the streaming/pipeline callers) **could not actually cancel or time-out** the operation — a host that cancels on request-abort or an outer timeout got a misreported successful empty extraction instead of an `OperationCanceledException`.

This also contradicted the codebase's **own** convention: `Neo4jTextSearch`, `Neo4jGraphRagContextSource`, `MemoryQueryFacade`, and even the extraction feature's own `StreamingExtractor` all rethrow OCE before their generic catch (`// Honor cancellation — do not mask it as an empty result`).

## Fix — all three layers

- **`ExtractorBase.ExtractAsync`** — `catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }` before the degrade-to-empty catch.
- **`ExtractionStage.ExtractSafeAsync`** — same guard (threaded the cancellation token in, which it previously didn't even take).
- **`PersistenceStage`** per-item loops — all 7 catch sites rethrow OCE so a cancelled persist **stops** instead of logging-and-continuing through the remaining items.

A genuine non-cancellation failure — or a *spurious* OCE whose token is **not** cancellation-requested (e.g. a client-side HTTP timeout) — still degrades to empty, so resilience is preserved.

## Tests
`ExtractorBaseCancellationTests`: caller-cancelled → rethrows OCE; genuine failure → empty; spurious OCE with uncancelled token → empty. No regression across the extraction suite (68 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)