### PR TITLE
fix(enrichment): keep background worker alive on non-cancellation faults

### DIFF
--- a/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
+++ b/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
@@ -99,6 +99,20 @@ public sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDis
                 {
                     await ProcessItemAsync(item, ct).ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw; // shutdown — propagate to the outer catch and end the worker loop
+                }
+                catch (Exception ex)
+                {
+                    // A non-cancellation fault outside the per-provider try (e.g. a transient Neo4j error
+                    // from GetByIdAsync/UpsertAsync, or Task.Delay) must NOT kill the worker — otherwise the
+                    // only worker-level catch was for OCE, so the task faulted permanently and the entire
+                    // queue silently stopped processing all future items. Log and continue with the next.
+                    _logger.LogError(ex,
+                        "Background enrichment failed for entity {EntityId}; skipping and continuing.",
+                        item.EntityId);
+                }
                 finally
                 {
                     Interlocked.Decrement(ref _activeCount);

--- a/tests/AgentMemory.Tests.Unit/Enrichment/BackgroundEnrichmentQueueTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/BackgroundEnrichmentQueueTests.cs
@@ -564,6 +564,38 @@ public sealed class BackgroundEnrichmentQueueTests
     }
 
     [Fact]
+    public async Task RepositoryThrowsOnOneItem_WorkerSurvivesAndProcessesNextItem()
+    {
+        // A transient (non-OCE) fault on a repo call must NOT kill the worker. Before the fix the only
+        // worker-level catch was for OperationCanceledException, so a GetByIdAsync fault faulted the worker
+        // task permanently and every later item went unprocessed (queue silently dies). With MaxConcurrency=1
+        // there is exactly one worker, so if it dies on "bad", "good" is never processed and this times out.
+        var goodProcessed = new TaskCompletionSource();
+
+        var service = Substitute.For<IEnrichmentService>();
+        // "good" succeeds (a real result) so it is not retried — keeps the call count deterministic.
+        service.EnrichEntityAsync("Entity-good", Arg.Any<string>(), Arg.Any<CancellationToken>())
+               .Returns(_ => { goodProcessed.TrySetResult(); return Task.FromResult<EnrichmentResult?>(CreateResult("Entity-good")); });
+
+        var repo = Substitute.For<IEntityRepository>();
+        repo.GetByIdAsync("bad", Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("transient db fault"));
+        repo.GetByIdAsync("good", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Entity?>(CreateEntity("good")));
+        repo.UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<Entity>()));
+
+        var opts = new EnrichmentQueueOptions { MaxConcurrency = 1, RetryDelay = TimeSpan.Zero };
+        await using var sut = CreateSut(service, repo, opts);
+
+        await sut.EnqueueAsync("bad");
+        await sut.EnqueueAsync("good");
+
+        await goodProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.Received(1).EnrichEntityAsync("Entity-good", "PLACE", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task EnqueueAsync_UpdatesEntityDescription_FromEnrichmentSummary()
     {
         var enrichmentResult = new EnrichmentResult


### PR DESCRIPTION
## Summary
**Round 4 hunt finding — HIGH (the only one rated HIGH).** `BackgroundEnrichmentQueue.RunWorkerAsync`'s per-item `try` had only a `finally`, and the worker's only `catch` was for `OperationCanceledException`. A non-OCE fault outside the per-provider `try` — e.g. a transient Neo4j error from `GetByIdAsync`/`UpsertAsync`, or `Task.Delay` — escaped `ProcessItemAsync`, was not matched by the OCE catch, and **faulted the worker `Task` permanently**.

Because workers are started fire-and-forget and `_processingTask` is only awaited in `DisposeAsync`, the fault was never observed or logged. Under repeated transient DB blips the workers die one-by-one until enrichment **silently and permanently stops** for the process lifetime, contradicting the queue's own retry contract.

## Fix
The per-item body now:
- rethrows `OperationCanceledException` on shutdown cancellation (handled by the outer catch, ends the loop cleanly), and
- logs + continues on any other exception,

so a transient repo/scheduling fault skips a single item instead of killing the worker.

## Verification
- Regression test: with `MaxConcurrency=1`, a `GetByIdAsync` that throws on one item no longer prevents the next item from being processed (without the fix the single worker dies and the test times out).
- `BackgroundEnrichmentQueueTests`: 23/23 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)