### PR TITLE
fix(core): wire LongTermMemoryOptions.MinConfidenceThreshold into Add* persistence

### DIFF
--- a/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
@@ -23,7 +23,9 @@ namespace AgentMemory.Abstractions.Services;
 public interface ILongTermMemoryService
 {
     /// <summary>
-    /// Adds or updates an entity.
+    /// Adds or updates an entity. When the entity's <c>Confidence</c> is below
+    /// <c>LongTermMemoryOptions.MinConfidenceThreshold</c> the add is skipped (not persisted) and the
+    /// supplied entity is returned unchanged.
     /// </summary>
     Task<Entity> AddEntityAsync(
         Entity entity,
@@ -64,7 +66,9 @@ public interface ILongTermMemoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Adds or updates a preference.
+    /// Adds or updates a preference. When the preference's <c>Confidence</c> is below
+    /// <c>LongTermMemoryOptions.MinConfidenceThreshold</c> the add is skipped (not persisted) and the
+    /// supplied preference is returned unchanged.
     /// </summary>
     Task<Preference> AddPreferenceAsync(
         Preference preference,
@@ -89,7 +93,9 @@ public interface ILongTermMemoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Adds or updates a fact.
+    /// Adds or updates a fact. When the fact's <c>Confidence</c> is below
+    /// <c>LongTermMemoryOptions.MinConfidenceThreshold</c> the add is skipped (not persisted) and the
+    /// supplied fact is returned unchanged.
     /// </summary>
     Task<Fact> AddFactAsync(
         Fact fact,

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -75,6 +75,15 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entity);
+
+        if (entity.Confidence < _options.MinConfidenceThreshold)
+        {
+            _logger.LogDebug(
+                "Skipping entity '{Id}' — confidence {Confidence} below LongTerm.MinConfidenceThreshold {Threshold}; not persisted.",
+                entity.EntityId, entity.Confidence, _options.MinConfidenceThreshold);
+            return Task.FromResult(entity);
+        }
+
         return EnsureEmbeddingThenUpsertAsync(
             entity,
             shouldEmbed: _options.GenerateEntityEmbeddings && entity.Embedding is null,
@@ -117,6 +126,14 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(preference);
+
+        if (preference.Confidence < _options.MinConfidenceThreshold)
+        {
+            _logger.LogDebug(
+                "Skipping preference '{Id}' — confidence {Confidence} below LongTerm.MinConfidenceThreshold {Threshold}; not persisted.",
+                preference.PreferenceId, preference.Confidence, _options.MinConfidenceThreshold);
+            return preference;
+        }
 
         var embedding = preference.Embedding;
         if (_options.GeneratePreferenceEmbeddings && embedding is null)
@@ -172,6 +189,14 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(fact);
+
+        if (fact.Confidence < _options.MinConfidenceThreshold)
+        {
+            _logger.LogDebug(
+                "Skipping fact '{Id}' ({S} {P} {O}) — confidence {Confidence} below LongTerm.MinConfidenceThreshold {Threshold}; not persisted.",
+                fact.FactId, fact.Subject, fact.Predicate, fact.Object, fact.Confidence, _options.MinConfidenceThreshold);
+            return fact;
+        }
 
         var embedding = fact.Embedding;
         if (_options.GenerateFactEmbeddings && embedding is null)

--- a/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
@@ -360,6 +360,60 @@ public sealed class LongTermMemoryServiceTests
         result.PreferenceId.Should().Be("p-existing");
     }
 
+    // ---- MinConfidenceThreshold gating ----
+
+    [Fact]
+    public async Task AddEntityAsync_BelowMinConfidence_NotPersisted_ReturnsItem()
+    {
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { MinConfidenceThreshold = 0.7 }));
+        var entity = CreateEntity("e-low") with { Confidence = 0.6 };
+
+        var result = await sut.AddEntityAsync(entity);
+
+        await _entityRepo.DidNotReceive().UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+        await _embeddingOrchestrator.DidNotReceive().EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        result.Should().BeSameAs(entity);
+    }
+
+    [Fact]
+    public async Task AddEntityAsync_AtMinConfidence_IsPersisted()
+    {
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { MinConfidenceThreshold = 0.7 }));
+        var entity = CreateEntity("e-boundary") with { Confidence = 0.7 };
+
+        await sut.AddEntityAsync(entity);
+
+        await _entityRepo.Received(1).UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AddFactAsync_BelowMinConfidence_NotPersisted_AndSkipsDuplicateLookup()
+    {
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { MinConfidenceThreshold = 0.7 }));
+        var fact = CreateFact("f-low") with { Confidence = 0.6 };
+
+        var result = await sut.AddFactAsync(fact);
+
+        await _factRepo.DidNotReceive().UpsertAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>());
+        await _factRepo.DidNotReceive().FindDuplicateAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+        result.Should().BeSameAs(fact);
+    }
+
+    [Fact]
+    public async Task AddPreferenceAsync_BelowMinConfidence_NotPersisted_AndSkipsDuplicateLookup()
+    {
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { MinConfidenceThreshold = 0.7 }));
+        var pref = CreatePreference("p-low") with { Confidence = 0.6 };
+
+        var result = await sut.AddPreferenceAsync(pref);
+
+        await _prefRepo.DidNotReceive().UpsertAsync(Arg.Any<Preference>(), Arg.Any<CancellationToken>());
+        await _prefRepo.DidNotReceive().FindDuplicateAsync(
+            Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+        result.Should().BeSameAs(pref);
+    }
+
     // ---- Helpers ----
 
     private static Entity CreateEntity(string id, bool withEmbedding = false) => new()


### PR DESCRIPTION
## Summary
`LongTermMemoryOptions.MinConfidenceThreshold` (default 0.5) was a **dead config option** — documented and settable but read nowhere. (The extraction pipeline filters on the *separate* `ExtractionOptions.MinConfidenceThreshold` in `ExtractionStage`; this option governs the direct `ILongTermMemoryService.Add*` API used by the MCP tools and `MemoryQueryFacade`.)

This wires it up: `AddEntityAsync` / `AddPreferenceAsync` / `AddFactAsync` now skip persistence (and the preceding embedding + dedup work) when the item's `Confidence` is below the threshold, log a debug line, and return the supplied item unchanged.

This is finding **F** of the round-3 "4 dead config options" set, with the maintainer decision **"wire them all up."**

## Changes
- `LongTermMemoryService`: confidence gate at the top of the three `Add*` methods.
- `ILongTermMemoryService`: XML docs now state the skip-below-threshold contract.
- Tests: below-threshold add does not hit the repo (entity/fact/preference) and skips the dedup lookup; a boundary (== threshold) add is persisted.

## Verification
- `dotnet build` Core: clean.
- `LongTermMemoryServiceTests`: 35/35 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)