### PR TITLE
fix(reasoning): honor StoreToolCalls + GenerateTaskEmbeddings

### DIFF
--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -16,6 +16,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
     private readonly IReasoningTraceRepository _traceRepo;
     private readonly IReasoningStepRepository _stepRepo;
     private readonly IToolCallRepository _toolCallRepo;
+    private readonly IEmbeddingOrchestrator _embeddingOrchestrator;
     private readonly IClock _clock;
     private readonly IIdGenerator _idGenerator;
     private readonly ReasoningMemoryOptions _options;
@@ -28,6 +29,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         IReasoningTraceRepository traceRepo,
         IReasoningStepRepository stepRepo,
         IToolCallRepository toolCallRepo,
+        IEmbeddingOrchestrator embeddingOrchestrator,
         IClock clock,
         IIdGenerator idGenerator,
         IOptions<ReasoningMemoryOptions> options,
@@ -37,6 +39,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         _traceRepo = traceRepo;
         _stepRepo = stepRepo;
         _toolCallRepo = toolCallRepo;
+        _embeddingOrchestrator = embeddingOrchestrator;
         _clock = clock;
         _idGenerator = idGenerator;
         _options = options.Value;
@@ -52,13 +55,22 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         string? ownerId = null,
         CancellationToken cancellationToken = default)
     {
+        // Auto-embed the task description so the trace is reachable by SearchSimilarTraces vector recall,
+        // unless the caller already supplied an embedding or auto-embedding is disabled.
+        var effectiveEmbedding = taskEmbedding;
+        if (effectiveEmbedding is null && _options.GenerateTaskEmbeddings && !string.IsNullOrWhiteSpace(task))
+        {
+            _logger.LogDebug("Generating task embedding for new trace in session {SessionId}", sessionId);
+            effectiveEmbedding = await _embeddingOrchestrator.EmbedAsync(task, cancellationToken);
+        }
+
         var trace = new ReasoningTrace
         {
             TraceId = _idGenerator.GenerateId(),
             SessionId = sessionId,
             OwnerId = ownerId,
             Task = task,
-            TaskEmbedding = taskEmbedding,
+            TaskEmbedding = effectiveEmbedding,
             StartedAtUtc = _clock.UtcNow,
             Metadata = metadata ?? new Dictionary<string, object>()
         };
@@ -141,6 +153,13 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
             Error = error,
             Metadata = metadata ?? new Dictionary<string, object>()
         };
+
+        if (!_options.StoreToolCalls)
+        {
+            // Tool-call persistence is disabled — return the (un-persisted) record without writing.
+            _logger.LogDebug("Skipping tool-call persistence for {ToolName} (StoreToolCalls=false).", toolName);
+            return toolCall;
+        }
 
         _logger.LogDebug("Recording tool call {ToolName} for step {StepId}", toolName, stepId);
         return await _toolCallRepo.AddAsync(toolCall, cancellationToken);

--- a/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
@@ -14,6 +14,7 @@ public sealed class ReasoningMemoryServiceTests
     private readonly IReasoningTraceRepository _traceRepo;
     private readonly IReasoningStepRepository _stepRepo;
     private readonly IToolCallRepository _toolCallRepo;
+    private readonly IEmbeddingOrchestrator _embeddingOrchestrator;
     private readonly IClock _clock;
     private readonly IIdGenerator _idGenerator;
     private readonly DateTimeOffset _fixedTime = new(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
@@ -23,11 +24,14 @@ public sealed class ReasoningMemoryServiceTests
         _traceRepo = Substitute.For<IReasoningTraceRepository>();
         _stepRepo = Substitute.For<IReasoningStepRepository>();
         _toolCallRepo = Substitute.For<IToolCallRepository>();
+        _embeddingOrchestrator = Substitute.For<IEmbeddingOrchestrator>();
         _clock = Substitute.For<IClock>();
         _idGenerator = Substitute.For<IIdGenerator>();
 
         _clock.UtcNow.Returns(_fixedTime);
         _idGenerator.GenerateId().Returns("generated-id-1", "generated-id-2", "generated-id-3");
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[8]));
 
         _traceRepo
             .AddAsync(Arg.Any<ReasoningTrace>(), Arg.Any<CancellationToken>())
@@ -47,7 +51,7 @@ public sealed class ReasoningMemoryServiceTests
     }
 
     private ReasoningMemoryService CreateSut(ReasoningMemoryOptions? options = null) =>
-        new(_traceRepo, _stepRepo, _toolCallRepo, _clock, _idGenerator,
+        new(_traceRepo, _stepRepo, _toolCallRepo, _embeddingOrchestrator, _clock, _idGenerator,
             Microsoft.Extensions.Options.Options.Create(options ?? new ReasoningMemoryOptions()),
             NullLogger<ReasoningMemoryService>.Instance);
 
@@ -130,6 +134,64 @@ public sealed class ReasoningMemoryServiceTests
         var result = await sut.StartTraceAsync("session-1", "Test task");
 
         result.SessionId.Should().Be("session-1"); // trace still returned despite prune failure
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_GenerateTaskEmbeddingsEnabled_AutoEmbedsTaskWhenNoneSupplied()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { GenerateTaskEmbeddings = true });
+
+        await sut.StartTraceAsync("session-1", "Summarize the report");
+
+        await _embeddingOrchestrator.Received(1).EmbedAsync("Summarize the report", Arg.Any<CancellationToken>());
+        await _traceRepo.Received(1).AddAsync(
+            Arg.Is<ReasoningTrace>(t => t.TaskEmbedding != null && t.TaskEmbedding.Length == 8), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_GenerateTaskEmbeddingsDisabled_DoesNotEmbed()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { GenerateTaskEmbeddings = false });
+
+        await sut.StartTraceAsync("session-1", "Summarize the report");
+
+        await _embeddingOrchestrator.DidNotReceive().EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _traceRepo.Received(1).AddAsync(
+            Arg.Is<ReasoningTrace>(t => t.TaskEmbedding == null), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartTraceAsync_CallerSuppliedEmbedding_IsNotOverwritten()
+    {
+        var supplied = new float[] { 1f, 2f, 3f };
+        var sut = CreateSut(new ReasoningMemoryOptions { GenerateTaskEmbeddings = true });
+
+        await sut.StartTraceAsync("session-1", "task", taskEmbedding: supplied);
+
+        await _embeddingOrchestrator.DidNotReceive().EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _traceRepo.Received(1).AddAsync(
+            Arg.Is<ReasoningTrace>(t => t.TaskEmbedding == supplied), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordToolCallAsync_StoreToolCallsFalse_DoesNotPersist_ButReturnsRecord()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { StoreToolCalls = false });
+
+        var result = await sut.RecordToolCallAsync("step-1", "search", "{}");
+
+        result.ToolName.Should().Be("search");
+        await _toolCallRepo.DidNotReceive().AddAsync(Arg.Any<ToolCall>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordToolCallAsync_StoreToolCallsTrue_Persists()
+    {
+        var sut = CreateSut(new ReasoningMemoryOptions { StoreToolCalls = true });
+
+        await sut.RecordToolCallAsync("step-1", "search", "{}");
+
+        await _toolCallRepo.Received(1).AddAsync(Arg.Any<ToolCall>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
**Round 4 dead-config-options (MEDIUM) — wired.** Two `ReasoningMemoryOptions` siblings (the third, `MaxTracesPerSession`, was wired in the H fix) were documented + settable but read nowhere:

- **`StoreToolCalls`** (default true) — `RecordToolCallAsync` always persisted; setting it false had no effect. Now it skips the repo write when false and returns the un-persisted `ToolCall`.
- **`GenerateTaskEmbeddings`** (default true, "generate embeddings for task descriptions automatically") — `StartTraceAsync` stored only the caller-supplied embedding (often null), so an MCP-started trace got a NULL `task_embedding` that `SearchSimilarTraces` vector recall could never match. The service now injects `IEmbeddingOrchestrator` and auto-embeds the task text when the option is on and no embedding was supplied. A caller-supplied embedding is never overwritten.

Decision: **wire** (both are legitimate knobs; `GenerateTaskEmbeddings` is recall-affecting). `IEmbeddingOrchestrator` is already DI-registered.

## Verification
- `ReasoningMemoryServiceTests` 26/26 green (auto-embed on/off, caller-embedding wins; StoreToolCalls false skips persistence but returns the record, true persists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)