### PR TITLE
fix(core): tolerate a vanished dedup target in MarkDeduplicated

### DIFF
--- a/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
@@ -20,8 +20,12 @@ public interface IFactRepository
         string subject, string predicate, float[] embedding, string? ownerId, double threshold,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Reinforces an existing fact reached by dedup: sets its confidence and returns it.</summary>
-    Task<Fact> MarkDeduplicatedAsync(string factId, double confidence, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Reinforces an existing fact reached by dedup: sets its confidence and returns it. Returns <c>null</c>
+    /// if no fact with that id still exists (it may have been concurrently hard-deleted between the duplicate
+    /// lookup and this call) — the caller should then create the new node instead.
+    /// </summary>
+    Task<Fact?> MarkDeduplicatedAsync(string factId, double confidence, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a fact by identifier. Deliberately unscoped (R1): the id is itself an already-owned handle,

--- a/src/AgentMemory.Abstractions/Repositories/IPreferenceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IPreferenceRepository.cs
@@ -20,8 +20,12 @@ public interface IPreferenceRepository
         string category, float[] embedding, string? ownerId, double threshold,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Reinforces an existing preference reached by dedup: sets its confidence and returns it.</summary>
-    Task<Preference> MarkDeduplicatedAsync(string preferenceId, double confidence, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Reinforces an existing preference reached by dedup: sets its confidence and returns it. Returns
+    /// <c>null</c> if no preference with that id still exists (it may have been concurrently hard-deleted
+    /// between the duplicate lookup and this call) — the caller should then create the new node instead.
+    /// </summary>
+    Task<Preference?> MarkDeduplicatedAsync(string preferenceId, double confidence, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a preference by identifier. Deliberately unscoped (R1): the id is itself an already-owned

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -152,9 +152,16 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
             if (dup is not null)
             {
                 var reinforced = BumpConfidence(dup.Confidence, preference.Confidence);
-                _logger.LogDebug("Deduplicated preference in '{Category}' onto {Id} (confidence→{C}).",
-                    preference.Category, dup.PreferenceId, reinforced);
-                return await _prefRepo.MarkDeduplicatedAsync(dup.PreferenceId, reinforced, cancellationToken);
+                var marked = await _prefRepo.MarkDeduplicatedAsync(dup.PreferenceId, reinforced, cancellationToken);
+                if (marked is not null)
+                {
+                    _logger.LogDebug("Deduplicated preference in '{Category}' onto {Id} (confidence→{C}).",
+                        preference.Category, dup.PreferenceId, reinforced);
+                    return marked;
+                }
+                // The duplicate was concurrently hard-deleted between find and reinforce — fall through and
+                // create the new node instead of failing the add.
+                _logger.LogDebug("Dedup target preference {Id} vanished before reinforce; creating new node.", dup.PreferenceId);
             }
         }
 
@@ -216,9 +223,16 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
             if (dup is not null)
             {
                 var reinforced = BumpConfidence(dup.Confidence, fact.Confidence);
-                _logger.LogDebug("Deduplicated fact '{S} {P}' onto {Id} (confidence→{C}).",
-                    fact.Subject, fact.Predicate, dup.FactId, reinforced);
-                return await _factRepo.MarkDeduplicatedAsync(dup.FactId, reinforced, cancellationToken);
+                var marked = await _factRepo.MarkDeduplicatedAsync(dup.FactId, reinforced, cancellationToken);
+                if (marked is not null)
+                {
+                    _logger.LogDebug("Deduplicated fact '{S} {P}' onto {Id} (confidence→{C}).",
+                        fact.Subject, fact.Predicate, dup.FactId, reinforced);
+                    return marked;
+                }
+                // The duplicate was concurrently hard-deleted between find and reinforce — fall through and
+                // create the new node instead of failing the add.
+                _logger.LogDebug("Dedup target fact {Id} vanished before reinforce; creating new node.", dup.FactId);
             }
         }
 

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -251,14 +251,17 @@ public sealed class Neo4jFactRepository : IFactRepository
         }, cancellationToken);
     }
 
-    public async Task<Fact> MarkDeduplicatedAsync(string factId, double confidence, CancellationToken cancellationToken = default)
+    public async Task<Fact?> MarkDeduplicatedAsync(string factId, double confidence, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Reinforcing fact {FactId} via dedup (confidence={Confidence}).", factId, confidence);
-        return await _tx.WriteAsync(async runner =>
+        return await _tx.WriteAsync<Fact?>(async runner =>
         {
             var cursor = await runner.RunAsync(FactQueries.MarkDeduplicated, new { id = factId, confidence });
-            var record = await cursor.SingleAsync();
-            var node = record["f"].As<INode>();
+            // 0/1-row read (not SingleAsync): the node can be concurrently hard-deleted between the dedup
+            // lookup and this write (e.g. a destructive decay prune), leaving an empty result.
+            var records = await cursor.ToListAsync();
+            if (records.Count == 0) return null;
+            var node = records[0]["f"].As<INode>();
             return MapToFact(node, ReadEmbedding(node));
         }, cancellationToken);
     }

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
@@ -180,14 +180,17 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         }, cancellationToken);
     }
 
-    public async Task<Preference> MarkDeduplicatedAsync(string preferenceId, double confidence, CancellationToken cancellationToken = default)
+    public async Task<Preference?> MarkDeduplicatedAsync(string preferenceId, double confidence, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Reinforcing preference {Id} via dedup (confidence={Confidence}).", preferenceId, confidence);
-        return await _tx.WriteAsync(async runner =>
+        return await _tx.WriteAsync<Preference?>(async runner =>
         {
             var cursor = await runner.RunAsync(PreferenceQueries.MarkDeduplicated, new { id = preferenceId, confidence });
-            var record = await cursor.SingleAsync();
-            var node = record["p"].As<INode>();
+            // 0/1-row read (not SingleAsync): the node can be concurrently hard-deleted between the dedup
+            // lookup and this write (e.g. a destructive decay prune), leaving an empty result.
+            var records = await cursor.ToListAsync();
+            if (records.Count == 0) return null;
+            var node = records[0]["p"].As<INode>();
             return MapToPreference(node, ReadEmbedding(node));
         }, cancellationToken);
     }

--- a/tests/AgentMemory.Tests.Integration/Repositories/DedupOnCreateIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/DedupOnCreateIntegrationTests.cs
@@ -75,8 +75,27 @@ public class DedupOnCreateIntegrationTests : IAsyncLifetime
 
         var updated = await _facts.MarkDeduplicatedAsync(f.FactId, 0.85);
 
-        updated.Confidence.Should().Be(0.85);
+        updated.Should().NotBeNull("the node still exists, so the reinforce returns it");
+        updated!.Confidence.Should().Be(0.85);
         (await _facts.GetByIdAsync(f.FactId))!.Confidence.Should().Be(0.85);
+    }
+
+    [Fact]
+    public async Task FactMarkDeduplicated_NonexistentId_ReturnsNull_DoesNotThrow()
+    {
+        // The dedup target can be concurrently hard-deleted between find and reinforce; the reinforce must
+        // return null (empty result) rather than throwing, so the caller can fall through to create.
+        var result = await _facts.MarkDeduplicatedAsync($"f-does-not-exist-{Guid.NewGuid():N}", 0.9);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PreferenceMarkDeduplicated_NonexistentId_ReturnsNull_DoesNotThrow()
+    {
+        var result = await _prefs.MarkDeduplicatedAsync($"p-does-not-exist-{Guid.NewGuid():N}", 0.9);
+
+        result.Should().BeNull();
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
@@ -360,6 +360,38 @@ public sealed class LongTermMemoryServiceTests
         result.PreferenceId.Should().Be("p-existing");
     }
 
+    [Fact]
+    public async Task AddFactAsync_WhenDuplicateVanishesBeforeReinforce_FallsThroughToCreate()
+    {
+        // FindDuplicate returns a dup, but the node is concurrently hard-deleted before reinforce, so
+        // MarkDeduplicatedAsync returns null. The add must NOT throw — it falls through to create the node.
+        var existing = CreateFact("f-existing");
+        _factRepo.FindDuplicateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Fact?>(existing));
+        _factRepo.MarkDeduplicatedAsync(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Fact?>(null)); // vanished
+
+        var result = await CreateSut().AddFactAsync(CreateFact("f-new"));
+
+        await _factRepo.Received(1).UpsertAsync(Arg.Is<Fact>(f => f.FactId == "f-new"), Arg.Any<CancellationToken>());
+        result.FactId.Should().Be("f-new");
+    }
+
+    [Fact]
+    public async Task AddPreferenceAsync_WhenDuplicateVanishesBeforeReinforce_FallsThroughToCreate()
+    {
+        var existing = CreatePreference("p-existing");
+        _prefRepo.FindDuplicateAsync(Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Preference?>(existing));
+        _prefRepo.MarkDeduplicatedAsync(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Preference?>(null)); // vanished
+
+        var result = await CreateSut().AddPreferenceAsync(CreatePreference("p-new"));
+
+        await _prefRepo.Received(1).UpsertAsync(Arg.Is<Preference>(p => p.PreferenceId == "p-new"), Arg.Any<CancellationToken>());
+        result.PreferenceId.Should().Be("p-new");
+    }
+
     // ---- MinConfidenceThreshold gating ----
 
     [Fact]


### PR DESCRIPTION
## Summary
**Round 4 hunt finding — LOW (concurrency).** Dedup-on-create in `LongTermMemoryService` is a read-then-write spanning two transactions: `FindDuplicateAsync` (read) returns a near-duplicate's id, then `MarkDeduplicatedAsync` (write) runs `MATCH (n {id}) SET n.confidence RETURN n` followed by `SingleAsync()`. If the node is concurrently **hard-deleted** between the two (a destructive decay prune with `NonDestructive=false`, or consolidation/conflict resolution), the result set is empty and `SingleAsync()` throws `InvalidOperationException` straight out of the public `AddFactAsync`/`AddPreferenceAsync`.

## Fix
- `MarkDeduplicatedAsync` (Fact + Preference) now does a 0/1-row read and returns the node or `null` (interface return types are now `Fact?` / `Preference?`).
- `LongTermMemoryService` treats a `null` reinforce result as "the duplicate vanished" and **falls through to create** the new node instead of failing the add.

## Verification
- Unit: vanished-dup → falls through to `UpsertAsync` (fact + preference).
- Integration (real Neo4j): `MarkDeduplicated` on a nonexistent id returns `null` and does not throw (fact + preference). `DedupOnCreateIntegrationTests` 7/7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)