### PR TITLE
refactor(options): remove dead duplicate options (EnableEntityResolution, EnableAutoExtraction)

### DIFF
--- a/src/AgentMemory.Abstractions/Options/LongTermMemoryOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/LongTermMemoryOptions.cs
@@ -17,8 +17,9 @@ public sealed record LongTermMemoryOptions
     /// <summary>Minimum confidence threshold for persisting extracted items.</summary>
     public double MinConfidenceThreshold { get; init; } = 0.5;
 
-    /// <summary>Whether to enable entity resolution and deduplication.</summary>
-    public bool EnableEntityResolution { get; init; } = true;
+    // NOTE: extraction-time entity resolution is configured by
+    // ExtractionOptions.EntityResolution.Enable{Exact,Fuzzy,Semantic}Match (which the resolver honors).
+    // The former EnableEntityResolution flag here was a duplicate that nothing read, so it was removed.
 
     /// <summary>
     /// When true, <c>AddFactAsync</c>/<c>AddPreferenceAsync</c> reinforce an existing near-duplicate

--- a/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
@@ -23,8 +23,10 @@ public sealed record MemoryOptions
     /// <summary>Whether to enable GraphRAG integration.</summary>
     public bool EnableGraphRag { get; init; }
 
-    /// <summary>Whether to enable automatic extraction after message save.</summary>
-    public bool EnableAutoExtraction { get; init; } = true;
+    // NOTE: extraction at the Core layer is explicit (call ExtractAndPersistAsync /
+    // ExtractFromSessionAsync). Automatic extraction on message persist is an adapter concern, configured
+    // by AgentFrameworkOptions.AutoExtractOnPersist. The former EnableAutoExtraction flag here was read
+    // nowhere (Core AddMessageAsync never auto-extracted), so it was removed.
 
     /// <summary>Extraction pipeline configuration.</summary>
     public ExtractionOptions Extraction { get; init; } = new();

--- a/tests/AgentMemory.Tests.Unit/Options/ConfigurationValidationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Options/ConfigurationValidationTests.cs
@@ -31,12 +31,6 @@ public sealed class ConfigurationValidationTests
     }
 
     [Fact]
-    public void MemoryOptions_Default_EnableAutoExtractionIsTrue()
-    {
-        new MemoryOptions().EnableAutoExtraction.Should().BeTrue();
-    }
-
-    [Fact]
     public void MemoryOptions_Default_EnableGraphRagIsFalse()
     {
         new MemoryOptions().EnableGraphRag.Should().BeFalse();
@@ -121,12 +115,6 @@ public sealed class ConfigurationValidationTests
     {
         var o = new LongTermMemoryOptions();
         o.MinConfidenceThreshold.Should().BeGreaterThanOrEqualTo(0.0).And.BeLessThanOrEqualTo(1.0);
-    }
-
-    [Fact]
-    public void LongTermMemoryOptions_Default_EnableEntityResolutionIsTrue()
-    {
-        new LongTermMemoryOptions().EnableEntityResolution.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Options/LongTermMemoryOptionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Options/LongTermMemoryOptionsTests.cs
@@ -27,13 +27,6 @@ public class LongTermMemoryOptionsTests
     }
 
     [Fact]
-    public void Default_EnableEntityResolutionIsTrue()
-    {
-        var options = new LongTermMemoryOptions();
-        options.EnableEntityResolution.Should().BeTrue();
-    }
-
-    [Fact]
     public void Default_MinConfidenceThresholdIs050()
     {
         var options = new LongTermMemoryOptions();
@@ -47,10 +40,4 @@ public class LongTermMemoryOptionsTests
         options.MinConfidenceThreshold.Should().BeInRange(0.0, 1.0);
     }
 
-    [Fact]
-    public void WithInit_CanDisableEntityResolution()
-    {
-        var options = new LongTermMemoryOptions { EnableEntityResolution = false };
-        options.EnableEntityResolution.Should().BeFalse();
-    }
 }

--- a/tests/AgentMemory.Tests.Unit/Options/MemoryOptionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Options/MemoryOptionsTests.cs
@@ -48,13 +48,6 @@ public class MemoryOptionsTests
     }
 
     [Fact]
-    public void DefaultOptions_EnableAutoExtractionIsTrue()
-    {
-        var options = new MemoryOptions();
-        options.EnableAutoExtraction.Should().BeTrue();
-    }
-
-    [Fact]
     public void DefaultOptions_EnableGraphRagIsFalse()
     {
         var options = new MemoryOptions();
@@ -74,10 +67,4 @@ public class MemoryOptionsTests
         options.EnableGraphRag.Should().BeTrue();
     }
 
-    [Fact]
-    public void WithInit_CanDisableAutoExtraction()
-    {
-        var options = new MemoryOptions { EnableAutoExtraction = false };
-        options.EnableAutoExtraction.Should().BeFalse();
-    }
 }


### PR DESCRIPTION
## Summary
**Round 4 dead-config-options (LOW + MEDIUM) — removed (not wired).** Both were documented + settable but read nowhere, and each duplicates a mechanism that already works at the correct layer — so per the "doesn't make sense → remove" call, they are removed with the docs redirected:

- **`LongTermMemoryOptions.EnableEntityResolution`** — extraction-time resolution is controlled by `ExtractionOptions.EntityResolution.Enable{Exact,Fuzzy,Semantic}Match` (which `CompositeEntityResolver` honors). The top-level flag was a redundant no-op duplicate.
- **`MemoryOptions.EnableAutoExtraction`** — Core extraction is explicit by design (`ExtractAndPersistAsync` / `ExtractFromSessionAsync`); auto-extract-on-persist is an *adapter* concern, wired via `AgentFrameworkOptions.AutoExtractOnPersist`. Core `AddMessageAsync` never auto-extracted, so the flag was a misleading no-op. (Wiring a second auto-extract path into Core would duplicate the adapter and force a heavy pipeline dependency + perf surprise.)

Removed the two properties and their default-value/override unit tests; left a code comment on each options type pointing at the supported switch. (Breaking change, acceptable for a preview package; setting either flag previously did nothing.)

## Verification
- Options/config unit tests 175/175 green; full unit project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)