### PR TITLE
fix(neo4j): re-asserting a Fact triple restores it to live recall + lands embedding/provenance

### DIFF
--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -31,7 +31,8 @@ public static class FactQueries
                 f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE f.valid_until END,
                 f.source_message_ids = $sourceMessageIds,
                 f.updated_at         = datetime($updatedAtUtc),
-                f.metadata           = $metadata
+                f.metadata           = $metadata,
+                f.invalidated_at     = null
             RETURN f";
 
     // ── UpsertBatchAsync ───────────────────────────────────────────────

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -70,13 +70,19 @@ public sealed class Neo4jFactRepository : IFactRepository
             var record = await cursor.SingleAsync();
             var node = record["f"].As<INode>();
 
+            // The MERGE is on the {subject,predicate,object,owner_key} triple and ON MATCH deliberately never
+            // rewrites f.id, so a re-extracted triple keeps its ORIGINAL node id while fact.FactId is a now-
+            // orphaned guid. The follow-up by-id sub-writes MUST target the surviving node, not the discarded
+            // caller id — otherwise on re-extraction they MATCH nothing and the embedding/provenance is lost.
+            var mergedId = node["id"].As<string>();
+
             // Only persist a real (non-empty) vector so a degraded empty embedding leaves `embedding`
             // NULL and re-queueable for the back-fill (mirrors the entity/preference repos).
             if (fact.Embedding is { Length: > 0 })
             {
                 await runner.RunAsync(
                     SharedFragments.SetFactEmbedding,
-                    new { id = fact.FactId, embedding = fact.Embedding.ToList() });
+                    new { id = mergedId, embedding = fact.Embedding.ToList() });
             }
 
             // Auto-create EXTRACTED_FROM relationships for all source messages
@@ -84,7 +90,7 @@ public sealed class Neo4jFactRepository : IFactRepository
             {
                 await runner.RunAsync(
                     SharedFragments.LinkFactExtractedFrom,
-                    new { id = fact.FactId, sourceMessageIds = fact.SourceMessageIds.ToList() });
+                    new { id = mergedId, sourceMessageIds = fact.SourceMessageIds.ToList() });
             }
 
             return MapToFact(node, fact.Embedding);

--- a/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
@@ -105,6 +105,68 @@ public class FactRepositoryIntegrationTests : IAsyncLifetime
         });
 
     [Fact]
+    public async Task UpsertAsync_ReAssertSupersededTriple_RestoresToLiveRecall_KeepsValidUntil()
+    {
+        // R5 HIGH: re-asserting a previously superseded triple is a present-time positive assertion; it must
+        // become visible to live recall again. Before the fix, the triple-MERGE re-matched the dead node but
+        // ON MATCH never cleared invalidated_at, so the fact stayed permanently invisible (write vanished).
+        var idA = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idA, Subject = "Alice", Predicate = "lives_in", Object = "Paris", Confidence = 0.9, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow });
+        var idB = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idB, Subject = "Alice", Predicate = "lives_in", Object = "London", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        (await _repo.SupersedeAsync(idA, idB, scope: null)).Should().BeTrue();
+        (await _repo.SearchByVectorAsync(QueryEmbedding, limit: 5)).Select(r => r.Fact.FactId)
+            .Should().NotContain(idA, "a superseded fact is invisible to live recall");
+
+        // Re-assert the SAME triple (fresh id, no explicit ValidUntil) WITH an embedding.
+        await _repo.UpsertAsync(new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = "Alice", Predicate = "lives_in", Object = "Paris", Confidence = 0.95, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        (await _repo.SearchByVectorAsync(QueryEmbedding, limit: 5)).Select(r => r.Fact.FactId)
+            .Should().Contain(idA, "re-asserting the triple must clear invalidated_at and restore the fact to live recall");
+        (await HasValidUntilAsync(idA)).Should().BeTrue(
+            "the fix clears only the transaction clock (invalidated_at); the valid-time clock (valid_until) stays as supersession stamped it");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ReExtractSameTriple_WritesEmbeddingAndProvenance_OnMergedNodeId()
+    {
+        // R5 MED: the triple-MERGE keeps the original node id, but the embedding + EXTRACTED_FROM sub-writes
+        // were keyed on the discarded caller id, so on re-extraction they targeted a non-existent node and
+        // the new embedding/provenance was silently lost. They must follow the merged node id.
+        var convRepo = new Neo4jConversationRepository(_fixture.TransactionRunner, NullLogger<Neo4jConversationRepository>.Instance);
+        var msgRepo = new Neo4jMessageRepository(_fixture.TransactionRunner, NullLogger<Neo4jMessageRepository>.Instance);
+        var conv = new Conversation { ConversationId = $"conv-{Guid.NewGuid():N}", SessionId = $"session-{Guid.NewGuid():N}", CreatedAtUtc = DateTimeOffset.UtcNow, UpdatedAtUtc = DateTimeOffset.UtcNow };
+        await convRepo.UpsertAsync(conv);
+        var msg = new Message { MessageId = $"msg-{Guid.NewGuid():N}", ConversationId = conv.ConversationId, SessionId = conv.SessionId, Role = "user", Content = "src", TimestampUtc = DateTimeOffset.UtcNow };
+        await msgRepo.AddAsync(msg);
+
+        // First extraction: degraded (no embedding, no sources).
+        var idA = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idA, Subject = "Alice", Predicate = "works_at", Object = "Acme", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        // Re-extraction of the SAME triple (fresh id) now carrying a real embedding + a source message.
+        var idB = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idB, Subject = "Alice", Predicate = "works_at", Object = "Acme", Confidence = 0.95, Embedding = TestEmbedding, SourceMessageIds = [msg.MessageId], CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        // Embedding landed on the surviving node (idA), so vector search finds it.
+        (await _repo.SearchByVectorAsync(QueryEmbedding, limit: 5)).Select(r => r.Fact.FactId)
+            .Should().Contain(idA, "the re-extracted embedding must be written to the merged node, not the discarded id");
+
+        // Provenance edge was created on the surviving node, not the orphan idB.
+        var edgeCount = await _fixture.TransactionRunner.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(
+                "MATCH (f:Fact {id: $fid})-[:EXTRACTED_FROM]->(m:Message {id: $mid}) RETURN count(*) AS c",
+                new { fid = idA, mid = msg.MessageId });
+            var record = await cursor.SingleAsync();
+            return global::Neo4j.Driver.ValueExtensions.As<long>(record["c"]);
+        });
+        edgeCount.Should().Be(1, "EXTRACTED_FROM provenance must be created on the merged node id");
+        (await _repo.GetByIdAsync(idB)).Should().BeNull("the discarded second id must never become a node");
+    }
+
+    [Fact]
     public async Task GetByIdAsync_ReturnsFact_WhenExists()
     {
         var fact = new Fact

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
@@ -322,7 +322,8 @@ MERGE (f:Fact {subject: $subject, predicate: $predicate, object: $object, owner_
                 f.valid_until        = CASE WHEN $validUntil IS NOT NULL THEN datetime($validUntil) ELSE f.valid_until END,
                 f.source_message_ids = $sourceMessageIds,
                 f.updated_at         = datetime($updatedAtUtc),
-                f.metadata           = $metadata
+                f.metadata           = $metadata,
+                f.invalidated_at     = null
             RETURN f
 
 ## FactQueries.UpsertBatch

--- a/tests/AgentMemory.Tests.Unit/Queries/TemporalAndDecayQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/TemporalAndDecayQueryTests.cs
@@ -20,6 +20,18 @@ public sealed class TemporalQueryTests
         query.Should().Contain(expectedFragment);
     }
 
+    // R5: re-asserting a fact triple (a present-time positive assertion) must clear the transaction clock so
+    // it returns to live recall, while preserving the independent valid-time clock (valid_until).
+    [Fact]
+    public void FactUpsert_OnMatch_ResetsInvalidatedAt_ButPreservesValidUntil()
+    {
+        var onMatch = FactQueries.Upsert[FactQueries.Upsert.IndexOf("ON MATCH SET", StringComparison.Ordinal)..];
+        onMatch.Should().Contain("f.invalidated_at     = null",
+            "re-asserting a triple must clear invalidated_at so the fact is visible to live recall again");
+        onMatch.Should().Contain("ELSE f.valid_until END",
+            "the valid-time clock must be preserved on a bare re-assert (only the transaction clock is reset)");
+    }
+
     // The scoped vector AsOf searches are now methods (IC5): they over-fetch + filter by owner.
     // They are bitemporal (D6): the transaction clock binds created_at/invalidated_at via $systemAsOf.
     [Fact]


### PR DESCRIPTION
## Summary
**Round 5 — two facets of the `Fact` triple-MERGE hazard family, fixed together** (the root-cause analysis flagged that these must land together or the next round re-finds the third; the third — single-vs-batch MERGE-key divergence, LOW, no production caller — follows in its own carefully-isolated PR).

### HIGH — re-asserting a superseded/invalidated triple silently vanished
`FactQueries.Upsert` MERGEs on `{subject,predicate,object,owner_key}`; its `ON MATCH SET` updated everything **except `invalidated_at`**, and no code path anywhere reset it. So re-asserting a previously invalidated/superseded triple (a normal "restate a corrected fact" flow) re-matched the **dead** node and left it `invalidated_at`-stamped — invisible to every live recall path, with a success-shaped return and no recovery. Unique to Facts (Entity/Preference MERGE on `id`, so a fresh id yields a fresh live node).

**Fix:** `ON MATCH SET f.invalidated_at = null` — a present-time positive assertion resets the *transaction* clock. The *valid-time* clock (`valid_until`) is deliberately preserved (its existing CASE), so the intentional `UpsertAsync_ReUpsertSupersededTriple_DoesNotClearValidUntil` guarantee still holds.

### MEDIUM — re-extracted embedding + provenance silently lost
The triple-MERGE keeps the original node id, but `UpsertAsync`'s by-id sub-writes (`SetFactEmbedding`, `LinkFactExtractedFrom`) were keyed on the **discarded caller id**, so on re-extraction they `MATCH` nothing and no-op (worst case: a degraded-NULL first embedding never receives the real vector → permanently unsearchable). **Fix:** key both sub-writes on the merged node id `node["id"]`, mirroring the batch path.

## Process note (per the root-cause findings)
Both tests **target the trigger, not the happy path** — the prior tests hid these by re-asserting *without* an embedding/sources. Cypher snapshot regenerated (count unchanged, 142).

## Verification
- Unit: `ON MATCH` resets `invalidated_at` + preserves `valid_until`; snapshot green.
- Integration (real Neo4j): re-assert after supersede returns the fact to live recall **and** keeps `valid_until`; re-extract writes embedding + `EXTRACTED_FROM` on the merged id (not the orphan id). `FactRepository`/`DedupOnCreate`/`Supersession` suites 38/38 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)