### PR TITLE
refactor(options): remove dead MemoryDecayOptions.MaxMemoriesPerSession

### DIFF
--- a/src/AgentMemory.Abstractions/Options/MemoryDecayOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/MemoryDecayOptions.cs
@@ -17,10 +17,11 @@ public sealed record MemoryDecayOptions
     /// </summary>
     public double MinRetentionScore { get; init; } = 0.1;
 
-    /// <summary>
-    /// Hard cap on the number of long-term memory nodes per session.
-    /// </summary>
-    public int MaxMemoriesPerSession { get; init; } = 10_000;
+    // NOTE: long-term memory (Entity/Fact/Preference) is cross-session knowledge — those nodes carry an
+    // owner_id, not a session_id — so a "max nodes per session" cap is not meaningful here; pruning is
+    // owner-scoped and retention-score driven (see MinRetentionScore / DecayHalfLifeDays / AccessBoostFactor).
+    // The genuinely session-scoped cap lives on ReasoningMemoryOptions.MaxTracesPerSession. The former
+    // MaxMemoriesPerSession property here was read nowhere and could not be coherently enforced, so it was removed.
 
     /// <summary>
     /// Boost factor applied per access (recall hit) when computing the retention score.

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
@@ -223,7 +223,6 @@ public sealed class MemoryDecayServiceTests
 
         options.DecayHalfLifeDays.Should().Be(30);
         options.MinRetentionScore.Should().Be(0.1);
-        options.MaxMemoriesPerSession.Should().Be(10_000);
         options.AccessBoostFactor.Should().Be(0.2);
         options.EnableAutoPrune.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary
**Round 4 dead-config-option (LOW) — removed (not wired).** `MemoryDecayOptions.MaxMemoriesPerSession` was documented as a "hard cap on the number of long-term memory nodes per session" but read nowhere — **and it can't be coherently enforced**: long-term memory (Entity/Fact/Preference) is *cross-session* knowledge whose nodes carry `owner_id`, not `session_id` (the decay prune scopes by owner, never session). There is no session to cap by.

Pruning is owner-scoped and retention-score driven (`MinRetentionScore` / `DecayHalfLifeDays` / `AccessBoostFactor`). The genuinely session-scoped cap is `ReasoningMemoryOptions.MaxTracesPerSession` (wired in the H fix). So per the "doesn't make sense → remove" call (this is the one where my initial *wire* lean flipped to *remove* once I confirmed LTM nodes have no `session_id`), the property is removed with the docs redirected.

Removed the property + its default-value test assertion; left a code comment explaining the retention model and pointing at the reasoning-trace cap.

## Verification
- `MemoryDecayServiceTests` 18/18 green; unit project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)