### PR TITLE
fix(reasoning): trace prune confines to one owner bucket — never cross-evict (regression from #40)

### DIFF
--- a/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
@@ -62,9 +62,10 @@ public interface IReasoningTraceRepository
     /// <summary>
     /// Enforces a per-session retention cap (H): keeps the newest <paramref name="maxToKeep"/> traces for
     /// the session and hard-deletes older traces together with their child ReasoningStep nodes. Returns the
-    /// number of traces pruned. When <paramref name="scope"/> carries an owner (R1), the prune only considers
-    /// that owner's traces — it never evicts another owner's (and, with <c>IncludeShared=false</c>, never
-    /// shared/global) traces. Ordering is newest-first, so a just-added trace is always retained.
+    /// number of traces pruned. This is a DESTRUCTIVE write, so it ALWAYS confines to exactly one R1 bucket:
+    /// when <paramref name="ownerId"/> is set, only that owner's own traces; when it is <c>null</c>, only the
+    /// shared/global bucket (<c>owner_id IS NULL</c>) — never another owner's traces, and never "all owners".
+    /// Ordering is newest-first, so a just-added trace is always retained.
     /// </summary>
-    Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, MemoryScope? scope = null, CancellationToken cancellationToken = default);
+    Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, string? ownerId = null, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -79,14 +79,14 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         var added = await _traceRepo.AddAsync(trace, cancellationToken);
 
         // Retention cap (H): when MaxTracesPerSession is configured, prune older traces beyond the cap so a
-        // session's reasoning history cannot grow without bound. The prune is owner-scoped (R1) when an owner
-        // is present — own-only, so one owner's traces can never evict another owner's (or shared) traces.
+        // session's reasoning history cannot grow without bound. The prune confines to exactly the just-added
+        // trace's R1 bucket — its own owner when present, or the shared/global bucket (owner_id IS NULL) when
+        // null — so it can never evict another owner's (or, when owned, shared) traces.
         if (_options.MaxTracesPerSession is { } cap && cap > 0)
         {
-            var scope = ownerId is null ? null : MemoryScope.For(ownerId, includeShared: false);
             try
             {
-                var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, cap, scope, cancellationToken);
+                var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, cap, ownerId, cancellationToken);
                 if (pruned > 0)
                     _logger.LogDebug("Pruned {Pruned} trace(s) beyond MaxTracesPerSession={Cap} for session {SessionId}.",
                         pruned, cap, sessionId);

--- a/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
@@ -68,17 +68,18 @@ public static class ReasoningQueries
         DETACH DELETE t, s";
 
     /// <summary>
-    /// Retention prune (H): keep the newest <c>$keep</c> traces for a session (optionally R1-scoped to an
-    /// owner) and delete the older ones together with their child ReasoningStep nodes. Returns the number
-    /// of traces pruned. Ordering is by <c>started_at</c> DESC, so the just-added trace (newest) is always
-    /// retained. (A method, not a const, so it is excluded from the Cypher snapshot inventory — like the
-    /// other owner-parameterized builders here.)
+    /// Retention prune (H): keep the newest <c>$keep</c> traces for a session and delete the older ones with
+    /// their child ReasoningStep nodes. Returns the number pruned. Ordering is by <c>started_at</c> DESC, so
+    /// the just-added trace (newest) is always retained. ALWAYS confines to exactly one R1 bucket — the
+    /// owner's own traces (<c>owner_id = $ownerId</c>), or, when <paramref name="ownerIsShared"/>, the
+    /// shared/global bucket only (<c>owner_id IS NULL</c>) — so this destructive write can never cross owners.
+    /// (A method, not a const, so it is excluded from the Cypher snapshot inventory.)
     /// </summary>
-    public static string PruneSessionTraces(bool hasOwnerFilter, bool includeShared)
+    public static string PruneSessionTraces(bool ownerIsShared)
     {
-        var owner = !hasOwnerFilter ? string.Empty
-            : includeShared ? " AND (t.owner_id = $ownerId OR t.owner_id IS NULL)"
-                            : " AND t.owner_id = $ownerId";
+        // A retention prune is a DESTRUCTIVE write keyed by a guessable session_id, so its owner clause must
+        // NEVER collapse to "all owners" (the #40 regression). It always confines to a single bucket.
+        var owner = ownerIsShared ? " AND t.owner_id IS NULL" : " AND t.owner_id = $ownerId";
         return @"
             MATCH (t:ReasoningTrace {session_id: $sessionId})
             WHERE true" + owner + @"

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -221,20 +221,21 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         }, cancellationToken);
     }
 
-    public async Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+    public async Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, string? ownerId = null, CancellationToken cancellationToken = default)
     {
-        bool hasOwner = scope?.HasOwnerFilter == true;
-        bool includeShared = scope?.IncludeShared ?? true;
+        // null ownerId = the shared/global bucket ONLY (owner_id IS NULL), never "all owners" — a destructive
+        // prune must confine to exactly one R1 bucket (mirrors the FindDuplicate ownerIsShared idiom).
+        bool ownerIsShared = string.IsNullOrEmpty(ownerId);
         _logger.LogDebug("Pruning reasoning traces for session {SessionId} to newest {Keep}, owner={Owner}",
-            sessionId, maxToKeep, scope?.OwnerId);
+            sessionId, maxToKeep, ownerId);
 
-        var cypher = ReasoningQueries.PruneSessionTraces(hasOwner, includeShared);
+        var cypher = ReasoningQueries.PruneSessionTraces(ownerIsShared);
         var parameters = new Dictionary<string, object>
         {
             ["sessionId"] = sessionId,
             ["keep"] = maxToKeep
         };
-        if (hasOwner) parameters["ownerId"] = scope!.OwnerId!;
+        if (!ownerIsShared) parameters["ownerId"] = ownerId!;
 
         return await _tx.WriteAsync(async runner =>
         {

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTracePruneIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTracePruneIntegrationTests.cs
@@ -128,9 +128,8 @@ public class ReasoningTracePruneIntegrationTests : IAsyncLifetime
         await _traceRepo.AddAsync(bob2);
         await _traceRepo.AddAsync(shared);
 
-        // Prune Alice own-only to keep 1 → 2 of Alice's pruned; Bob's + shared untouched.
-        var scope = MemoryScope.For("alice", includeShared: false);
-        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 1, scope: scope);
+        // Prune Alice's own bucket to keep 1 → 2 of Alice's pruned; Bob's + shared untouched.
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 1, ownerId: "alice");
 
         pruned.Should().Be(2);
 
@@ -142,5 +141,36 @@ public class ReasoningTracePruneIntegrationTests : IAsyncLifetime
             "Bob's traces are never touched by Alice's prune");
 
         (await _traceRepo.GetByIdAsync(shared.TraceId)).Should().NotBeNull("shared trace is never evicted by an own-only prune");
+    }
+
+    [Fact]
+    public async Task PruneSessionTracesAsync_NullOwner_PrunesSharedBucketOnly_NeverEvictsOwnedTraces()
+    {
+        // R5 regression of #40: a null-owner (shared/MCP) prune must NOT cross-evict owner-tagged traces in
+        // the same (guessable) session. Before the fix, null owner collapsed to "all owners" and the
+        // destructive prune DETACH-DELETEd Bob's and Alice's traces.
+        var sessionId = $"session-{Guid.NewGuid():N}";
+        var shared = new List<ReasoningTrace>();
+        for (var day = 0; day < 3; day++)
+        {
+            var t = MakeTrace(sessionId, day, ownerId: null);
+            await _traceRepo.AddAsync(t);
+            shared.Add(t);
+        }
+        var bob1 = MakeTrace(sessionId, 0, ownerId: "bob");
+        var bob2 = MakeTrace(sessionId, 1, ownerId: "bob");
+        var alice1 = MakeTrace(sessionId, 0, ownerId: "alice");
+        await _traceRepo.AddAsync(bob1);
+        await _traceRepo.AddAsync(bob2);
+        await _traceRepo.AddAsync(alice1);
+
+        // Prune the shared bucket to keep 1 → 2 shared pruned; every OWNED trace must survive.
+        var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, maxToKeep: 1, ownerId: null);
+
+        pruned.Should().Be(2);
+        (await _traceRepo.GetByIdAsync(shared[2].TraceId)).Should().NotBeNull("the newest shared trace survives");
+        foreach (var owned in new[] { bob1.TraceId, bob2.TraceId, alice1.TraceId })
+            (await _traceRepo.GetByIdAsync(owned)).Should().NotBeNull(
+                "a shared-bucket prune must never evict another owner's traces (the #40 cross-eviction)");
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
@@ -86,31 +86,30 @@ public sealed class ReasoningMemoryServiceTests
         await sut.StartTraceAsync("session-1", "Test task");
 
         await _traceRepo.DidNotReceive().PruneSessionTracesAsync(
-            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task StartTraceAsync_MaxTracesConfigured_PrunesUnscopedWhenNoOwner()
+    public async Task StartTraceAsync_MaxTracesConfigured_NullOwner_PrunesSharedBucket()
     {
         var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 5 });
 
         await sut.StartTraceAsync("session-1", "Test task");
 
+        // null ownerId now means "the shared bucket only", never "all owners".
         await _traceRepo.Received(1).PruneSessionTracesAsync(
-            "session-1", 5, null, Arg.Any<CancellationToken>());
+            "session-1", 5, (string?)null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task StartTraceAsync_MaxTracesConfiguredWithOwner_PrunesOwnerScopedOwnOnly()
+    public async Task StartTraceAsync_MaxTracesConfiguredWithOwner_PrunesOwnBucketOnly()
     {
         var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 3 });
 
         await sut.StartTraceAsync("session-1", "Test task", ownerId: "alice");
 
         await _traceRepo.Received(1).PruneSessionTracesAsync(
-            "session-1", 3,
-            Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice" && s.IncludeShared == false),
-            Arg.Any<CancellationToken>());
+            "session-1", 3, "alice", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -121,13 +120,13 @@ public sealed class ReasoningMemoryServiceTests
         await sut.StartTraceAsync("session-1", "Test task");
 
         await _traceRepo.DidNotReceive().PruneSessionTracesAsync(
-            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task StartTraceAsync_PruneFailure_DoesNotFailStartTrace()
     {
-        _traceRepo.PruneSessionTracesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+        _traceRepo.PruneSessionTracesAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns<Task<int>>(_ => throw new InvalidOperationException("boom"));
         var sut = CreateSut(new ReasoningMemoryOptions { MaxTracesPerSession = 2 });
 


### PR DESCRIPTION
## Summary
**Round 5 — confirmed regression from fix #40 (MEDIUM).** The retention prune mapped a null-owner `StartTrace` to `scope==null`, which the prune Cypher rendered as **no owner clause** — so an unscoped `StartTrace` (concretely the MCP `memory_start_trace` tool, which has no owner parameter and falls back to a shared `DefaultSessionId`) with `MaxTracesPerSession` set would `DETACH DELETE` **other owners'** traces in the same guessable session. That's a cross-owner destructive eviction — the exact thing the codebase forbids elsewhere (`SupersessionIntegrationTests`: "even with NO scope the admin path must not cross owners").

## Fix (remove the all-owners path entirely)
A retention prune is a destructive write keyed by a guessable `session_id`, so it must never collapse to "all owners". It now **always confines to exactly one R1 bucket**, mirroring the existing `FindDuplicate` `ownerIsShared` idiom:
- `IReasoningTraceRepository.PruneSessionTracesAsync(... MemoryScope? scope ...)` → `(... string? ownerId ...)`: `null` = the **shared/global bucket only** (`owner_id IS NULL`), never all owners.
- `ReasoningQueries.PruneSessionTraces(bool ownerIsShared)` — two branches (`owner_id = $ownerId` / `owner_id IS NULL`), no all-owners path.
- `ReasoningMemoryService` passes the trace's `ownerId` straight through.

Cross-owner deletion is now **structurally impossible**. (Cypher is a builder method, so no snapshot change; `PruneSessionTracesAsync` has exactly one production caller.)

## Verification
- Unit: matchers updated to the `string?` signature (null owner = shared bucket); 26/26 green.
- Integration (real Neo4j): new `PruneSessionTracesAsync_NullOwner_PrunesSharedBucketOnly_NeverEvictsOwnedTraces` proves a null-owner prune evicts only shared traces and leaves every owned (alice/bob) trace intact; the owned-bucket test re-expressed against the new signature. 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)