### PR TITLE
fix(core): EmbeddingOrchestrator must propagate cancellation, not mask it as an empty vector

### DIFF
--- a/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
+++ b/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
@@ -39,6 +39,10 @@ public sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
             var result = await _generator.GenerateAsync([text], cancellationToken: ct).ConfigureAwait(false);
             return result[0].Vector.ToArray();
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // Honor caller cancellation — do not mask it as a successful empty vector.
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Embedding generation failed for text (length={Len}); returning empty vector.", text.Length);
@@ -86,6 +90,10 @@ public sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
             }
             for (int j = 0; j < nonBlankIndices.Count && j < generated.Count; j++)
                 results[nonBlankIndices[j]] = generated[j].Vector.ToArray();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // Honor caller cancellation — do not mask it as successful empty vectors.
         }
         catch (Exception ex)
         {

--- a/tests/AgentMemory.Tests.Unit/Services/EmbeddingOrchestratorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/EmbeddingOrchestratorTests.cs
@@ -167,6 +167,37 @@ public sealed class EmbeddingOrchestratorTests
     }
 
     [Fact]
+    public async Task EmbedAsync_CallerCancelled_RethrowsOperationCanceled_NotEmpty()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var sut = new EmbeddingOrchestrator(generator, NullLogger<EmbeddingOrchestrator>.Instance);
+
+        var act = () => sut.EmbedAsync("some text", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a cancelled embed must surface cancellation, not a 'successful' empty vector");
+    }
+
+    [Fact]
+    public async Task EmbedBatchAsync_CallerCancelled_RethrowsOperationCanceled_NotEmpty()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var sut = new EmbeddingOrchestrator(generator, NullLogger<EmbeddingOrchestrator>.Instance);
+
+        var act = () => sut.EmbedBatchAsync(new[] { "a", "b" }, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task EmbedEntityAsync_GeneratorThrows_ReturnsEmptyArrayGracefully()
     {
         var failingGenerator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();


### PR DESCRIPTION
Round-3 audit — **MEDIUM**. `EmbedAsync`/`EmbedBatchAsync` wrap the generator call in a bare `catch (Exception)` that returns an empty vector. `OperationCanceledException` is an `Exception`, so a **caller-cancelled embed was swallowed and degraded to empty** — the same bug class rounds 1–2 fixed in the extraction pipeline, but missed on this far hotter path.

`EmbedQueryAsync` feeds **every recall**: `MemoryContextAssembler` gates each semantic search on the resulting vector's length, so a cancelled recall returned a "successful" partial context (recent messages only, all semantic sections empty) instead of throwing `OperationCanceledException`. The caller couldn't distinguish "cancelled" from "no semantic matches".

**Fix:** `catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }` before each broad catch in both methods (mirrors the round-2 extractor fix). Genuine generation failures still degrade to empty. Tests assert both `EmbedAsync` and `EmbedBatchAsync` rethrow on a cancelled token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)