### PR TITLE
fix(enrichment): don't cache transient (Error/RateLimited) enrichment results

### DIFF
--- a/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
@@ -43,7 +43,7 @@ public sealed class CachedEnrichmentService : IEnrichmentService
 
         var result = await _inner.EnrichEntityAsync(entityName, entityType, ct).ConfigureAwait(false);
 
-        if (result is not null)
+        if (result is not null && IsCacheable(result))
         {
             _cache.Set(key, result, _options.EnrichmentCacheDuration);
             _logger.LogDebug("Cached enrichment result for key '{Key}'", key);
@@ -51,4 +51,14 @@ public sealed class CachedEnrichmentService : IEnrichmentService
 
         return result;
     }
+
+    // Providers signal TRANSIENT failures (HTTP 429/5xx) by RETURNING a non-null result with
+    // Status=RateLimited/Error (not by throwing); BackgroundEnrichmentQueue retries exactly those. Caching a
+    // transient failure for EnrichmentCacheDuration (default 24h) would make that retry short-circuit on the
+    // cached poison result without re-contacting the provider — the entity is never enriched until the TTL
+    // expires. Cache only non-transient outcomes: Success, null-status (Wikimedia success), and terminal
+    // NotFound/Skipped (a genuinely absent/unsupported entity is worth caching). The result is still RETURNED
+    // unchanged so the queue keeps observing the Error/RateLimited status to drive its retry.
+    private static bool IsCacheable(EnrichmentResult result) =>
+        result.Status is not (EnrichmentStatus.Error or EnrichmentStatus.RateLimited);
 }

--- a/tests/AgentMemory.Tests.Unit/Enrichment/CachedEnrichmentServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/CachedEnrichmentServiceTests.cs
@@ -72,6 +72,56 @@ public sealed class CachedEnrichmentServiceTests
         await inner.Received(2).EnrichEntityAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData(EnrichmentStatus.RateLimited)]
+    [InlineData(EnrichmentStatus.Error)]
+    public async Task EnrichEntity_TransientFailure_NotCached_AllowsRetry(EnrichmentStatus status)
+    {
+        // R5: a status-bearing transient failure must NOT be cached — otherwise the queue's retry hits the
+        // cached poison result and never re-contacts the provider until the 24h TTL expires.
+        var (sut, inner) = CreateSut();
+        var failure = new EnrichmentResult { EntityName = "London", Status = status };
+        inner.EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>()).Returns(failure);
+
+        var r1 = await sut.EnrichEntityAsync("London", "PLACE");
+        var r2 = await sut.EnrichEntityAsync("London", "PLACE");
+
+        r1!.Status.Should().Be(status); // still returned so the queue can observe it and retry
+        r2!.Status.Should().Be(status);
+        await inner.Received(2).EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(EnrichmentStatus.Success)]
+    [InlineData(null)]
+    public async Task EnrichEntity_SuccessOrNullStatus_Cached(EnrichmentStatus? status)
+    {
+        var (sut, inner) = CreateSut();
+        var ok = new EnrichmentResult { EntityName = "London", Status = status };
+        inner.EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>()).Returns(ok);
+
+        await sut.EnrichEntityAsync("London", "PLACE");
+        await sut.EnrichEntityAsync("London", "PLACE");
+
+        await inner.Received(1).EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(EnrichmentStatus.NotFound)]
+    [InlineData(EnrichmentStatus.Skipped)]
+    public async Task EnrichEntity_TerminalNonSuccess_Cached(EnrichmentStatus status)
+    {
+        // Terminal outcomes (genuinely absent/unsupported) are cached to avoid re-hitting the provider.
+        var (sut, inner) = CreateSut();
+        var terminal = new EnrichmentResult { EntityName = "London", Status = status };
+        inner.EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>()).Returns(terminal);
+
+        await sut.EnrichEntityAsync("London", "PLACE");
+        await sut.EnrichEntityAsync("London", "PLACE");
+
+        await inner.Received(1).EnrichEntityAsync("London", "PLACE", Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task EnrichEntity_DifferentEntityTypes_CachedSeparately()
     {


### PR DESCRIPTION
## Summary
**Round 5 (LOW) — the "provider failure result treated as success" shape, at the cache layer.** `CachedEnrichmentService` cached **any** non-null `EnrichmentResult` for 24h with no `Status` check. Providers signal *transient* failures by **returning** a non-null result with `Status=Error/RateLimited` (the PR#37 convention), and `BackgroundEnrichmentQueue` retries exactly those — but a status-bearing failure behind the cache is served from the cache on the retry, so the queue never re-contacts the provider until the TTL expires (poison cache; the Diffbot timeout path already *throws* to avoid exactly this).

## Fix
`_cache.Set` is gated on `IsCacheable` (`Status is not (Error or RateLimited)`) — the exact complement of the queue's transient-retry set. Success / null-status (Wikimedia success) / terminal `NotFound`/`Skipped` are still cached; the result is **returned unchanged** so the queue keeps observing the failure status and retries. Default DI (Wikimedia, returns null on failure) is unaffected; `CachedGeocodingService` is untouched (`GeocodingResult` has no `Status`).

## Verification
- `CachedEnrichmentServiceTests` 13/13 green, incl. new theories: transient `Error`/`RateLimited` not cached (inner re-called on retry); `Success`/null cached; terminal `NotFound`/`Skipped` cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)