### PR TITLE
fix(enrichment): background queue must retry transient Error/RateLimited results, not treat them as success

### DIFF
--- a/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
+++ b/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
@@ -1,6 +1,7 @@
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using AgentMemory.Abstractions.Domain.Enrichment;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
@@ -118,13 +119,20 @@ public sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDis
 
         var updated = entity;
         bool anySuccess = false;
+        // Providers signal TRANSIENT failures (HTTP 429/5xx) by RETURNING a non-null Error/RateLimited
+        // result, not by throwing — so success cannot be inferred from `result is not null`. Track whether
+        // anything is worth retrying separately, otherwise a rate-limit/server-error is silently treated as
+        // a successful enrichment and the entity is never retried.
+        bool anyRetryable = false;
 
         foreach (var service in _enrichmentServices)
         {
             try
             {
                 var result = await service.EnrichEntityAsync(entity.Name, entity.Type, ct).ConfigureAwait(false);
-                if (result is not null)
+                var status = result?.Status;
+
+                if (result is not null && status is null or EnrichmentStatus.Success)
                 {
                     updated = updated with
                     {
@@ -133,10 +141,19 @@ public sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDis
                     anySuccess = true;
                     _logger.LogDebug("Enriched entity {EntityId} via {Provider}", entity.EntityId, result.Provider);
                 }
+                else if (result is null || status is EnrichmentStatus.Error or EnrichmentStatus.RateLimited)
+                {
+                    // Transient: worth a retry. (NotFound / Skipped are terminal — neither success nor retry.)
+                    anyRetryable = true;
+                    _logger.LogDebug(
+                        "Enrichment provider {Provider} returned a transient {Status} for entity {EntityId}",
+                        service.GetType().Name, status, entity.EntityId);
+                }
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
+                anyRetryable = true;
                 _logger.LogError(ex, "Enrichment provider {Provider} failed for entity {EntityId}",
                     service.GetType().Name, entity.EntityId);
             }
@@ -148,7 +165,9 @@ public sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDis
             return;
         }
 
-        if (item.RetryCount < _options.MaxRetries)
+        // Nothing succeeded. Only retry on a TRANSIENT failure; if every provider returned a terminal
+        // NotFound/Skipped (the entity is genuinely un-enrichable), do not loop — just stop.
+        if (anyRetryable && item.RetryCount < _options.MaxRetries)
         {
             _logger.LogWarning(
                 "All enrichment providers failed for entity {EntityId}; scheduling retry {Attempt}/{Max}",

--- a/tests/AgentMemory.Tests.Unit/Enrichment/BackgroundEnrichmentQueueTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/BackgroundEnrichmentQueueTests.cs
@@ -270,6 +270,60 @@ public sealed class BackgroundEnrichmentQueueTests
     }
 
     [Fact]
+    public async Task EnqueueAsync_ProviderReturnsTransientRateLimitedThenSuccess_Retries()
+    {
+        // Providers signal transient failures by RETURNING a non-null Error/RateLimited result (not by
+        // throwing). The queue must treat that as a retryable failure, not a success.
+        var callCount = 0;
+        var upsertTcs = new TaskCompletionSource();
+        var service = Substitute.For<IEnrichmentService>();
+        service.EnrichEntityAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+               .Returns(_ => Interlocked.Increment(ref callCount) == 1
+                   ? Task.FromResult<EnrichmentResult?>(new EnrichmentResult { EntityName = "Entity-e1", Provider = "Test", Status = EnrichmentStatus.RateLimited })
+                   : Task.FromResult<EnrichmentResult?>(CreateResult("Entity-e1")));
+
+        var repo = CreateRepo("e1");
+        repo.UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(ci => { upsertTcs.TrySetResult(); return Task.FromResult(ci.Arg<Entity>()); });
+        var opts = new EnrichmentQueueOptions { MaxRetries = 2, RetryDelay = TimeSpan.Zero };
+        await using var sut = CreateSut(service, repo, opts);
+
+        await sut.EnqueueAsync("e1");
+
+        await upsertTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        callCount.Should().BeGreaterThanOrEqualTo(2, "a non-null RateLimited result is a transient failure that must be retried");
+        await repo.Received(1).UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_ProviderReturnsTerminalNotFound_DoesNotRetryOrUpsert()
+    {
+        // NotFound (and Skipped) are terminal — the entity is genuinely un-enrichable, so the queue must
+        // NOT retry (and must not loop) and must not perform a no-op upsert.
+        var callCount = 0;
+        var doneTcs = new TaskCompletionSource();
+        var service = Substitute.For<IEnrichmentService>();
+        service.EnrichEntityAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+               .Returns(_ =>
+               {
+                   Interlocked.Increment(ref callCount);
+                   doneTcs.TrySetResult();
+                   return Task.FromResult<EnrichmentResult?>(new EnrichmentResult { EntityName = "Entity-e1", Provider = "Test", Status = EnrichmentStatus.NotFound });
+               });
+
+        var repo = CreateRepo("e1");
+        var opts = new EnrichmentQueueOptions { MaxRetries = 2, RetryDelay = TimeSpan.Zero };
+        await using var sut = CreateSut(service, repo, opts);
+
+        await sut.EnqueueAsync("e1");
+
+        await doneTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(150); // give any erroneous retry a chance to fire
+        callCount.Should().Be(1, "NotFound is terminal — it must not retry");
+        await repo.DidNotReceive().UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task EnqueueAsync_MaxRetriesExceeded_ItemDropped()
     {
         var callCount = 0;


### PR DESCRIPTION
Round-3 audit — **HIGH**. The background enrichment queue inferred success purely from `result is not null`, **ignoring `EnrichmentResult.Status`**. But providers signal *transient* failures by **returning** a non-null status-bearing result, not by throwing: `DiffbotEnrichmentService` returns a non-null `Status = RateLimited` on HTTP 429 and `Status = Error` on 5xx (and on a generic exception).

Because those are non-null, the queue set `anySuccess = true`, did a **no-op upsert** (Error/RateLimited carry null Summary/Description), and returned — the `RetryCount < MaxRetries` re-queue branch was **unreachable**. So a transient 429/503 from the primary provider was permanently swallowed as a "successful" enrichment and **never retried**, despite `MaxRetries` defaulting to 2. (The Diffbot author had worked around this **only** for timeouts by throwing `TimeoutException` — the 429/5xx returned-result paths still hit it.)

## Fix
Classify each provider result by `Status`:
- `Success`/null → real success (merge + upsert)
- `Error` / `RateLimited` (or a null result, or a thrown exception) → **transient, retryable**
- `NotFound` / `Skipped` → **terminal** (neither success nor retry — a genuinely un-enrichable entity must not loop)

Only a transient failure now schedules a retry.

## Tests
A non-null `RateLimited` result then a success → retried + upserted; a terminal `NotFound` → no retry, no upsert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)