### PR TITLE
fix(core): honor ShortTermMemoryOptions.DefaultRecentMessageLimit

### DIFF
--- a/src/AgentMemory.Abstractions/Services/IShortTermMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/IShortTermMemoryService.cs
@@ -32,13 +32,14 @@ public interface IShortTermMemoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets recent messages for a session. The result is capped at the configured
-    /// <c>MaxMessagesPerQuery</c> and ordered newest-first; use it for recall/context, not for
-    /// whole-session operations.
+    /// Gets recent messages for a session, ordered newest-first; use it for recall/context, not for
+    /// whole-session operations. When <paramref name="limit"/> is null the configured
+    /// <c>ShortTermMemoryOptions.DefaultRecentMessageLimit</c> is used. The effective limit is always
+    /// capped at the configured <c>MaxMessagesPerQuery</c>.
     /// </summary>
     Task<IReadOnlyList<Message>> GetRecentMessagesAsync(
         string sessionId,
-        int limit = 10,
+        int? limit = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
@@ -110,10 +110,14 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
     /// <inheritdoc/>
     public async Task<IReadOnlyList<Message>> GetRecentMessagesAsync(
         string sessionId,
-        int limit = 10,
+        int? limit = null,
         CancellationToken cancellationToken = default)
     {
-        var cappedLimit = Math.Min(limit, _options.MaxMessagesPerQuery);
+        // A null limit means "use the configured default"; the effective value is then capped by the
+        // per-query maximum. (A non-nullable `= 10` default could not distinguish "omitted" from "explicitly
+        // 10", which is why DefaultRecentMessageLimit was previously unreadable.)
+        var requested = limit ?? _options.DefaultRecentMessageLimit;
+        var cappedLimit = Math.Min(requested, _options.MaxMessagesPerQuery);
         return await _messageRepo.GetRecentBySessionAsync(sessionId, cappedLimit, cancellationToken);
     }
 

--- a/tests/AgentMemory.Tests.Integration/GraphRag/GraphRagAdapterIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/GraphRag/GraphRagAdapterIntegrationTests.cs
@@ -294,7 +294,7 @@ public class GraphRagAdapterIntegrationTests : IAsyncLifetime
     private MemoryContextAssembler CreateAssemblerWithEmptyMemory(IGraphRagContextSource graphRag)
     {
         var shortTerm = Substitute.For<IShortTermMemoryService>();
-        shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
         shortTerm.SearchMessagesAsync(Arg.Any<string?>(), Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));

--- a/tests/AgentMemory.Tests.Unit/McpServer/ObservationToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/ObservationToolsTests.cs
@@ -33,7 +33,7 @@ public sealed class ObservationToolsTests
     [Fact]
     public async Task MemoryGetObservations_ReturnsEmptyForSessionWithNoMessages()
     {
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Message>());
 
         var result = await ObservationTools.MemoryGetObservations(
@@ -49,7 +49,7 @@ public sealed class ObservationToolsTests
     [Fact]
     public async Task MemoryGetObservations_DoesNotCallCompressorForEmptySession()
     {
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Message>());
 
         await ObservationTools.MemoryGetObservations(
@@ -67,7 +67,7 @@ public sealed class ObservationToolsTests
     public async Task MemoryGetObservations_CallsCompressorWithMessagesAndOptions()
     {
         var messages = new[] { CreateMessage("m1", "Hello"), CreateMessage("m2", "World") };
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(messages);
 
         _compressor.CompressAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ContextCompressionOptions>(), Arg.Any<CancellationToken>())
@@ -93,7 +93,7 @@ public sealed class ObservationToolsTests
     public async Task MemoryGetObservations_ReturnsCompressedResultWithObservations()
     {
         var messages = new[] { CreateMessage("m1", "Hello") };
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(messages);
 
         _compressor.CompressAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ContextCompressionOptions>(), Arg.Any<CancellationToken>())
@@ -124,7 +124,7 @@ public sealed class ObservationToolsTests
     [Fact]
     public async Task MemoryGetObservations_RespectsIncludeFlags()
     {
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Message>());
 
         var result = await ObservationTools.MemoryGetObservations(
@@ -140,7 +140,7 @@ public sealed class ObservationToolsTests
     [Fact]
     public async Task MemoryGetObservations_AllIncludeFlagsTrue_IncludesAllSections()
     {
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Message>());
 
         var result = await ObservationTools.MemoryGetObservations(
@@ -157,7 +157,7 @@ public sealed class ObservationToolsTests
     [Fact]
     public async Task MemoryGetObservations_UsesDefaultSessionIdWhenNoneProvided()
     {
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Message>());
 
         var result = await ObservationTools.MemoryGetObservations(
@@ -176,7 +176,7 @@ public sealed class ObservationToolsTests
     public async Task MemoryGetObservations_IncludesFormattedSummaryWhenCompressed()
     {
         var messages = new[] { CreateMessage("m1", "Test message") };
-        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _shortTermMemory.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(messages);
 
         _compressor.CompressAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ContextCompressionOptions>(), Arg.Any<CancellationToken>())

--- a/tests/AgentMemory.Tests.Unit/Services/AssemblerRankingContextDiWiringTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/AssemblerRankingContextDiWiringTests.cs
@@ -29,7 +29,7 @@ public sealed class AssemblerRankingContextDiWiringTests
         // mocks so the assembler resolves; the embedding orchestrator returns a non-empty vector so the
         // long-term searches actually run.
         var shortTerm = Substitute.For<IShortTermMemoryService>();
-        shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
         var reasoning = Substitute.For<IReasoningMemoryService>();
         reasoning.SearchSimilarTracesAsync(Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
@@ -43,7 +43,7 @@ public sealed class MemoryContextAssemblerTests
     private void SetupEmptyServiceReturns()
     {
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
         _shortTerm
             .SearchMessagesAsync(Arg.Any<string?>(), Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
@@ -153,7 +153,7 @@ public sealed class MemoryContextAssemblerTests
         await _graphRag.DidNotReceive()
             .GetContextAsync(Arg.Any<GraphRagContextRequest>(), Arg.Any<CancellationToken>());
         await _shortTerm.Received(1)
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
         result.GraphRagContext.Should().BeNull();
         result.BlendMode.Should().Be(RetrievalBlendMode.MemoryOnly);
     }
@@ -172,7 +172,7 @@ public sealed class MemoryContextAssemblerTests
         await _embeddingOrchestrator.DidNotReceive()
             .EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _shortTerm.DidNotReceive()
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
         await _longTerm.DidNotReceive()
             .SearchEntitiesAsync(Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
         await _graphRag.Received(1)
@@ -195,7 +195,7 @@ public sealed class MemoryContextAssemblerTests
             CreateRequest(queryEmbedding: new float[1536], blendMode: RetrievalBlendMode.GraphRagThenMemory));
 
         await _shortTerm.Received(1)
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
         await _graphRag.Received(1)
             .GetContextAsync(Arg.Any<GraphRagContextRequest>(), Arg.Any<CancellationToken>());
         result.GraphRagContext.Should().Contain("graph context");
@@ -314,7 +314,7 @@ public sealed class MemoryContextAssemblerTests
         var oldMsg = CreateMessage("old", "1234567890", _fixedTime.AddHours(-1));
         var newMsg = CreateMessage("new", "ABCDEFGHIJ", _fixedTime);
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(new[] { oldMsg, newMsg }));
 
         var options = Options.Create(new MemoryOptions
@@ -343,7 +343,7 @@ public sealed class MemoryContextAssemblerTests
         var oldMsg = CreateMessage("old", "1234567890", _fixedTime.AddHours(-1));
         var newMsg = CreateMessage("new", "ABCDEFGHIJ", _fixedTime);
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(new[] { oldMsg, newMsg }));
 
         var overBudget = await CreateSut(options: Options.Create(new MemoryOptions
@@ -366,7 +366,7 @@ public sealed class MemoryContextAssemblerTests
         var highScoreMsg = CreateMessage("high-score", "AAAAAAAAAA", _fixedTime);
         var lowScoreMsg = CreateMessage("low-score", "BBBBBBBBBB", _fixedTime.AddMinutes(-1));
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(new[] { highScoreMsg, lowScoreMsg }));
 
         var options = Options.Create(new MemoryOptions
@@ -400,7 +400,7 @@ public sealed class MemoryContextAssemblerTests
         var r0 = CreateMessage("R0", "AAAAAAAAAA", _fixedTime);                 // newest, best score (index 0)
         var r1 = CreateMessage("R1", "BBBBBBBBBB", _fixedTime.AddMinutes(-1));  // mid age, worst score (index 1)
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(new[] { r0, r1 }));
 
         var f0 = CreateFact("F0", "S", "P", "OOOO", _fixedTime.AddHours(-1));   // oldest, best score (index 0)
@@ -479,7 +479,7 @@ public sealed class MemoryContextAssemblerTests
             CreateMessage("msg-2", "More content to count chars", _fixedTime.AddMinutes(-1))
         };
         _shortTerm
-            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Message>>(messages));
         var sut = CreateSut();
 

--- a/tests/AgentMemory.Tests.Unit/Services/ShortTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ShortTermMemoryServiceTests.cs
@@ -171,6 +171,21 @@ public sealed class ShortTermMemoryServiceTests
     }
 
     [Fact]
+    public async Task GetRecentMessagesAsync_NullLimit_UsesConfiguredDefault()
+    {
+        _messageRepo
+            .GetRecentBySessionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        var sut = CreateSut(Options.Create(new ShortTermMemoryOptions { DefaultRecentMessageLimit = 25, MaxMessagesPerQuery = 100 }));
+
+        await sut.GetRecentMessagesAsync("session-1"); // no explicit limit
+
+        await _messageRepo
+            .Received(1)
+            .GetRecentBySessionAsync("session-1", 25, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GetRecentMessagesAsync_CapsAtMaxMessagesPerQuery()
     {
         const int maxPerQuery = 50;


### PR DESCRIPTION
## Summary
**Round 4 dead-config-option (LOW) — wired.** `ShortTermMemoryService.GetRecentMessagesAsync` hardcoded a `limit = 10` parameter default and only read `MaxMessagesPerQuery`, so the documented `DefaultRecentMessageLimit` was read nowhere — a caller who set it and called without an explicit limit still got 10.

## Fix
The `limit` parameter is now `int? limit = null`; `null` resolves to `_options.DefaultRecentMessageLimit`, then capped by `MaxMessagesPerQuery`. A non-nullable `= 10` default could not distinguish "omitted" from "explicitly 10", which is exactly why the option was unreadable. Interface signature + doc updated; mock matchers for the now-nullable parameter updated across the affected tests.

Decision: **wire** (a configurable default page size is a legitimate knob).

## Verification
- Affected unit tests 46/46 green (new test: a null limit uses the configured default, capped by max). Integration project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)