### PR TITLE
fix(mcp): report McpServerOptions.ServerName/ServerVersion to MCP clients

### DIFF
--- a/src/AgentMemory.McpServer/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.McpServer/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using AgentMemory.McpServer.Prompts;
 using AgentMemory.McpServer.Resources;
@@ -17,6 +19,17 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IMcpServerBuilder AddAgentMemoryMcpTools(this IMcpServerBuilder builder)
     {
+        // Project the configured ServerName/ServerVersion into the MCP handshake's server identity. Runs
+        // after AddMcpServer()'s defaults, so a configured McpServerOptions wins. (Uses our McpServerOptions,
+        // resolved by IOptions, to set the SDK's McpServerOptions.ServerInfo.)
+        builder.Services
+            .AddOptions<ModelContextProtocol.Server.McpServerOptions>()
+            .Configure<IOptions<McpServerOptions>>((sdk, ours) =>
+            {
+                var o = ours.Value;
+                sdk.ServerInfo = new Implementation { Name = o.ServerName, Version = o.ServerVersion };
+            });
+
         return builder
             .WithTools<CoreMemoryTools>()
             .WithTools<ConversationTools>()

--- a/tests/AgentMemory.Tests.Unit/McpServer/McpServerOptionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/McpServerOptionsTests.cs
@@ -1,10 +1,32 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
 using AgentMemory.McpServer;
+using McpServerOptions = AgentMemory.McpServer.McpServerOptions;
 
 namespace AgentMemory.Tests.Unit.McpServer;
 
 public sealed class McpServerOptionsTests
 {
+    [Fact]
+    public void AddAgentMemoryMcpTools_ProjectsServerNameAndVersion_IntoMcpServerInfo()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer().AddAgentMemoryMcpTools(o =>
+        {
+            o.ServerName = "custom-mem";
+            o.ServerVersion = "9.9.9";
+        });
+
+        using var sp = services.BuildServiceProvider();
+        var sdkOptions = sp.GetRequiredService<IOptions<ModelContextProtocol.Server.McpServerOptions>>().Value;
+
+        sdkOptions.ServerInfo.Should().NotBeNull("ServerName/ServerVersion must be reported to MCP clients");
+        sdkOptions.ServerInfo!.Name.Should().Be("custom-mem");
+        sdkOptions.ServerInfo.Version.Should().Be("9.9.9");
+    }
+
     [Fact]
     public void DefaultServerName_IsNeo4jAgentMemory()
     {


### PR DESCRIPTION
## Summary
**Round 4 dead-config-option (LOW) — wired.** `McpServerOptions.ServerName` / `ServerVersion` were documented as "reported to MCP clients" but read nowhere, so the MCP `initialize` handshake advertised the SDK's default identity regardless of configuration.

## Fix
`AddAgentMemoryMcpTools` now projects the configured `ServerName`/`ServerVersion` into the SDK's `ModelContextProtocol.Server.McpServerOptions.ServerInfo` (`Implementation { Name, Version }`). Wired in the base overload (registered via `AddOptions<...>().Configure<IOptions<McpServerOptions>>(...)`) so it applies regardless of which `AddAgentMemoryMcpTools` overload the host calls, and runs after `AddMcpServer()`'s defaults so a configured value wins.

Decision: **wire** (custom MCP server identity is a standard, legitimate feature).

## Verification
- `McpServerOptionsTests` 7/7 green (new DI test: configuring ServerName/ServerVersion sets the SDK `ServerInfo.Name`/`.Version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)