### PR TITLE
fix(core): correct as-of recall total, backfill update count, and recall docs

### DIFF
--- a/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
@@ -18,7 +18,11 @@ public interface IMemoryMaintenance
     /// currently have a null embedding. Processes in batches of <paramref name="batchSize"/>.
     /// Supported labels: <c>Entity</c>, <c>Fact</c>, <c>Preference</c>.
     /// </summary>
-    /// <returns>Total number of nodes updated.</returns>
+    /// <returns>
+    /// The number of nodes actually updated — i.e. for which a non-empty embedding was generated and
+    /// persisted. Nodes whose embedding generation degraded to an empty vector (and were therefore skipped)
+    /// are not counted.
+    /// </returns>
     Task<int> GenerateEmbeddingsBatchAsync(
         string nodeLabel,
         int batchSize = 100,

--- a/src/AgentMemory.Abstractions/Services/IMemoryRecall.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryRecall.cs
@@ -16,10 +16,10 @@ public interface IMemoryRecall
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Recalls memory context as it existed at a specific point in time (single-clock).
-    /// Only entities, facts, and preferences that were created on or before <paramref name="asOf"/>
-    /// and had not been invalidated by that time are included. Equivalent to the bitemporal overload
-    /// with both clocks equal to <paramref name="asOf"/>.
+    /// Recalls memory context as it existed at a specific point in time (single-clock). Returns the recent
+    /// messages, entities, facts, preferences, and similar reasoning traces that existed at
+    /// <paramref name="asOf"/> — i.e. created on or before it and not yet invalidated by that time.
+    /// Equivalent to the bitemporal overload with both clocks equal to <paramref name="asOf"/>.
     /// </summary>
     Task<RecallResult> RecallAsOfAsync(
         RecallRequest request,

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -138,10 +138,14 @@ public sealed class MemoryService : IMemoryService
             request.SessionId, validAsOf, systemAsOf);
         var context = await _assembler.AssembleContextAsOfAsync(request, validAsOf, systemAsOf, cancellationToken);
 
+        // Count every populated section so TotalItemsRetrieved matches the documented "across all sections"
+        // contract and the live RecallAsync path. SimilarTraces is populated on the as-of path too, so it
+        // must be included (RelevantMessages is intentionally Empty here — see the assembler's as-of path).
         int totalItems = context.RecentMessages.Items.Count
             + context.RelevantEntities.Items.Count
             + context.RelevantPreferences.Items.Count
-            + context.RelevantFacts.Items.Count;
+            + context.RelevantFacts.Items.Count
+            + context.SimilarTraces.Items.Count;
 
         return new RecallResult
         {
@@ -304,8 +308,9 @@ public sealed class MemoryService : IMemoryService
             {
                 var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, ct);
                 await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, ct);
-                total++;
-                if (embedding.Length > 0) embeddedThisPage++;
+                // Count only nodes actually updated: the repo skips persisting an empty (degraded) embedding,
+                // so a skipped node must not inflate the "nodes updated" return value.
+                if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
 
             if (StalledOnPage(page.Items.Count, embeddedThisPage, "Entity")) break;
@@ -327,8 +332,8 @@ public sealed class MemoryService : IMemoryService
             {
                 var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, ct);
                 await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, ct);
-                total++;
-                if (embedding.Length > 0) embeddedThisPage++;
+                // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
+                if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
 
             if (StalledOnPage(page.Items.Count, embeddedThisPage, "Fact")) break;
@@ -350,8 +355,8 @@ public sealed class MemoryService : IMemoryService
             {
                 var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, ct);
                 await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, ct);
-                total++;
-                if (embedding.Length > 0) embeddedThisPage++;
+                // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
+                if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
 
             if (StalledOnPage(page.Items.Count, embeddedThisPage, "Preference")) break;

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
@@ -229,7 +229,8 @@ public sealed class MemoryServiceBatchTests
         var sut = CreateSut();
         var count = await sut.GenerateEmbeddingsBatchAsync("Entity", batchSize: 100);
 
-        count.Should().Be(1, "the single stalled page is processed once, then the back-fill stops");
+        count.Should().Be(0, "the stalled page's node had an empty (degraded) embedding that was not persisted, " +
+            "so it is not counted as updated — and the back-fill then stops");
         await _entityRepo.Received(1).GetPageWithoutEmbeddingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/AgentMemory.Tests.Unit/Services/TemporalRecallTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/TemporalRecallTests.cs
@@ -95,6 +95,14 @@ public sealed class TemporalRecallTests
             RelevantPreferences = new MemoryContextSection<Preference>
             {
                 Items = new[] { CreatePreference("pref-1") }
+            },
+            // SimilarTraces is populated on the as-of path too, so it must be counted in the total.
+            SimilarTraces = new MemoryContextSection<ReasoningTrace>
+            {
+                Items = new[]
+                {
+                    new ReasoningTrace { TraceId = "trace-1", SessionId = "session-1", Task = "t", StartedAtUtc = _fixedTime }
+                }
             }
         };
 
@@ -106,7 +114,7 @@ public sealed class TemporalRecallTests
         var result = await sut.RecallAsOfAsync(
             new RecallRequest { SessionId = "session-1", Query = "test" }, asOf);
 
-        result.TotalItemsRetrieved.Should().Be(5); // 1 + 2 + 1 + 1
+        result.TotalItemsRetrieved.Should().Be(6); // 1 msg + 2 entities + 1 fact + 1 pref + 1 trace
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Three accuracy fixes from the Round 4 hunt (all LOW), bundled as one themed PR.

1. **`RecallAsOfAsync` under-counts** — `TotalItemsRetrieved` on the as-of path omitted `context.SimilarTraces.Items.Count`, so it under-reported whenever similar reasoning traces were returned, contradicting `RecallResult`'s documented "across all sections" and the live `RecallAsync` path. Added the term.
2. **`GenerateEmbeddingsBatchAsync` over-counts** — the `<returns>` documents "nodes updated", but the loop counted every node *processed*. The repos deliberately skip persisting an empty/degraded embedding, so a failing run returned a positive count when **zero** nodes were written. Now counts only persisted updates (using the existing `embedding.Length > 0` condition).
3. **Doc accuracy** — `IMemoryRecall.RecallAsOfAsync` said "only entities, facts, and preferences", but the as-of path also returns recent messages and similar reasoning traces; reworded to list all returned sections. `IMemoryMaintenance.GenerateEmbeddingsBatchAsync` return doc clarified to "nodes actually updated".

## Verification
- `MemoryServiceBatchTests` + `TemporalRecallTests`: 19/19 green (as-of total now `6` incl. a trace; the persistent-failure backfill test now asserts `0` updated — the skipped node is no longer counted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)