### PR TITLE
fix(core): clamp token→char budget so a huge MaxTokens can't overflow to empty context

### DIFF
--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -391,6 +391,19 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         string? GraphRag,
         bool Truncated);
 
+    /// <summary>
+    /// Resolves the character budget. ~4 chars/token, computed in <c>long</c> and clamped to
+    /// <see cref="int.MaxValue"/> so a very large <c>MaxTokens</c> (an "effectively unlimited" value
+    /// &gt; ~536M) cannot overflow int and wrap NEGATIVE — which would make <c>totalChars &lt;= maxChars</c>
+    /// always false and silently truncate the whole context to empty.
+    /// </summary>
+    internal static int ResolveMaxChars(ContextBudget budget)
+    {
+        if (budget.MaxCharacters.HasValue) return budget.MaxCharacters.Value;
+        if (budget.MaxTokens.HasValue) return (int)Math.Min((long)budget.MaxTokens.Value * 4, int.MaxValue);
+        return int.MaxValue;
+    }
+
     private AssembledSections ApplyBudget(
         ContextBudget budget,
         IReadOnlyList<Message> recent,
@@ -401,8 +414,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         IReadOnlyList<ReasoningTrace> traces,
         string? graphRagContext)
     {
-        int maxChars = budget.MaxCharacters
-            ?? (budget.MaxTokens.HasValue ? budget.MaxTokens.Value * 4 : int.MaxValue);
+        int maxChars = ResolveMaxChars(budget);
 
         int totalChars = ContextBudgetEstimator.EstimateChars(recent) + ContextBudgetEstimator.EstimateChars(relevant)
             + ContextBudgetEstimator.EstimateChars(entities) + ContextBudgetEstimator.EstimateChars(preferences)

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTruncationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTruncationTests.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Core.Services;
 using AgentMemory.Core.Services.Budgeting;
 
 namespace AgentMemory.Tests.Unit.Services;
@@ -10,6 +12,28 @@ namespace AgentMemory.Tests.Unit.Services;
 /// </summary>
 public sealed class MemoryContextAssemblerTruncationTests
 {
+    // R5: token→char budget must never wrap negative on a very large MaxTokens (which would invert the
+    // "totalChars <= maxChars" check and silently truncate the whole context to empty).
+    [Theory]
+    [InlineData(600_000_000, int.MaxValue)]   // the reported trigger: 600M*4 = 2.4e9 -> clamp, NOT negative
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(4096, 16384)]                 // normal: 4096*4
+    [InlineData(536_870_911, 2_147_483_644)]  // largest MaxTokens whose *4 still fits int
+    public void ResolveMaxChars_TokenBudget_NeverWrapsNegative(int maxTokens, int expected)
+    {
+        int maxChars = MemoryContextAssembler.ResolveMaxChars(new ContextBudget { MaxTokens = maxTokens });
+        maxChars.Should().BePositive();
+        maxChars.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ResolveMaxChars_MaxCharactersWins_OverTokens()
+        => MemoryContextAssembler.ResolveMaxChars(new ContextBudget { MaxCharacters = 100, MaxTokens = 600_000_000 }).Should().Be(100);
+
+    [Fact]
+    public void ResolveMaxChars_NoLimits_IsIntMaxValue()
+        => MemoryContextAssembler.ResolveMaxChars(new ContextBudget()).Should().Be(int.MaxValue);
+
     [Theory]
     [InlineData("hello", 3, "hel")]
     [InlineData("hello", 10, "hello")] // budget >= length ⇒ unchanged


### PR DESCRIPTION
## Summary
**Round 5 (LOW, numeric).** `MemoryContextAssembler.ApplyBudget` computed `maxChars = MaxTokens.Value * 4` in **unchecked int**. For `MaxTokens > ~536M` (a plausible "effectively unlimited" value, e.g. 600M) the product overflows int and **wraps negative**, so `totalChars <= maxChars` is always false and truncation runs against a negative limit — **emptying the whole context** (returns `Truncated=true`, no error). The user asked for a huge budget and got nothing.

## Fix
Extracted `internal static int ResolveMaxChars(ContextBudget)`: the token→char conversion is computed in `long` and clamped to `int.MaxValue`, so a large `MaxTokens` yields `int.MaxValue` (no truncation — the intended "unlimited" behavior). `MaxCharacters` precedence and `null ⇒ unlimited` are unchanged. (Clamping, not `checked()`, so the legitimate "give me everything" intent is honored rather than throwing.)

## Verification
- `ResolveMaxChars` never wraps negative (incl. the 600M trigger and `int.MaxValue` boundary; `4096→16384`; the largest-fitting `536_870_911→2_147_483_644`); `MaxCharacters` wins; no-limits = `int.MaxValue`. `MemoryContextAssemblerTruncationTests` 12/12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)