### PR TITLE
fix(analytics): re-probe GDS after a transient failure; log the exception

### DIFF
--- a/src/AgentMemory.Analytics/GdsAvailability.cs
+++ b/src/AgentMemory.Analytics/GdsAvailability.cs
@@ -10,7 +10,7 @@ public sealed class GdsAvailability : IGdsAvailability
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<GdsAvailability> _logger;
     private readonly object _gate = new();
-    private Task<bool>? _probe;
+    private bool? _available;       // definitive cached result (present / genuinely not installed); null = undetermined
 
     public GdsAvailability(INeo4jTransactionRunner tx, ILogger<GdsAvailability> logger)
     {
@@ -18,13 +18,24 @@ public sealed class GdsAvailability : IGdsAvailability
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
-        // Memoize the probe — GDS availability doesn't change during the process lifetime.
-        lock (_gate) { return _probe ??= ProbeAsync(); }
+        // Memoize only a DEFINITIVE answer — GDS present, or genuinely not installed. A transient probe
+        // failure (a connectivity/timeout blip) is NOT cached, so a first-use that happens to land during a
+        // Neo4j outage cannot disable analytics for the whole process lifetime: the next call re-probes.
+        lock (_gate)
+        {
+            if (_available is { } cached) return cached;
+        }
+
+        var (available, definitive) = await ProbeAsync().ConfigureAwait(false);
+        if (definitive)
+            lock (_gate) { _available = available; }
+        return available;
     }
 
-    private async Task<bool> ProbeAsync()
+    /// <summary>Probes for GDS. Returns whether it is available and whether that answer is definitive (stable).</summary>
+    private async Task<(bool Available, bool Definitive)> ProbeAsync()
     {
         try
         {
@@ -33,17 +44,28 @@ public sealed class GdsAvailability : IGdsAvailability
                 var cursor = await runner.RunAsync(GdsQueries.ProbeVersion);
                 var record = await cursor.SingleAsync();
                 return record["version"].As<string>();
-            });
+            }).ConfigureAwait(false);
+
             _logger.LogInformation("Neo4j GDS plugin detected (version {Version}); analytics enabled.", version);
-            return true;
+            return (true, true);
+        }
+        catch (ClientException ex)
+        {
+            // A client error on `RETURN gds.version()` means the function is unknown — GDS is genuinely not
+            // installed. That is a stable answer, so it is memoized by the caller.
+            _logger.LogWarning(ex,
+                "Neo4j GDS plugin not available; analytics will return empty results. " +
+                "Install the Graph Data Science plugin to enable PageRank / community detection.");
+            return (false, true);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
-                "Neo4j GDS plugin not available ({Reason}); analytics will return empty results. " +
-                "Install the Graph Data Science plugin to enable PageRank / community detection.",
-                ex.GetType().Name);
-            return false;
+            // Transient failure (connectivity/timeout/transaction). Degrade to unavailable for THIS call but
+            // do NOT cache it — the next IsAvailableAsync re-probes once Neo4j recovers.
+            _logger.LogWarning(ex,
+                "Neo4j GDS availability probe failed transiently; treating as unavailable for now and will " +
+                "re-probe on next use.");
+            return (false, false);
         }
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Analytics/GdsAnalyticsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Analytics/GdsAnalyticsTests.cs
@@ -4,12 +4,59 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Analytics;
 using AgentMemory.Neo4j.Infrastructure;
+using Neo4j.Driver;
 using NSubstitute;
 
 namespace AgentMemory.Tests.Unit.Analytics;
 
 public sealed class GdsAnalyticsTests
 {
+    // ── GdsAvailability: definitive vs transient probe caching ───────────────
+
+    [Fact]
+    public async Task GdsAvailability_TransientProbeFailure_IsNotCached_AndReprobes()
+    {
+        var tx = Substitute.For<INeo4jTransactionRunner>();
+        var calls = 0;
+        tx.ReadAsync(Arg.Any<Func<IAsyncQueryRunner, Task<string>>>(), Arg.Any<CancellationToken>())
+          .Returns(_ => ++calls == 1
+              ? throw new ServiceUnavailableException("connection blip")
+              : Task.FromResult("2.5.0"));
+        var sut = new GdsAvailability(tx, NullLogger<GdsAvailability>.Instance);
+
+        (await sut.IsAvailableAsync()).Should().BeFalse("a transient probe failure degrades to unavailable");
+        (await sut.IsAvailableAsync()).Should().BeTrue("the transient failure was not cached, so it re-probes and recovers");
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GdsAvailability_NotInstalled_IsCached_AfterOneProbe()
+    {
+        var tx = Substitute.For<INeo4jTransactionRunner>();
+        var calls = 0;
+        tx.ReadAsync(Arg.Any<Func<IAsyncQueryRunner, Task<string>>>(), Arg.Any<CancellationToken>())
+          .Returns<Task<string>>(_ => { calls++; throw new ClientException("Unknown function 'gds.version'"); });
+        var sut = new GdsAvailability(tx, NullLogger<GdsAvailability>.Instance);
+
+        (await sut.IsAvailableAsync()).Should().BeFalse();
+        (await sut.IsAvailableAsync()).Should().BeFalse();
+        calls.Should().Be(1, "a genuine not-installed result is a stable answer and is memoized");
+    }
+
+    [Fact]
+    public async Task GdsAvailability_Available_IsCached_AndReturnsTrue()
+    {
+        var tx = Substitute.For<INeo4jTransactionRunner>();
+        var calls = 0;
+        tx.ReadAsync(Arg.Any<Func<IAsyncQueryRunner, Task<string>>>(), Arg.Any<CancellationToken>())
+          .Returns(_ => { calls++; return Task.FromResult("2.5.0"); });
+        var sut = new GdsAvailability(tx, NullLogger<GdsAvailability>.Instance);
+
+        (await sut.IsAvailableAsync()).Should().BeTrue();
+        (await sut.IsAvailableAsync()).Should().BeTrue();
+        calls.Should().Be(1, "a present result is memoized for the process lifetime");
+    }
+
     // ── Projection Cypher shape (owner isolation) ────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
**Round 4 hunt finding — LOW.** `GdsAvailability.ProbeAsync` logged only `ex.GetType().Name` (dropping the message/inner/stack) and a broad `catch` memoized `false` for the entire process lifetime. A transient Neo4j blip on the first `IsAvailableAsync` call therefore **permanently** disabled PageRank/community analytics — empty results even after Neo4j+GDS recover — with an undiagnosable one-line warning.

## Fix
- The probe distinguishes a **definitive** answer (GDS present, or a `ClientException` on `RETURN gds.version()` = genuinely not installed) from a **transient** failure (connectivity/timeout/transaction).
- Only definitive answers are memoized; a transient failure degrades to unavailable for that call but is re-probed on the next call.
- The exception object is now passed to `LogWarning` so operators can distinguish "not installed" from "transient blip".
- Simplified the memoization to be robust whether the probe completes synchronously or asynchronously (no in-flight-task clobber).

## Verification
- `GdsAnalyticsTests`: 10/10 green (incl. transient-not-cached/re-probe, not-installed-cached, available-cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)