### PR TITLE
fix(core): propagate caller cancellation in ContextCompressor LLM calls

### DIFF
--- a/src/AgentMemory.Core/Services/ContextCompressor.cs
+++ b/src/AgentMemory.Core/Services/ContextCompressor.cs
@@ -138,6 +138,10 @@ public sealed class ContextCompressor : IContextCompressor
             var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken);
             return response.Text?.Trim() ?? string.Empty;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // caller cancellation must propagate, not be masked as fallback summary text
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to summarize conversation chunk; using fallback.");
@@ -164,6 +168,10 @@ public sealed class ContextCompressor : IContextCompressor
 
             var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken);
             return response.Text?.Trim() ?? string.Empty;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // caller cancellation must propagate, not be masked as an empty reflection
         }
         catch (Exception ex)
         {

--- a/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
@@ -196,4 +196,24 @@ public sealed class ContextCompressorTests
         Content = content,
         TimestampUtc = DateTimeOffset.UtcNow
     };
+
+    [Fact]
+    public async Task CompressAsync_CallerCancellation_PropagatesInsteadOfFallbackText()
+    {
+        // When the caller cancels mid-compression, the LLM call's OperationCanceledException must
+        // propagate — not be swallowed and replaced with placeholder summary/reflection text that would
+        // make a cancelled operation look like a successful compression.
+        using var cts = new CancellationTokenSource();
+        _chatClient
+            .GetResponseAsync(Arg.Any<IList<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ChatResponse>>(_ => { cts.Cancel(); throw new OperationCanceledException(cts.Token); });
+
+        var messages = Enumerable.Range(1, 6)
+            .Select(i => CreateMessage($"m{i}", new string('x', 100)))
+            .ToArray();
+
+        var act = () => _sut.CompressAsync(messages, _defaultOptions, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }


### PR DESCRIPTION
## Summary
**Round 4 hunt finding — MEDIUM.** `ContextCompressor.SummarizeChunkAsync` / `GenerateReflectionAsync` wrapped the `IChatClient.GetResponseAsync` call in a bare `catch (Exception)` with no cancellation guard. A caller-requested cancellation mid-compression was swallowed and replaced with placeholder fallback text (`"[Summary of N messages]"` / empty), so a cancelled `CompressAsync` returned `WasCompressed = true` with degraded content and the cancellation was invisible to the caller (it surfaces e.g. through the MCP `ObservationTools` path).

## Fix
Added `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }` before each broad catch, matching the OCE idiom used by `StreamingExtractor`, `EmbeddingOrchestrator`, the extraction pipeline, etc. Transient LLM failures still fall back as before.

## Verification
- `ContextCompressorTests`: 13/13 green (incl. a new test asserting caller cancellation propagates instead of producing fallback text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)