### PR TITLE
test(core): fix CS8620 nullable warnings in dedup mock setups

### DIFF
--- a/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
@@ -310,7 +310,7 @@ public sealed class LongTermMemoryServiceTests
         _factRepo.FindDuplicateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Fact?>(existing));
         _factRepo.MarkDeduplicatedAsync(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(existing with { Confidence = ci.ArgAt<double>(1) }));
+            .Returns(ci => Task.FromResult<Fact?>(existing with { Confidence = ci.ArgAt<double>(1) }));
 
         var sut = CreateSut();
         var result = await sut.AddFactAsync(CreateFact("f-new"));
@@ -351,7 +351,7 @@ public sealed class LongTermMemoryServiceTests
         _prefRepo.FindDuplicateAsync(Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Preference?>(existing));
         _prefRepo.MarkDeduplicatedAsync(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(existing with { Confidence = ci.ArgAt<double>(1) }));
+            .Returns(ci => Task.FromResult<Preference?>(existing with { Confidence = ci.ArgAt<double>(1) }));
 
         var result = await CreateSut().AddPreferenceAsync(CreatePreference("p-new"));
 


### PR DESCRIPTION
## Summary
After `MarkDeduplicatedAsync` became `Task<Fact?>` / `Task<Preference?>` (PR #46), two pre-existing dedup mock setups in `LongTermMemoryServiceTests` returned `Task.FromResult(existing with {...})` (`Task<Fact>` / `Task<Preference>`), producing CS8620 nullability-mismatch warnings on every build. Typed the `FromResult` explicitly (`Task.FromResult<Fact?>` / `<Preference?>`) so the unit-test build is warning-clean.

## Verification
- Unit test project builds with **0 warnings, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)