### PR TITLE
fix(reasoning): enforce ReasoningMemoryOptions.MaxTracesPerSession retention cap

### DIFF
--- a/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
@@ -58,4 +58,13 @@ public interface IReasoningTraceRepository
     /// Deletes all ReasoningTrace and child ReasoningStep nodes for a session.
     /// </summary>
     Task DeleteBySessionAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Enforces a per-session retention cap (H): keeps the newest <paramref name="maxToKeep"/> traces for
+    /// the session and hard-deletes older traces together with their child ReasoningStep nodes. Returns the
+    /// number of traces pruned. When <paramref name="scope"/> carries an owner (R1), the prune only considers
+    /// that owner's traces — it never evicts another owner's (and, with <c>IncludeShared=false</c>, never
+    /// shared/global) traces. Ordering is newest-first, so a just-added trace is always retained.
+    /// </summary>
+    Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, MemoryScope? scope = null, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Options;
@@ -17,6 +18,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
     private readonly IToolCallRepository _toolCallRepo;
     private readonly IClock _clock;
     private readonly IIdGenerator _idGenerator;
+    private readonly ReasoningMemoryOptions _options;
     private readonly ILogger<ReasoningMemoryService> _logger;
 
     /// <summary>
@@ -28,13 +30,16 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         IToolCallRepository toolCallRepo,
         IClock clock,
         IIdGenerator idGenerator,
+        IOptions<ReasoningMemoryOptions> options,
         ILogger<ReasoningMemoryService> logger)
     {
+        ArgumentNullException.ThrowIfNull(options);
         _traceRepo = traceRepo;
         _stepRepo = stepRepo;
         _toolCallRepo = toolCallRepo;
         _clock = clock;
         _idGenerator = idGenerator;
+        _options = options.Value;
         _logger = logger;
     }
 
@@ -59,7 +64,30 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         };
 
         _logger.LogDebug("Starting trace {TraceId} for session {SessionId}", trace.TraceId, sessionId);
-        return await _traceRepo.AddAsync(trace, cancellationToken);
+        var added = await _traceRepo.AddAsync(trace, cancellationToken);
+
+        // Retention cap (H): when MaxTracesPerSession is configured, prune older traces beyond the cap so a
+        // session's reasoning history cannot grow without bound. The prune is owner-scoped (R1) when an owner
+        // is present — own-only, so one owner's traces can never evict another owner's (or shared) traces.
+        if (_options.MaxTracesPerSession is { } cap && cap > 0)
+        {
+            var scope = ownerId is null ? null : MemoryScope.For(ownerId, includeShared: false);
+            try
+            {
+                var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, cap, scope, cancellationToken);
+                if (pruned > 0)
+                    _logger.LogDebug("Pruned {Pruned} trace(s) beyond MaxTracesPerSession={Cap} for session {SessionId}.",
+                        pruned, cap, sessionId);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                // Retention is best-effort housekeeping; never fail the StartTrace call because a prune failed.
+                _logger.LogWarning(ex, "Failed to prune traces for session {SessionId} (cap {Cap}).", sessionId, cap);
+            }
+        }
+
+        return added;
     }
 
     /// <inheritdoc/>

--- a/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
@@ -68,6 +68,30 @@ public static class ReasoningQueries
         DETACH DELETE t, s";
 
     /// <summary>
+    /// Retention prune (H): keep the newest <c>$keep</c> traces for a session (optionally R1-scoped to an
+    /// owner) and delete the older ones together with their child ReasoningStep nodes. Returns the number
+    /// of traces pruned. Ordering is by <c>started_at</c> DESC, so the just-added trace (newest) is always
+    /// retained. (A method, not a const, so it is excluded from the Cypher snapshot inventory — like the
+    /// other owner-parameterized builders here.)
+    /// </summary>
+    public static string PruneSessionTraces(bool hasOwnerFilter, bool includeShared)
+    {
+        var owner = !hasOwnerFilter ? string.Empty
+            : includeShared ? " AND (t.owner_id = $ownerId OR t.owner_id IS NULL)"
+                            : " AND t.owner_id = $ownerId";
+        return @"
+            MATCH (t:ReasoningTrace {session_id: $sessionId})
+            WHERE true" + owner + @"
+            WITH t ORDER BY t.started_at DESC
+            SKIP $keep
+            OPTIONAL MATCH (t)-[:HAS_STEP]->(s:ReasoningStep)
+            WITH collect(DISTINCT t) AS traces, collect(DISTINCT s) AS steps, count(DISTINCT t) AS pruned
+            FOREACH (x IN traces | DETACH DELETE x)
+            FOREACH (x IN steps  | DETACH DELETE x)
+            RETURN pruned";
+    }
+
+    /// <summary>
     /// Vector similarity search over ReasoningTrace task embeddings, with an optional success filter
     /// and an optional owner/shared filter (R1). When scoped, over-fetches <paramref name="topK"/>
     /// candidates then LIMITs to <c>$limit</c> after filtering, so the owner filter is never starved

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -221,6 +221,29 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         }, cancellationToken);
     }
 
+    public async Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+    {
+        bool hasOwner = scope?.HasOwnerFilter == true;
+        bool includeShared = scope?.IncludeShared ?? true;
+        _logger.LogDebug("Pruning reasoning traces for session {SessionId} to newest {Keep}, owner={Owner}",
+            sessionId, maxToKeep, scope?.OwnerId);
+
+        var cypher = ReasoningQueries.PruneSessionTraces(hasOwner, includeShared);
+        var parameters = new Dictionary<string, object>
+        {
+            ["sessionId"] = sessionId,
+            ["keep"] = maxToKeep
+        };
+        if (hasOwner) parameters["ownerId"] = scope!.OwnerId!;
+
+        return await _tx.WriteAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(cypher, parameters);
+            var record = await cursor.SingleAsync();
+            return record["pruned"].As<int>();
+        }, cancellationToken);
+    }
+
     private static ReasoningTrace MapToTrace(INode node, float[]? taskEmbedding) =>
         new()
         {

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTracePruneIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTracePruneIntegrationTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Neo4j.Repositories;
+using AgentMemory.Tests.Integration.Fixtures;
+using Neo4j.Driver;
+
+namespace AgentMemory.Tests.Integration.Repositories;
+
+/// <summary>
+/// Integration coverage for the per-session retention prune (H): keep the newest N traces, delete older
+/// ones (with their child steps), and honor R1 owner scoping.
+/// </summary>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public class ReasoningTracePruneIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private readonly Neo4jReasoningTraceRepository _traceRepo;
+    private readonly Neo4jReasoningStepRepository _stepRepo;
+
+    public ReasoningTracePruneIntegrationTests(Neo4jIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _traceRepo = new Neo4jReasoningTraceRepository(
+            fixture.TransactionRunner, NullLogger<Neo4jReasoningTraceRepository>.Instance);
+        _stepRepo = new Neo4jReasoningStepRepository(
+            fixture.TransactionRunner, NullLogger<Neo4jReasoningStepRepository>.Instance);
+    }
+
+    public Task InitializeAsync() => _fixture.CleanDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private ReasoningTrace MakeTrace(string sessionId, int dayOffset, string? ownerId = null) => new()
+    {
+        TraceId = $"trace-{Guid.NewGuid():N}",
+        SessionId = sessionId,
+        OwnerId = ownerId,
+        Task = $"Task day {dayOffset}",
+        StartedAtUtc = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero).AddDays(dayOffset)
+    };
+
+    [Fact]
+    public async Task PruneSessionTracesAsync_KeepsNewest_DeletesOlder_ReturnsCount()
+    {
+        var sessionId = $"session-{Guid.NewGuid():N}";
+        var traces = new List<ReasoningTrace>();
+        for (var day = 0; day < 5; day++)
+        {
+            var t = MakeTrace(sessionId, day);
+            await _traceRepo.AddAsync(t);
+            traces.Add(t);
+        }
+
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 3);
+
+        pruned.Should().Be(2);
+        var remaining = await _traceRepo.ListBySessionAsync(sessionId, limit: 100);
+        remaining.Select(t => t.TraceId).Should().BeEquivalentTo(
+            new[] { traces[4].TraceId, traces[3].TraceId, traces[2].TraceId },
+            "the 3 newest (by started_at) are retained");
+    }
+
+    [Fact]
+    public async Task PruneSessionTracesAsync_DeletesChildStepsOfPrunedTraces()
+    {
+        var sessionId = $"session-{Guid.NewGuid():N}";
+        var older = MakeTrace(sessionId, 0);
+        var newer = MakeTrace(sessionId, 1);
+        await _traceRepo.AddAsync(older);
+        await _traceRepo.AddAsync(newer);
+
+        var step = new ReasoningStep
+        {
+            StepId = $"step-{Guid.NewGuid():N}",
+            TraceId = older.TraceId,
+            StepNumber = 1,
+            Thought = "to be pruned"
+        };
+        await _stepRepo.AddAsync(step);
+
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 1);
+
+        pruned.Should().Be(1);
+        (await _traceRepo.GetByIdAsync(older.TraceId)).Should().BeNull("older trace was pruned");
+        (await _traceRepo.GetByIdAsync(newer.TraceId)).Should().NotBeNull("newest trace is retained");
+
+        var orphanStepCount = await _fixture.TransactionRunner.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(
+                "MATCH (s:ReasoningStep {id: $sid}) RETURN count(s) AS c", new { sid = step.StepId });
+            var record = await cursor.SingleAsync();
+            return global::Neo4j.Driver.ValueExtensions.As<long>(record["c"]);
+        });
+        orphanStepCount.Should().Be(0, "the pruned trace's child step must be deleted, not orphaned");
+    }
+
+    [Fact]
+    public async Task PruneSessionTracesAsync_NothingToPrune_ReturnsZero_AndKeepsAll()
+    {
+        var sessionId = $"session-{Guid.NewGuid():N}";
+        await _traceRepo.AddAsync(MakeTrace(sessionId, 0));
+        await _traceRepo.AddAsync(MakeTrace(sessionId, 1));
+
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 5);
+
+        pruned.Should().Be(0);
+        (await _traceRepo.ListBySessionAsync(sessionId, limit: 100)).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task PruneSessionTracesAsync_OwnerScopedOwnOnly_DoesNotEvictOtherOwnersOrShared()
+    {
+        var sessionId = $"session-{Guid.NewGuid():N}";
+        // Alice has 3 traces; Bob has 2; one shared (owner null). Same session id (a guessable handle).
+        var alice = new List<ReasoningTrace>();
+        for (var day = 0; day < 3; day++)
+        {
+            var t = MakeTrace(sessionId, day, ownerId: "alice");
+            await _traceRepo.AddAsync(t);
+            alice.Add(t);
+        }
+        var bob1 = MakeTrace(sessionId, 0, ownerId: "bob");
+        var bob2 = MakeTrace(sessionId, 1, ownerId: "bob");
+        var shared = MakeTrace(sessionId, 0, ownerId: null);
+        await _traceRepo.AddAsync(bob1);
+        await _traceRepo.AddAsync(bob2);
+        await _traceRepo.AddAsync(shared);
+
+        // Prune Alice own-only to keep 1 → 2 of Alice's pruned; Bob's + shared untouched.
+        var scope = MemoryScope.For("alice", includeShared: false);
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 1, scope: scope);
+
+        pruned.Should().Be(2);
+
+        var aliceRemaining = await _traceRepo.ListBySessionAsync(sessionId, limit: 100, scope: MemoryScope.For("alice", includeShared: false));
+        aliceRemaining.Should().ContainSingle().Which.TraceId.Should().Be(alice[2].TraceId, "only Alice's newest survives");
+
+        var bobRemaining = await _traceRepo.ListBySessionAsync(sessionId, limit: 100, scope: MemoryScope.For("bob", includeShared: false));
+        bobRemaining.Select(t => t.TraceId).Should().BeEquivalentTo(new[] { bob1.TraceId, bob2.TraceId },
+            "Bob's traces are never touched by Alice's prune");
+
+        (await _traceRepo.GetByIdAsync(shared.TraceId)).Should().NotBeNull("shared trace is never evicted by an own-only prune");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
@@ -46,8 +46,9 @@ public sealed class ReasoningMemoryServiceTests
             .Returns(ci => Task.FromResult(ci.Arg<ToolCall>()));
     }
 
-    private ReasoningMemoryService CreateSut() =>
+    private ReasoningMemoryService CreateSut(ReasoningMemoryOptions? options = null) =>
         new(_traceRepo, _stepRepo, _toolCallRepo, _clock, _idGenerator,
+            Microsoft.Extensions.Options.Options.Create(options ?? new ReasoningMemoryOptions()),
             NullLogger<ReasoningMemoryService>.Instance);
 
     [Fact]
@@ -71,6 +72,64 @@ public sealed class ReasoningMemoryServiceTests
         var result = await sut.StartTraceAsync("session-1", "Test task");
 
         result.StartedAtUtc.Should().Be(_fixedTime);
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_NoMaxTracesConfigured_DoesNotPrune()
+    {
+        var sut = CreateSut(); // MaxTracesPerSession = null (default)
+
+        await sut.StartTraceAsync("session-1", "Test task");
+
+        await _traceRepo.DidNotReceive().PruneSessionTracesAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_MaxTracesConfigured_PrunesUnscopedWhenNoOwner()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 5 });
+
+        await sut.StartTraceAsync("session-1", "Test task");
+
+        await _traceRepo.Received(1).PruneSessionTracesAsync(
+            "session-1", 5, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_MaxTracesConfiguredWithOwner_PrunesOwnerScopedOwnOnly()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 3 });
+
+        await sut.StartTraceAsync("session-1", "Test task", ownerId: "alice");
+
+        await _traceRepo.Received(1).PruneSessionTracesAsync(
+            "session-1", 3,
+            Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice" && s.IncludeShared == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_MaxTracesZeroOrNegative_DoesNotPrune()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 0 });
+
+        await sut.StartTraceAsync("session-1", "Test task");
+
+        await _traceRepo.DidNotReceive().PruneSessionTracesAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_PruneFailure_DoesNotFailStartTrace()
+    {
+        _traceRepo.PruneSessionTracesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("boom"));
+        var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 2 });
+
+        var result = await sut.StartTraceAsync("session-1", "Test task");
+
+        result.SessionId.Should().Be("session-1"); // trace still returned despite prune failure
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
`ReasoningMemoryOptions.MaxTracesPerSession` was a **dead config option** — documented and settable but read nowhere — so a session's reasoning-trace history grew without bound. `StartTraceAsync` now prunes older traces beyond the cap after adding the new trace.

Finding **H** of the round-3 "4 dead config options" set; maintainer decision **"wire them all up."**

## Changes
- **New** `IReasoningTraceRepository.PruneSessionTracesAsync(sessionId, maxToKeep, scope)`: keeps the newest *N* traces (by `started_at`), hard-deletes older traces **with their child `ReasoningStep` nodes** (mirrors `DeleteBySession`), returns the count pruned. The Cypher is a builder *method*, so it's excluded from the Cypher snapshot inventory (like the other owner-parameterized builders).
- `ReasoningMemoryService` now takes `IOptions<ReasoningMemoryOptions>` and prunes when `MaxTracesPerSession` is set.
  - **R1-safe**: when an owner is present the prune is **own-only** (`MemoryScope.For(ownerId, includeShared: false)`) — one owner's new trace can never evict another owner's or shared traces. Null owner → unscoped (single-tenant). `null`/`<1` cap → disabled (no behavior change).
  - **Best-effort**: a prune failure is logged and swallowed (never fails `StartTrace`); `OperationCanceledException` is rethrown on cancellation.

## Verification
- Full unit suite: **green** (incl. 5 new: prunes only when cap set; unscoped vs own-only scope; zero/negative cap no-op; prune failure doesn't fail StartTrace).
- Integration (real Neo4j via Testcontainers, **4/4 green**): keeps newest/deletes older + correct count; deletes child steps (no orphans); nothing-to-prune returns 0; owner own-only prune leaves other owners' **and** shared traces intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)