### PR TITLE
fix(extraction): honor caller cancellation in the entity-resolution loop

### DIFF
--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -108,6 +108,10 @@ internal sealed class ExtractionStage : IExtractionStage
                 resolvedEntityMap[extracted.Name] = entity;
                 _logger.LogDebug("Resolved entity '{Name}' (id={Id}).", entity.Name, entity.EntityId);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw; // Honor caller cancellation — do not mask it as a per-entity resolution error.
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error resolving entity '{Name}'.", extracted.Name);

--- a/tests/AgentMemory.Tests.Unit/Extraction/ExtractionStageTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/ExtractionStageTests.cs
@@ -592,6 +592,43 @@ public sealed class ExtractionStageTests
         result.ResolvedEntityMap.Should().NotContainKey("BadEntity");
     }
 
+    [Fact]
+    public async Task ExtractAsync_ResolutionCancelled_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("Alice"), MakeEntity("Bob") });
+        var sut = CreateSut(entityExtractors: new[] { ext });
+
+        // Simulate in-flight Neo4j/embedding I/O observing caller cancellation: cancel then throw OCE.
+        _resolver
+            .ResolveEntityAsync(Arg.Any<ExtractedEntity>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Entity>>(_ => { cts.Cancel(); throw new OperationCanceledException(cts.Token); });
+
+        await FluentActions.Awaiting(() => sut.ExtractAsync(TestMessages, ExtractionTypes.All, scope: null, cancellationToken: cts.Token))
+            .Should().ThrowAsync<OperationCanceledException>("caller cancellation must propagate, not be masked as a per-entity error");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ResolutionThrowsOceOnNonCancelledToken_StillLogsAndContinues()
+    {
+        // The `when (IsCancellationRequested)` filter must not over-catch: an OCE on a token the caller did
+        // NOT cancel (e.g. an inner timeout) is a per-entity failure — log and continue, don't propagate.
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("Alice"), MakeEntity("BadEntity") });
+        var sut = CreateSut(entityExtractors: new[] { ext });
+        _resolver
+            .ResolveEntityAsync(Arg.Is<ExtractedEntity>(e => e.Name == "BadEntity"), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("inner timeout, caller token not cancelled"));
+
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All); // caller token never cancelled
+
+        result.ResolvedEntityMap.Should().ContainKey("Alice");
+        result.ResolvedEntityMap.Should().NotContainKey("BadEntity");
+    }
+
     // ── Confidence filtering on relationships ──
 
     [Fact]


### PR DESCRIPTION
## Summary
**Round 5 (MEDIUM) — the silent-failure-swallow shape, swept.** `ExtractionStage`'s per-entity resolution loop wrapped `ResolveEntityAsync` (cancellable Neo4j/embedding I/O) in a bare `catch (Exception) { log }` with **no OCE guard**, so caller cancellation mid-extraction was demoted to a logged "Error resolving entity"; the loop ran to completion returning a **partial result as SUCCESS** — violating the .NET cancellation contract and wasting work on an already-cancelled token. The same file's `ExtractSafeAsync` and the sibling `PersistenceStage` already use the guard, so this was an internal inconsistency.

## Fix
Added `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }` as the first catch. The `when` filter is load-bearing — an OCE on a token the caller did **not** cancel (e.g. an inner timeout) still falls through to per-entity log-and-continue, preserving the "one bad entity doesn't abort the batch" contract.

## Verification
- `ExtractionStageTests` 28/28 green, incl. two new tests: caller cancellation propagates OCE; an OCE on a non-cancelled token still logs-and-continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)