### PR TITLE
fix(neo4j): make the empty-embedding guard a search-boundary invariant

### DIFF
--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -144,7 +144,11 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
 
         // Dedup-on-create: reinforce an existing same-category, same-owner near-duplicate instead of
         // creating a new node (preferences MERGE on id, so every add would otherwise be a fresh node).
-        if (_options.DeduplicateOnCreate && embedding is not null)
+        // Length-check (not just non-null): EmbeddingOrchestrator degrades a generation failure to an EMPTY
+        // (zero-dimension) vector, which would otherwise be handed to db.index.vector.queryNodes and throw a
+        // dimension mismatch — aborting the whole add. An empty embedding has no semantic signal, so skip
+        // dedup and fall through to a plain create (the node persists with a NULL, re-queueable embedding).
+        if (_options.DeduplicateOnCreate && embedding is { Length: > 0 })
         {
             var dup = await _prefRepo.FindDuplicateAsync(
                 preference.Category, embedding, preference.OwnerId,
@@ -215,7 +219,11 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         // Dedup-on-create: reinforce an existing same-subject+predicate, same-owner near-duplicate
         // (e.g. the same fact phrased differently across sessions) instead of creating a new node.
         // Exact triples already collapse via the owner_key MERGE; this catches the near-duplicate case.
-        if (_options.DeduplicateOnCreate && embedding is not null)
+        // Length-check (not just non-null): EmbeddingOrchestrator degrades a generation failure to an EMPTY
+        // (zero-dimension) vector, which would otherwise be handed to db.index.vector.queryNodes and throw a
+        // dimension mismatch — aborting the whole add. An empty embedding has no semantic signal, so skip
+        // dedup and fall through to a plain create (the node persists with a NULL, re-queueable embedding).
+        if (_options.DeduplicateOnCreate && embedding is { Length: > 0 })
         {
             var dup = await _factRepo.FindDuplicateAsync(
                 fact.Subject, fact.Predicate, embedding, fact.OwnerId,

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -152,6 +152,9 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding has no semantic signal and
+        // would throw a dimension mismatch at db.index.vector.queryNodes — short-circuit to an empty result.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Entity, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * OwnerOverFetchFactor, limit + OwnerOverFetchFloor) : limit;
@@ -694,6 +697,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding short-circuits to empty.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Entity, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * Neo4jFactRepository.OwnerOverFetchFactor, limit + Neo4jFactRepository.OwnerOverFetchFloor) : limit;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -193,6 +193,9 @@ public sealed class Neo4jFactRepository : IFactRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding has no semantic signal and
+        // would throw a dimension mismatch at db.index.vector.queryNodes — short-circuit to an empty result.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Fact, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * OwnerOverFetchFactor, limit + OwnerOverFetchFloor) : limit;
@@ -231,6 +234,9 @@ public sealed class Neo4jFactRepository : IFactRepository
         string subject, string predicate, float[] embedding, string? ownerId, double threshold,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) embedding can't address the vector index;
+        // there is no duplicate to find, so short-circuit (caller then creates a new node).
+        if (embedding is not { Length: > 0 }) return null;
         var cypher = FactQueries.FindDuplicate(DedupOverFetch);
         var parameters = new Dictionary<string, object?>
         {
@@ -456,6 +462,8 @@ public sealed class Neo4jFactRepository : IFactRepository
         DateTimeOffset? systemAsOf = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding short-circuits to empty.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Fact, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * OwnerOverFetchFactor, limit + OwnerOverFetchFloor) : limit;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
@@ -202,6 +202,9 @@ public sealed class Neo4jMessageRepository : IMessageRepository
         Dictionary<string, object>? metadataFilters = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding has no semantic signal and
+        // would throw a dimension mismatch at db.index.vector.queryNodes — short-circuit to an empty result.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Message, double)>();
         _logger.LogDebug("Vector search messages, sessionId={SessionId}, limit={Limit}", sessionId, limit);
 
         var (filterClause, filterParams) = MetadataFilterBuilder.Build(metadataFilters, nodeAlias: "node");

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
@@ -124,6 +124,9 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding has no semantic signal and
+        // would throw a dimension mismatch at db.index.vector.queryNodes — short-circuit to an empty result.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Preference, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * OwnerOverFetchFactor, limit + OwnerOverFetchFloor) : limit;
@@ -160,6 +163,9 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         string category, float[] embedding, string? ownerId, double threshold,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) embedding can't address the vector index;
+        // there is no duplicate to find, so short-circuit (caller then creates a new node).
+        if (embedding is not { Length: > 0 }) return null;
         bool ownerIsShared = string.IsNullOrEmpty(ownerId);
         var cypher = PreferenceQueries.FindDuplicate(DedupOverFetch, ownerIsShared);
         var parameters = new Dictionary<string, object?>
@@ -356,6 +362,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) query embedding short-circuits to empty.
+        if (queryEmbedding is not { Length: > 0 }) return Array.Empty<(Preference, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner ? Math.Max(limit * Neo4jFactRepository.OwnerOverFetchFactor, limit + Neo4jFactRepository.OwnerOverFetchFloor) : limit;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -111,6 +111,9 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) task embedding has no semantic signal and
+        // would throw a dimension mismatch at db.index.vector.queryNodes — short-circuit to an empty result.
+        if (taskEmbedding is not { Length: > 0 }) return Array.Empty<(ReasoningTrace, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner
@@ -153,6 +156,8 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
+        // Boundary invariant: a zero-dimension (empty/degraded) task embedding short-circuits to empty.
+        if (taskEmbedding is not { Length: > 0 }) return Array.Empty<(ReasoningTrace, double)>();
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         int topK = hasOwner

--- a/tests/AgentMemory.Tests.Unit/Repositories/VectorSearchBoundaryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Repositories/VectorSearchBoundaryTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Neo4j.Infrastructure;
+using AgentMemory.Neo4j.Repositories;
+using NSubstitute;
+
+namespace AgentMemory.Tests.Unit.Repositories;
+
+/// <summary>
+/// R5 boundary invariant: an empty/degraded (zero-dimension) embedding must NOT reach
+/// db.index.vector.queryNodes (which throws a dimension mismatch). Every repository vector-search /
+/// dedup entry point short-circuits to an empty result BEFORE issuing a transaction — so a bare
+/// transaction-runner substitute (whose ReadAsync is unconfigured) returning a usable result is itself
+/// the proof that no query was attempted (otherwise awaiting the unconfigured runner would fault).
+/// </summary>
+public sealed class VectorSearchBoundaryTests
+{
+    private static readonly DateTimeOffset AsOf = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static INeo4jTransactionRunner BareRunner() => Substitute.For<INeo4jTransactionRunner>();
+
+    private static readonly float[][] Degraded = [System.Array.Empty<float>(), null!];
+
+    public static IEnumerable<object[]> EmptyEmbeddings() => Degraded.Select(e => new object[] { e });
+
+    [Theory]
+    [MemberData(nameof(EmptyEmbeddings))]
+    public async Task FactSearch_EmptyEmbedding_ReturnsEmpty_WithoutQuerying(float[] embedding)
+    {
+        var repo = new Neo4jFactRepository(BareRunner(), NullLogger<Neo4jFactRepository>.Instance);
+        (await repo.SearchByVectorAsync(embedding)).Should().BeEmpty();
+        (await repo.SearchByVectorAsOfAsync(embedding, AsOf)).Should().BeEmpty();
+        (await repo.FindDuplicateAsync("Alice", "works_at", embedding, ownerId: null, threshold: 0.95)).Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyEmbeddings))]
+    public async Task EntitySearch_EmptyEmbedding_ReturnsEmpty_WithoutQuerying(float[] embedding)
+    {
+        var repo = new Neo4jEntityRepository(BareRunner(), NullLogger<Neo4jEntityRepository>.Instance);
+        (await repo.SearchByVectorAsync(embedding)).Should().BeEmpty();
+        (await repo.SearchByVectorAsOfAsync(embedding, AsOf)).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyEmbeddings))]
+    public async Task PreferenceSearch_EmptyEmbedding_ReturnsEmpty_WithoutQuerying(float[] embedding)
+    {
+        var repo = new Neo4jPreferenceRepository(BareRunner(), NullLogger<Neo4jPreferenceRepository>.Instance);
+        (await repo.SearchByVectorAsync(embedding)).Should().BeEmpty();
+        (await repo.SearchByVectorAsOfAsync(embedding, AsOf)).Should().BeEmpty();
+        (await repo.FindDuplicateAsync("style", embedding, ownerId: null, threshold: 0.95)).Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyEmbeddings))]
+    public async Task ReasoningTraceSearch_EmptyEmbedding_ReturnsEmpty_WithoutQuerying(float[] embedding)
+    {
+        var repo = new Neo4jReasoningTraceRepository(BareRunner(), NullLogger<Neo4jReasoningTraceRepository>.Instance);
+        (await repo.SearchByTaskVectorAsync(embedding)).Should().BeEmpty();
+        (await repo.SearchByTaskVectorAsOfAsync(embedding, AsOf)).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyEmbeddings))]
+    public async Task MessageSearch_EmptyEmbedding_ReturnsEmpty_WithoutQuerying(float[] embedding)
+    {
+        var repo = new Neo4jMessageRepository(BareRunner(), NullLogger<Neo4jMessageRepository>.Instance);
+        (await repo.SearchByVectorAsync(embedding)).Should().BeEmpty();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/LongTermMemoryServiceTests.cs
@@ -392,6 +392,40 @@ public sealed class LongTermMemoryServiceTests
         result.PreferenceId.Should().Be("p-new");
     }
 
+    // ---- degraded (empty) embedding skips dedup vector lookup ----
+
+    [Fact]
+    public async Task AddFactAsync_DegradedEmptyEmbedding_SkipsDuplicateLookup_AndStillCreates()
+    {
+        // A transient embed failure degrades to an empty vector; it must NOT be handed to the dedup vector
+        // index (which would throw a dimension mismatch and abort the add). Skip dedup, still create.
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Array.Empty<float>()));
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { GenerateFactEmbeddings = true, DeduplicateOnCreate = true }));
+
+        var result = await sut.AddFactAsync(CreateFact("f-new", withEmbedding: false));
+
+        await _factRepo.DidNotReceive().FindDuplicateAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+        await _factRepo.Received(1).UpsertAsync(Arg.Is<Fact>(f => f.FactId == "f-new"), Arg.Any<CancellationToken>());
+        result.FactId.Should().Be("f-new");
+    }
+
+    [Fact]
+    public async Task AddPreferenceAsync_DegradedEmptyEmbedding_SkipsDuplicateLookup_AndStillCreates()
+    {
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Array.Empty<float>()));
+        var sut = CreateSut(Options.Create(new LongTermMemoryOptions { GeneratePreferenceEmbeddings = true, DeduplicateOnCreate = true }));
+
+        var result = await sut.AddPreferenceAsync(CreatePreference("p-new", withEmbedding: false));
+
+        await _prefRepo.DidNotReceive().FindDuplicateAsync(
+            Arg.Any<string>(), Arg.Any<float[]>(), Arg.Any<string?>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+        await _prefRepo.Received(1).UpsertAsync(Arg.Is<Preference>(p => p.PreferenceId == "p-new"), Arg.Any<CancellationToken>());
+        result.PreferenceId.Should().Be("p-new");
+    }
+
     // ---- MinConfidenceThreshold gating ----
 
     [Fact]


### PR DESCRIPTION
## Summary
**Round 5 — the "sweep the shape to exhaustion" fix the root-cause analysis prescribed.** The "a zero-dimension embedding must not reach `db.index.vector.queryNodes`" rule was enforced *per-call-site* and kept being re-discovered each round on a new entry point (4th discovery this round). This pushes it down to the boundary that owns the `queryNodes` call, so it can't be bypassed by adding a caller.

Closes two findings:
- **#9 (MED)** — direct `Search{Facts,Entities,Preferences}(AsOf)` / `SearchSimilarTraces` / `SearchMessages` bypassed the guard (only the assembler gated). A degraded/empty vector → dimension-mismatch throw.
- **#4 (MED)** — `AddFact/AddPreferenceAsync` gated dedup on `embedding is not null`, but `EmbeddingOrchestrator` degrades a failure to `Array.Empty<float>()` (non-null), so the empty vector reached `FindDuplicate → queryNodes` and threw, aborting the whole add.

## Changes
- `if (embedding is not { Length: > 0 }) return empty;` as the **first statement** of all 9 repo vector-search methods (Fact/Entity/Preference × Search+AsOf, ReasoningTrace × Search+AsOf, Message) — short-circuits before any transaction, null-tolerant.
- Same guard on `Fact`/`Preference` `FindDuplicateAsync`.
- `LongTermMemoryService` dedup gates → `embedding is { Length: > 0 }`; an empty vector now skips dedup and persists the node with a NULL (re-queueable) embedding.
- `MemoryContextAssembler`'s `hasEmbedding` gate **left in place** (additive defense-in-depth — its `DidNotReceive` test still passes).

## Verification
- `VectorSearchBoundaryTests`: every entry point returns empty/null on an empty **or null** embedding without issuing a query (10 theory cases).
- Service tests: a degraded embedding skips the dedup lookup and still persists (fact + preference).
- Full unit suite **green (2603)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)