### PR TITLE
fix(extraction): wire LlmExtractionOptions.EntityTypes into the entity prompt

### DIFF
--- a/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
@@ -13,28 +13,27 @@ namespace AgentMemory.Extraction.Llm;
 /// </summary>
 public sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEntityExtractor
 {
-    public const string DefaultSystemPrompt =
-        """
-        You are an entity extraction assistant. Extract named entities from the conversation.
-        Return JSON only — no markdown, no explanation.
+    /// <summary>The canonical POLE+O entity types, used when no custom set is configured.</summary>
+    internal static readonly IReadOnlyList<string> DefaultEntityTypes =
+        new[] { "PERSON", "ORGANIZATION", "LOCATION", "EVENT", "OBJECT" };
 
-        Entity Types (POLE+O Model):
-        - PERSON: Individuals by name or role
-        - ORGANIZATION: Companies, groups, institutions
-        - LOCATION: Places, addresses, geographic areas
-        - EVENT: Incidents, meetings, occurrences
-        - OBJECT: Physical or digital items, concepts, technologies
+    /// <summary>Rich descriptions for the built-in POLE+O types; custom types fall back to a generic line.</summary>
+    private static readonly IReadOnlyDictionary<string, string> KnownTypeDescriptions =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PERSON"] = "Individuals by name or role",
+            ["ORGANIZATION"] = "Companies, groups, institutions",
+            ["LOCATION"] = "Places, addresses, geographic areas",
+            ["EVENT"] = "Incidents, meetings, occurrences",
+            ["OBJECT"] = "Physical or digital items, concepts, technologies",
+        };
 
-        Output format:
-        {"entities": [{"name": "...", "type": "ENTITY_TYPE", "subtype": "optional or null", "description": "brief context", "confidence": 0.9, "aliases": ["alt_name"]}]}
-
-        Guidelines:
-        - Use UPPERCASE for type
-        - Confidence: 0.95 for explicit mentions, 0.8 for inferred
-        - Include aliases when mentioned
-        - Do not extract pronouns or generic references
-        - Return {"entities": []} if nothing found
-        """;
+    /// <summary>
+    /// The default entity-extraction system prompt for the canonical POLE+O type set. Kept for
+    /// back-compat; the prompt actually sent is built from the configured
+    /// <see cref="LlmExtractionOptions.EntityTypes"/> via <see cref="BuildSystemPrompt"/>.
+    /// </summary>
+    public static readonly string DefaultSystemPrompt = BuildSystemPrompt(DefaultEntityTypes);
 
     private readonly LlmExtractionOptions _options;
     private readonly LlmExtractionRunner _runner;
@@ -54,11 +53,61 @@ public sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEntity
     {
         var conversationText = ConversationTextBuilder.Build(messages);
         return await _runner.RunAsync(
-            _options.EntityExtractionPrompt ?? DefaultSystemPrompt,
+            _options.EntityExtractionPrompt ?? BuildSystemPrompt(_options.EntityTypes),
             "Extract entities from this conversation:",
             conversationText,
             ProjectEntities,
             ct);
+    }
+
+    /// <summary>
+    /// Builds the entity-extraction system prompt, listing the supplied <paramref name="entityTypes"/>
+    /// (falling back to <see cref="DefaultEntityTypes"/> when none are configured). Built-in POLE+O types
+    /// get their canonical descriptions; any custom type is listed with a generic descriptor. Newlines are
+    /// normalized to LF so the output is stable regardless of source line endings.
+    /// </summary>
+    internal static string BuildSystemPrompt(IReadOnlyList<string> entityTypes)
+    {
+        var types = entityTypes is { Count: > 0 } ? entityTypes : DefaultEntityTypes;
+        var typeLines = string.Join("\n", types.Select(FormatTypeLine));
+
+        // Assembled as header + dynamic type lines + footer (joined with LF) rather than a single
+        // interpolated raw literal, because a multi-line interpolation hole inside a raw string literal
+        // has ambiguous continuation-line indentation. "" injects the blank line before "Output format:".
+        const string header =
+            """
+            You are an entity extraction assistant. Extract named entities from the conversation.
+            Return JSON only — no markdown, no explanation.
+
+            Entity Types (POLE+O Model):
+            """;
+
+        const string footer =
+            """
+            Output format:
+            {"entities": [{"name": "...", "type": "ENTITY_TYPE", "subtype": "optional or null", "description": "brief context", "confidence": 0.9, "aliases": ["alt_name"]}]}
+
+            Guidelines:
+            - Use UPPERCASE for type
+            - Confidence: 0.95 for explicit mentions, 0.8 for inferred
+            - Include aliases when mentioned
+            - Do not extract pronouns or generic references
+            - Return {"entities": []} if nothing found
+            """;
+
+        return string.Join("\n",
+            header.Replace("\r\n", "\n"),
+            typeLines,
+            "",
+            footer.Replace("\r\n", "\n"));
+    }
+
+    private static string FormatTypeLine(string type)
+    {
+        var name = (type ?? string.Empty).Trim().ToUpperInvariant();
+        return KnownTypeDescriptions.TryGetValue(name, out var desc)
+            ? $"- {name}: {desc}"
+            : $"- {name}: Domain-specific entity type";
     }
 
     private static IReadOnlyList<ExtractedEntity> ProjectEntities(LlmExtractionResponse dto)

--- a/tests/AgentMemory.Tests.Unit/Extraction/LlmSystemPromptTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/LlmSystemPromptTests.cs
@@ -61,6 +61,42 @@ public sealed class LlmSystemPromptTests
         systemMsg.Text.Should().Be(customPrompt);
     }
 
+    [Fact]
+    public async Task EntityExtractor_ConfiguredEntityTypes_DriveTheSystemPrompt()
+    {
+        var (client, captured) = SetupClient();
+        // Custom taxonomy: keep one built-in type, add custom ones (one lowercase to prove normalization),
+        // and drop the rest of the default POLE+O set.
+        var options = new LlmExtractionOptions
+        {
+            EntityExtractionPrompt = null,
+            EntityTypes = new[] { "PERSON", "product", "TECHNOLOGY" }
+        };
+        var sut = new LlmEntityExtractor(client, Options.Create(options), NullLogger<LlmEntityExtractor>.Instance);
+
+        await sut.ExtractAsync(new[] { SampleMessage });
+
+        var systemMsg = captured[0].First(m => m.Role == ChatRole.System);
+        systemMsg.Text.Should().Contain("- PERSON: Individuals by name or role");      // built-in keeps its rich description
+        systemMsg.Text.Should().Contain("- PRODUCT: Domain-specific entity type");     // custom type listed + uppercased
+        systemMsg.Text.Should().Contain("- TECHNOLOGY: Domain-specific entity type");
+        systemMsg.Text.Should().NotContain("ORGANIZATION");                            // a dropped default type is absent
+        systemMsg.Text.Should().NotBe(LlmEntityExtractor.DefaultSystemPrompt);
+    }
+
+    [Fact]
+    public async Task EntityExtractor_EmptyEntityTypes_FallsBackToDefaultPrompt()
+    {
+        var (client, captured) = SetupClient();
+        var options = new LlmExtractionOptions { EntityExtractionPrompt = null, EntityTypes = Array.Empty<string>() };
+        var sut = new LlmEntityExtractor(client, Options.Create(options), NullLogger<LlmEntityExtractor>.Instance);
+
+        await sut.ExtractAsync(new[] { SampleMessage });
+
+        var systemMsg = captured[0].First(m => m.Role == ChatRole.System);
+        systemMsg.Text.Should().Be(LlmEntityExtractor.DefaultSystemPrompt);
+    }
+
     // ── Fact extractor ─────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
`LlmExtractionOptions.EntityTypes` — documented as *"POLE+O entity types recognised by the entity extractor"* — was a **dead config option**. `LlmEntityExtractor` hardcoded the 5 POLE+O types in its `const DefaultSystemPrompt`, so changing `EntityTypes` had no effect on extraction.

This wires it: the entity-extraction system prompt is now built from the configured `EntityTypes` via `BuildSystemPrompt`:
- Built-in POLE+O types keep their canonical descriptions.
- Custom types are listed with a generic descriptor and uppercased.
- An empty/unset list falls back to the default POLE+O set.

`DefaultSystemPrompt` is now **computed from the default set** (`public const` → `public static readonly`), so for default configuration its value is unchanged and the existing *"default prompt used when override is null"* test passes byte-for-byte.

Finding **G** of the round-3 "4 dead config options" set; maintainer decision **"wire them all up."**

### Scope note
This drives the LLM **prompt** (the taxonomy the model is told to use) — it does not add a hard post-extraction type filter, to avoid silently dropping otherwise-valid LLM output and changing default-path behavior.

## Verification
- `dotnet build` Extraction.Llm: clean.
- `LlmSystemPromptTests`: 10/10 green (incl. 2 new: configured types drive the prompt; empty list → default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)