### PR TITLE
fix(core): honor ExtractionOptions.EnableAutoMerge (dead toggle → silent destructive merge)

### DIFF
--- a/src/AgentMemory.Core/Resolution/CompositeEntityResolver.cs
+++ b/src/AgentMemory.Core/Resolution/CompositeEntityResolver.cs
@@ -82,8 +82,11 @@ public sealed class CompositeEntityResolver : IEntityResolver
 
         var matched = resolutionResult.ResolvedEntity;
 
-        // >= AutoMergeThreshold: auto-merge (add alias to existing entity)
-        if (resolutionResult.Confidence >= _options.AutoMergeThreshold)
+        // >= AutoMergeThreshold: auto-merge (add alias to existing entity) — ONLY when auto-merge is
+        // enabled. With EnableAutoMerge=false a high-confidence match falls through to the SAME_AS band
+        // below (non-destructive: the entities are linked, not folded), so a user who disabled auto-merge
+        // to keep distinct-but-similar entities separate is honored instead of silently losing one.
+        if (_options.EnableAutoMerge && resolutionResult.Confidence >= _options.AutoMergeThreshold)
         {
             _logger.LogDebug(
                 "Auto-merging entity '{Candidate}' into '{Existing}' (confidence {Confidence:F3}).",

--- a/tests/AgentMemory.Tests.Unit/Resolution/CompositeEntityResolverTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Resolution/CompositeEntityResolverTests.cs
@@ -251,6 +251,29 @@ public sealed class CompositeEntityResolverTests
     }
 
     [Fact]
+    public async Task ResolveEntityAsync_AutoMergeDisabled_DoesNotMerge_FallsThroughToSameAs()
+    {
+        // Same high-confidence match as above, but with EnableAutoMerge=false: the destructive alias-merge
+        // (a re-embed + Upsert that folds the candidate into the existing entity) must be suppressed; the
+        // match falls through to the SAME_AS band, which returns the existing entity unmodified.
+        var existing = new[] { MakeEntity("e1", "Alice Smith", aliases: "Ally Smith") };
+        _entityRepo.GetByTypeAsync("Person", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Entity>>(existing));
+
+        var sut = CreateSut(new ExtractionOptions
+        {
+            EnableAutoMerge = false,
+            AutoMergeThreshold = 0.95,
+            SameAsThreshold = 0.85
+        });
+
+        var result = await sut.ResolveEntityAsync(MakeCandidate("Ally Smith"), Array.Empty<string>());
+
+        await _entityRepo.DidNotReceive().UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+        result.EntityId.Should().Be("e1"); // existing entity returned, not folded/mutated
+    }
+
+    [Fact]
     public async Task ResolveEntityAsync_ConfidenceInSameAsRange_ReturnsExistingWithoutUpsert()
     {
         // Fuzzy score for "John Smith Jr" vs "John Smith" should be in SameAs range


### PR DESCRIPTION
Round-3 audit — **MEDIUM** (silent data loss when a user disables auto-merge).

`ExtractionOptions.EnableAutoMerge` is documented *"When true, entities above `AutoMergeThreshold` are automatically merged"* but was read **nowhere** — `CompositeEntityResolver` auto-merged **unconditionally** whenever `Confidence >= AutoMergeThreshold`. The merge is **destructive** (the candidate is folded into the existing entity as an alias and is *not* created as a separate node), so a user who set `EnableAutoMerge=false` to keep distinct-but-similar entities separate still had them silently merged, losing the distinct entity.

## Fix
Gate the auto-merge branch on `_options.EnableAutoMerge`. With it `false`, a high-confidence match falls through to the **SAME_AS** band (non-destructive — the entities are *linked*, not folded). Default is `true`, so **default behavior is unchanged** — only users who explicitly disabled auto-merge (exactly those being harmed) are affected.

## Test
`EnableAutoMerge=false` with a `>=AutoMergeThreshold` match → no merge upsert; returns the existing entity unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)