### PR TITLE
fix(enrichment): wire EnrichmentOptions/GeocodingOptions.MaxRetries (retry policy)

### DIFF
--- a/src/AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs
+++ b/src/AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace AgentMemory.Enrichment.Http;
+
+/// <summary>
+/// A dependency-free <see cref="DelegatingHandler"/> that retries transient HTTP failures up to a
+/// configured number of times with exponential backoff. This wires the <c>MaxRetries</c> option of the
+/// Nominatim/Wikimedia clients without taking a Polly dependency.
+/// </summary>
+/// <remarks>
+/// <para>A failure is treated as transient when it is a network error (<see cref="HttpRequestException"/>),
+/// a request timeout (a <see cref="TaskCanceledException"/> whose token is <i>not</i> the caller's — i.e.
+/// the per-request <c>HttpClient.Timeout</c> fired), or a retryable status code (408, 429, 500, 502, 503,
+/// 504). Caller cancellation is never retried.</para>
+/// <para>Intended for the idempotent, body-less GET clients here; the same request instance is re-sent,
+/// which the runtime permits for requests without (non-rewindable) content.</para>
+/// </remarks>
+internal sealed class RetryHttpMessageHandler : DelegatingHandler
+{
+    private readonly int _maxRetries;
+    private readonly TimeSpan _baseDelay;
+    private readonly ILogger? _logger;
+
+    public RetryHttpMessageHandler(int maxRetries, ILogger? logger = null, TimeSpan? baseDelay = null)
+    {
+        _maxRetries = Math.Max(0, maxRetries);
+        _baseDelay = baseDelay ?? TimeSpan.FromMilliseconds(500);
+        _logger = logger;
+    }
+
+    private static bool IsTransient(HttpStatusCode status) => status switch
+    {
+        HttpStatusCode.RequestTimeout => true,        // 408
+        HttpStatusCode.TooManyRequests => true,       // 429
+        HttpStatusCode.InternalServerError => true,   // 500
+        HttpStatusCode.BadGateway => true,            // 502
+        HttpStatusCode.ServiceUnavailable => true,    // 503
+        HttpStatusCode.GatewayTimeout => true,        // 504
+        _ => false
+    };
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (attempt >= _maxRetries || !IsTransient(response.StatusCode))
+                    return response;
+
+                _logger?.LogDebug(
+                    "Transient HTTP {Status} from {Uri}; retry {Next}/{Max}.",
+                    (int)response.StatusCode, request.RequestUri, attempt + 1, _maxRetries);
+                response.Dispose();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw; // caller cancellation — never retry
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException && attempt < _maxRetries)
+            {
+                // Network failure, or a per-request timeout (a TaskCanceledException whose token was NOT
+                // the caller's — caller cancellation is handled by the guarded catch above). Retry.
+                _logger?.LogDebug(ex,
+                    "Transient HTTP failure to {Uri}; retry {Next}/{Max}.",
+                    request.RequestUri, attempt + 1, _maxRetries);
+            }
+
+            await Task.Delay(BackoffFor(attempt), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private TimeSpan BackoffFor(int attempt) =>
+        TimeSpan.FromMilliseconds(_baseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+}

--- a/src/AgentMemory.Enrichment/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Enrichment/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
+using AgentMemory.Enrichment.Http;
 
 namespace AgentMemory.Enrichment;
 
@@ -32,6 +33,7 @@ public static class ServiceCollectionExtensions
             .Validate(o => !string.IsNullOrWhiteSpace(o.UserAgent), "Geocoding UserAgent must be provided (Nominatim requires it).")
             .Validate(o => o.TimeoutSeconds > 0, "Geocoding TimeoutSeconds must be positive.")
             .Validate(o => o.RateLimitPerSecond > 0, "Geocoding RateLimitPerSecond must be positive.")
+            .Validate(o => o.MaxRetries >= 0, "Geocoding MaxRetries must be non-negative.")
             .ValidateOnStart();
 
         var enrichOptions = services.AddOptions<EnrichmentOptions>();
@@ -41,6 +43,7 @@ public static class ServiceCollectionExtensions
             .Validate(o => !string.IsNullOrWhiteSpace(o.WikipediaLanguage), "Enrichment WikipediaLanguage must be provided.")
             .Validate(o => !string.IsNullOrWhiteSpace(o.WikipediaBaseUrl), "Enrichment WikipediaBaseUrl must be provided.")
             .Validate(o => o.TimeoutSeconds > 0, "Enrichment TimeoutSeconds must be positive.")
+            .Validate(o => o.MaxRetries >= 0, "Enrichment MaxRetries must be non-negative.")
             .ValidateOnStart();
 
         var cacheOptions = services.AddOptions<EnrichmentCacheOptions>();
@@ -50,20 +53,26 @@ public static class ServiceCollectionExtensions
         // In-memory cache (no-op if already registered)
         services.AddMemoryCache();
 
-        // Named HTTP clients
+        // Named HTTP clients. Each gets a transient-retry handler honoring its MaxRetries option.
         services.AddHttpClient(NominatimGeocodingService.ClientName, (sp, client) =>
         {
             var opts = sp.GetRequiredService<IOptions<GeocodingOptions>>().Value;
             client.DefaultRequestHeaders.UserAgent.ParseAdd(opts.UserAgent);
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-        });
+        })
+        .AddHttpMessageHandler(sp => new RetryHttpMessageHandler(
+            sp.GetRequiredService<IOptions<GeocodingOptions>>().Value.MaxRetries,
+            sp.GetService<ILogger<RetryHttpMessageHandler>>()));
 
         services.AddHttpClient(WikimediaEnrichmentService.ClientName, (sp, client) =>
         {
             var opts = sp.GetRequiredService<IOptions<EnrichmentOptions>>().Value;
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
             client.DefaultRequestHeaders.UserAgent.ParseAdd("AgentMemory/1.0");
-        });
+        })
+        .AddHttpMessageHandler(sp => new RetryHttpMessageHandler(
+            sp.GetRequiredService<IOptions<EnrichmentOptions>>().Value.MaxRetries,
+            sp.GetService<ILogger<RetryHttpMessageHandler>>()));
 
         // Register concrete implementations for direct resolution
         services.TryAddSingleton<NominatimGeocodingService>();

--- a/tests/AgentMemory.Tests.Unit/Enrichment/RetryHttpMessageHandlerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/RetryHttpMessageHandlerTests.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using AgentMemory.Enrichment;
+using AgentMemory.Enrichment.Http;
+
+namespace AgentMemory.Tests.Unit.Enrichment;
+
+public sealed class RetryHttpMessageHandlerTests
+{
+    private static readonly TimeSpan FastDelay = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>Inner handler that replays a fixed sequence of responses/throws and counts invocations.</summary>
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _steps;
+        public int Calls { get; private set; }
+
+        public SequenceHandler(params Func<HttpResponseMessage>[] steps) => _steps = new Queue<Func<HttpResponseMessage>>(steps);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            if (_steps.Count == 0) throw new InvalidOperationException("SequenceHandler ran out of steps.");
+            return _steps.Dequeue()(); // the step may itself throw
+        }
+    }
+
+    private static Func<HttpResponseMessage> Status(HttpStatusCode code) => () => new HttpResponseMessage(code);
+    private static Func<HttpResponseMessage> Throws(Exception ex) => () => throw ex;
+
+    private static HttpClient ClientWith(int maxRetries, SequenceHandler inner) =>
+        new(new RetryHttpMessageHandler(maxRetries, logger: null, baseDelay: FastDelay) { InnerHandler = inner });
+
+    [Fact]
+    public async Task RetriesTransientStatus_ThenSucceeds()
+    {
+        var inner = new SequenceHandler(
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.OK));
+        var client = ClientWith(maxRetries: 2, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        inner.Calls.Should().Be(3); // initial + 2 retries
+    }
+
+    [Fact]
+    public async Task StopsAfterMaxRetries_ReturnsLastTransientResponse()
+    {
+        var inner = new SequenceHandler(
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.ServiceUnavailable));
+        var client = ClientWith(maxRetries: 2, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        inner.Calls.Should().Be(3); // initial + 2 retries, then gives up
+    }
+
+    [Fact]
+    public async Task RetriesHttpRequestException_ThenSucceeds()
+    {
+        var inner = new SequenceHandler(
+            Throws(new HttpRequestException("connection reset")),
+            Status(HttpStatusCode.OK));
+        var client = ClientWith(maxRetries: 2, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        inner.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DoesNotRetry_OnSuccess()
+    {
+        var inner = new SequenceHandler(Status(HttpStatusCode.OK));
+        var client = ClientWith(maxRetries: 3, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        inner.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DoesNotRetry_OnNonTransientStatus()
+    {
+        var inner = new SequenceHandler(Status(HttpStatusCode.NotFound));
+        var client = ClientWith(maxRetries: 3, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        inner.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MaxRetriesZero_NeverRetries()
+    {
+        var inner = new SequenceHandler(Status(HttpStatusCode.ServiceUnavailable));
+        var client = ClientWith(maxRetries: 0, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        inner.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsNotRetried_AndPropagates()
+    {
+        var inner = new SequenceHandler(Status(HttpStatusCode.OK)); // would succeed if reached
+        var client = ClientWith(maxRetries: 3, inner);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => client.GetAsync("https://example.test/", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        inner.Calls.Should().Be(1); // the single attempt observed the canceled token; no retry loop
+    }
+
+    [Fact]
+    public async Task TooManyRequests_IsTreatedAsTransient()
+    {
+        var inner = new SequenceHandler(
+            Status(HttpStatusCode.TooManyRequests),
+            Status(HttpStatusCode.OK));
+        var client = ClientWith(maxRetries: 1, inner);
+
+        var response = await client.GetAsync("https://example.test/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        inner.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AddEnrichmentServices_WiresRetryHandlerOnNominatimClient_HonoringMaxRetries()
+    {
+        // Proves the fix end-to-end: the named Nominatim client's pipeline includes the retry handler
+        // reading MaxRetries from GeocodingOptions. Without the handler the first 503 would be returned
+        // and the stub called once; the single retry (→ 2 calls) is what demonstrates the wiring.
+        var stub = new SequenceHandler(
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.OK));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEnrichmentServices(configureGeocoding: o =>
+        {
+            o.MaxRetries = 2;
+            o.UserAgent = "test/1.0";
+            o.BaseUrl = "https://nominatim.test";
+        });
+        // Swap the innermost handler so no real network call is made; the retry handler still wraps it.
+        services.AddHttpClient(NominatimGeocodingService.ClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => stub);
+
+        using var sp = services.BuildServiceProvider();
+        var factory = sp.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(NominatimGeocodingService.ClientName);
+
+        var response = await client.GetAsync("https://nominatim.test/search");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        stub.Calls.Should().Be(2); // initial 503 + one retry → the retry handler is wired into the pipeline
+    }
+}


### PR DESCRIPTION
## Summary
`EnrichmentOptions.MaxRetries` and `GeocodingOptions.MaxRetries` were **dead config options** — documented and settable but read nowhere. The Nominatim/Wikimedia named `HttpClient`s had no retry on transient failures.

This adds a **dependency-free** `RetryHttpMessageHandler` (`DelegatingHandler`) attached to each named client via `AddHttpMessageHandler`, honoring that client's `MaxRetries`. It retries transient failures with exponential backoff:
- network errors (`HttpRequestException`),
- request timeouts (a `TaskCanceledException` whose token is **not** the caller's),
- retryable status codes (408, 429, 500, 502, 503, 504).

Caller cancellation is **never** retried. No Polly dependency is taken (`Microsoft.Extensions.Http` is already referenced) — this was the stated reason the option was originally deferred. Also adds `MaxRetries >= 0` options validation.

Finding **I** of the round-3 "4 dead config options" set; maintainer decision **"wire them all up."** This completes the set (F, G, H, I).

## Verification
- `dotnet build` Enrichment: clean.
- Full unit suite: **green** (incl. 9 new: retries transient status/exception then succeeds; stops at MaxRetries; no retry on success/non-transient/caller-cancel; 429 transient; MaxRetries=0; **DI test** proving the handler is wired into the Nominatim named-client pipeline reading MaxRetries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)