### PR TITLE
fix(neo4j): dedup-on-create must exclude soft-invalidated nodes (re-asserted knowledge was lost)

### DIFF
--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -92,6 +92,7 @@ public static class FactQueries
             CALL db.index.vector.queryNodes('fact_embedding_idx', {topK}, $embedding)
             YIELD node, score
             WHERE score >= $threshold
+              AND node.invalidated_at IS NULL
               AND toLower(node.subject) = toLower($subject)
               AND toLower(node.predicate) = toLower($predicate)
               AND node.owner_key = $ownerKey

--- a/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
@@ -79,6 +79,7 @@ public static class PreferenceQueries
             CALL db.index.vector.queryNodes('preference_embedding_idx', {topK}, $embedding)
             YIELD node, score
             WHERE score >= $threshold
+              AND node.invalidated_at IS NULL
               AND node.category = $category
               AND {ownerClause}
             RETURN node, score

--- a/tests/AgentMemory.Tests.Integration/Repositories/DedupOnCreateIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/DedupOnCreateIntegrationTests.cs
@@ -49,6 +49,25 @@ public class DedupOnCreateIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task FindDuplicate_DoesNotMatchInvalidatedNodes_SoReAssertedKnowledgeIsNotLost()
+    {
+        // A soft-invalidated (decayed/superseded) node must NOT be a dedup target — otherwise re-asserting
+        // the same knowledge dedups onto the dead node (which stays invisible to live recall) and is
+        // silently lost instead of being re-created as a fresh live node.
+        var factId = $"f-{Guid.NewGuid():N}";
+        await _facts.UpsertAsync(new Fact { FactId = factId, Subject = "Alice", Predicate = "works_at", Object = "Acme", OwnerId = "alice", Confidence = 0.8, Embedding = E, CreatedAtUtc = DateTimeOffset.UtcNow });
+        (await _facts.InvalidateAsync(factId, scope: null)).Should().BeTrue();
+        (await _facts.FindDuplicateAsync("Alice", "works_at", E, "alice", threshold: 0.95))
+            .Should().BeNull("dedup must only match live facts, never a soft-invalidated one");
+
+        var prefId = $"p-{Guid.NewGuid():N}";
+        await _prefs.UpsertAsync(new Preference { PreferenceId = prefId, Category = "style", PreferenceText = "dark mode", OwnerId = "alice", Confidence = 0.8, Embedding = E, CreatedAtUtc = DateTimeOffset.UtcNow });
+        (await _prefs.InvalidateAsync(prefId, scope: null)).Should().BeTrue();
+        (await _prefs.FindDuplicateAsync("style", E, "alice", threshold: 0.95))
+            .Should().BeNull("dedup must only match live preferences, never a soft-invalidated one");
+    }
+
+    [Fact]
     public async Task FactMarkDeduplicated_BumpsConfidence()
     {
         var f = new Fact { FactId = $"f-{Guid.NewGuid():N}", Subject = "Alice", Predicate = "works_at", Object = "Acme", OwnerId = null, Confidence = 0.8, Embedding = E, CreatedAtUtc = DateTimeOffset.UtcNow };


### PR DESCRIPTION
Round-3 adversarial audit — **HIGH** (silent data loss on the default path).

`FactQueries.FindDuplicate` / `PreferenceQueries.FindDuplicate` select the top vector match by subject+predicate / category + owner, but — unlike **every** live-recall query (`SearchByVector`, all `TemporalQueries`) — did **not** filter `node.invalidated_at IS NULL`. The vector index still contains soft-invalidated nodes (Invalidate/Supersede and the **default** non-destructive decay only stamp `invalidated_at`; they don't drop the embedding).

**Consequence (default path: `DeduplicateOnCreate=true`, embeddings on, threshold 0.95):** after a fact/preference is soft-invalidated (decayed away or superseded) and the user re-asserts the same / near-duplicate knowledge, `AddFactAsync`/`AddPreferenceAsync` dedups onto the **dead** node, bumps its confidence via `MarkDeduplicated` (which does **not** clear `invalidated_at`), and **skips the upsert** — so the re-asserted knowledge neither resurrects the old node nor creates a fresh live one. It's **silently lost from live recall**, defeating dedup-on-create precisely when memory had decayed and the user is trying to bring it back.

## Fix
Add `AND node.invalidated_at IS NULL` to both `FindDuplicate` queries, matching the live-recall contract — so a re-asserted previously-invalidated item falls through to `UpsertAsync` and is re-created as a live node. (`FindDuplicate` are methods, not registry consts → no Cypher-snapshot change.)

## Test (live Neo4j)
Invalidate a fact and a preference, then `FindDuplicateAsync` with the same embedding returns `null` (no match on the dead node). 5 dedup integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)