### PR TITLE
fix(mcp): surface confidence-gate skip in add tools (R5 #1)

### DIFF
--- a/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 
 namespace AgentMemory.McpServer.Tools;
@@ -102,6 +103,7 @@ public sealed class CoreMemoryTools
         IIdGenerator idGenerator,
         IClock clock,
         IOptions<McpServerOptions> options,
+        IOptions<LongTermMemoryOptions> longTermOptions,
         [Description("Name of the entity")] string name,
         [Description("Type of entity: Person, Organization, Location, Event, or Object")] string type,
         [Description("Description of the entity (optional)")] string? description = null,
@@ -109,18 +111,20 @@ public sealed class CoreMemoryTools
         [Description("Owner/user identifier (optional). Null = shared/global knowledge visible to everyone.")] string? userId = null,
         CancellationToken cancellationToken = default)
     {
+        var confidenceValue = confidence ?? options.Value.DefaultConfidence;
         var entity = new Entity
         {
             EntityId = idGenerator.GenerateId(),
             Name = name,
             Type = type,
             Description = description,
-            Confidence = confidence ?? options.Value.DefaultConfidence,
+            Confidence = confidenceValue,
             OwnerId = userId,
             CreatedAtUtc = clock.UtcNow
         };
 
         var result = await longTermMemory.AddEntityAsync(entity, cancellationToken);
+        var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {
             result.EntityId,
@@ -128,7 +132,9 @@ public sealed class CoreMemoryTools
             result.Type,
             result.Description,
             result.Confidence,
-            result.CreatedAtUtc
+            result.CreatedAtUtc,
+            persisted,
+            reason
         });
     }
 
@@ -138,6 +144,7 @@ public sealed class CoreMemoryTools
         IIdGenerator idGenerator,
         IClock clock,
         IOptions<McpServerOptions> options,
+        IOptions<LongTermMemoryOptions> longTermOptions,
         [Description("Category of the preference (e.g., 'communication', 'style', 'tooling')")] string category,
         [Description("The preference text describing what the user prefers")] string preferenceText,
         [Description("Context in which the preference applies (optional)")] string? context = null,
@@ -145,18 +152,20 @@ public sealed class CoreMemoryTools
         [Description("Owner/user identifier (optional). Null = shared/global knowledge visible to everyone.")] string? userId = null,
         CancellationToken cancellationToken = default)
     {
+        var confidenceValue = confidence ?? options.Value.DefaultConfidence;
         var preference = new Preference
         {
             PreferenceId = idGenerator.GenerateId(),
             Category = category,
             PreferenceText = preferenceText,
             Context = context,
-            Confidence = confidence ?? options.Value.DefaultConfidence,
+            Confidence = confidenceValue,
             OwnerId = userId,
             CreatedAtUtc = clock.UtcNow
         };
 
         var result = await longTermMemory.AddPreferenceAsync(preference, cancellationToken);
+        var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {
             result.PreferenceId,
@@ -164,7 +173,9 @@ public sealed class CoreMemoryTools
             result.PreferenceText,
             result.Context,
             result.Confidence,
-            result.CreatedAtUtc
+            result.CreatedAtUtc,
+            persisted,
+            reason
         });
     }
 
@@ -174,6 +185,7 @@ public sealed class CoreMemoryTools
         IIdGenerator idGenerator,
         IClock clock,
         IOptions<McpServerOptions> options,
+        IOptions<LongTermMemoryOptions> longTermOptions,
         [Description("Subject of the fact (e.g., a person or concept name)")] string subject,
         [Description("Predicate or relationship (e.g., 'works_at', 'lives_in', 'knows')")] string predicate,
         [Description("Object or value of the fact (e.g., 'Microsoft', 'Seattle')")] string factObject,
@@ -183,6 +195,7 @@ public sealed class CoreMemoryTools
         [Description("Additional metadata as a JSON object string, e.g. {\"source\":\"crm\"} (optional)")] string? metadataJson = null,
         CancellationToken cancellationToken = default)
     {
+        var confidenceValue = confidence ?? options.Value.DefaultConfidence;
         var fact = new Fact
         {
             FactId = idGenerator.GenerateId(),
@@ -190,13 +203,14 @@ public sealed class CoreMemoryTools
             Predicate = predicate,
             Object = factObject,
             Category = category,
-            Confidence = confidence ?? options.Value.DefaultConfidence,
+            Confidence = confidenceValue,
             OwnerId = userId,
             CreatedAtUtc = clock.UtcNow,
             Metadata = ParseMetadata(metadataJson) ?? new Dictionary<string, object>()
         };
 
         var result = await longTermMemory.AddFactAsync(fact, cancellationToken);
+        var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {
             result.FactId,
@@ -206,9 +220,21 @@ public sealed class CoreMemoryTools
             result.Category,
             result.Confidence,
             result.CreatedAtUtc,
-            result.Metadata
+            result.Metadata,
+            persisted,
+            reason
         });
     }
+
+    // The Add* gate (LongTermMemoryOptions.MinConfidenceThreshold) skips persistence for a sub-threshold item
+    // and returns it un-stored. Surface that to the MCP caller so a low-confidence add is not reported as a
+    // false success. Uses the effective confidence the tool stamped (not result.Confidence, which the dedup-
+    // reinforce path can raise); mirrors the service's strict-&lt; skip, so persisted == (confidence >= threshold).
+    private static (bool Persisted, string? Reason) PersistenceOutcome(double confidence, double threshold) =>
+        confidence >= threshold
+            ? (true, (string?)null)
+            : (false, $"Not stored: confidence {confidence:0.###} is below the configured minimum {threshold:0.###} " +
+                      "(LongTermMemoryOptions.MinConfidenceThreshold). Increase confidence or lower the threshold.");
 
     // Parses an optional JSON-object string into a metadata dictionary. Returns null when blank;
     // throws an actionable ArgumentException (surfaced to the MCP caller) when the JSON is invalid.

--- a/tests/AgentMemory.Tests.Unit/McpServer/CoreMemoryToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/CoreMemoryToolsTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.McpServer;
 using AgentMemory.McpServer.Tools;
@@ -16,6 +17,7 @@ public sealed class CoreMemoryToolsTests
     private readonly IIdGenerator _idGenerator = Substitute.For<IIdGenerator>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly IOptions<McpServerOptions> _options = Options.Create(new McpServerOptions());
+    private readonly IOptions<LongTermMemoryOptions> _longTermOptions = Options.Create(new LongTermMemoryOptions());
 
     private static readonly DateTimeOffset FixedTime = new(2025, 1, 15, 10, 0, 0, TimeSpan.Zero);
 
@@ -195,7 +197,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Entity>());
 
         await CoreMemoryTools.MemoryAddEntity(
-            _longTermMemory, _idGenerator, _clock, _options, "Alice", "Person", "A developer");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Alice", "Person", "A developer");
 
         await _longTermMemory.Received(1).AddEntityAsync(
             Arg.Is<Entity>(e =>
@@ -214,7 +216,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Entity>());
 
         await CoreMemoryTools.MemoryAddEntity(
-            _longTermMemory, _idGenerator, _clock, _options, "Bob", "Person");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Bob", "Person");
 
         await _longTermMemory.Received(1).AddEntityAsync(
             Arg.Is<Entity>(e => e.Confidence == 0.9),
@@ -228,7 +230,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Entity>());
 
         await CoreMemoryTools.MemoryAddEntity(
-            _longTermMemory, _idGenerator, _clock, _options, "Bob", "Person", confidence: 0.75);
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Bob", "Person", confidence: 0.75);
 
         await _longTermMemory.Received(1).AddEntityAsync(
             Arg.Is<Entity>(e => e.Confidence == 0.75),
@@ -242,12 +244,15 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Entity>());
 
         var result = await CoreMemoryTools.MemoryAddEntity(
-            _longTermMemory, _idGenerator, _clock, _options, "Alice", "Person", "A developer");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Alice", "Person", "A developer");
 
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("entityId").GetString().Should().Be("generated-id-1");
         doc.RootElement.GetProperty("name").GetString().Should().Be("Alice");
         doc.RootElement.GetProperty("type").GetString().Should().Be("Person");
+        // Default confidence (0.9) is at/above the default threshold (0.5) → persisted, no reason.
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeTrue();
+        doc.RootElement.TryGetProperty("reason", out _).Should().BeFalse("a persisted add carries no reason");
     }
 
     // ── memory_add_preference ──
@@ -259,7 +264,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Preference>());
 
         await CoreMemoryTools.MemoryAddPreference(
-            _longTermMemory, _idGenerator, _clock, _options, "style", "dark mode", "IDE");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "style", "dark mode", "IDE");
 
         await _longTermMemory.Received(1).AddPreferenceAsync(
             Arg.Is<Preference>(p =>
@@ -278,7 +283,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Preference>());
 
         await CoreMemoryTools.MemoryAddPreference(
-            _longTermMemory, _idGenerator, _clock, _options, "style", "dark mode");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "style", "dark mode");
 
         await _longTermMemory.Received(1).AddPreferenceAsync(
             Arg.Is<Preference>(p => p.Confidence == 0.9),
@@ -292,12 +297,14 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Preference>());
 
         var result = await CoreMemoryTools.MemoryAddPreference(
-            _longTermMemory, _idGenerator, _clock, _options, "style", "dark mode", "IDE");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "style", "dark mode", "IDE");
 
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("preferenceId").GetString().Should().Be("generated-id-1");
         doc.RootElement.GetProperty("category").GetString().Should().Be("style");
         doc.RootElement.GetProperty("preferenceText").GetString().Should().Be("dark mode");
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeTrue();
+        doc.RootElement.TryGetProperty("reason", out _).Should().BeFalse("a persisted add carries no reason");
     }
 
     // ── memory_add_fact ──
@@ -309,7 +316,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Fact>());
 
         await CoreMemoryTools.MemoryAddFact(
-            _longTermMemory, _idGenerator, _clock, _options, "Alice", "works_at", "Microsoft");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Alice", "works_at", "Microsoft");
 
         await _longTermMemory.Received(1).AddFactAsync(
             Arg.Is<Fact>(f =>
@@ -328,7 +335,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Fact>());
 
         await CoreMemoryTools.MemoryAddFact(
-            _longTermMemory, _idGenerator, _clock, _options, "Alice", "works_at", "Microsoft");
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Alice", "works_at", "Microsoft");
 
         await _longTermMemory.Received(1).AddFactAsync(
             Arg.Is<Fact>(f => f.Confidence == 0.9),
@@ -342,7 +349,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Fact>());
 
         await CoreMemoryTools.MemoryAddFact(
-            _longTermMemory, _idGenerator, _clock, _options,
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions,
             "Alice", "works_at", "Microsoft",
             confidence: null, userId: "u1", category: "professional",
             metadataJson: "{\"source\":\"crm\"}");
@@ -359,7 +366,7 @@ public sealed class CoreMemoryToolsTests
     public async Task MemoryAddFact_InvalidMetadataJson_ThrowsArgumentException()
     {
         var act = async () => await CoreMemoryTools.MemoryAddFact(
-            _longTermMemory, _idGenerator, _clock, _options,
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions,
             "Alice", "works_at", "Microsoft", metadataJson: "not-json");
 
         await act.Should().ThrowAsync<ArgumentException>();
@@ -372,7 +379,7 @@ public sealed class CoreMemoryToolsTests
             .Returns(ci => ci.Arg<Fact>());
 
         var result = await CoreMemoryTools.MemoryAddFact(
-            _longTermMemory, _idGenerator, _clock, _options, "Alice", "works_at", "Microsoft", 0.8);
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions, "Alice", "works_at", "Microsoft", 0.8);
 
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("factId").GetString().Should().Be("generated-id-1");
@@ -380,5 +387,95 @@ public sealed class CoreMemoryToolsTests
         doc.RootElement.GetProperty("predicate").GetString().Should().Be("works_at");
         doc.RootElement.GetProperty("object").GetString().Should().Be("Microsoft");
         doc.RootElement.GetProperty("confidence").GetDouble().Should().Be(0.8);
+        // 0.8 ≥ default threshold (0.5) → persisted, no reason.
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeTrue();
+        doc.RootElement.TryGetProperty("reason", out _).Should().BeFalse("a persisted add carries no reason");
+    }
+
+    // ── persistence-outcome gate (#1: low-confidence add must not be reported as a false success) ──
+    // The Add* service skips persistence when confidence < LongTermMemoryOptions.MinConfidenceThreshold.
+    // The MCP add tools must surface that as persisted == false + a non-empty reason, rather than a
+    // silent "success" that returns the (un-stored) record verbatim.
+
+    private IOptions<LongTermMemoryOptions> Threshold(double minConfidence) =>
+        Options.Create(new LongTermMemoryOptions { MinConfidenceThreshold = minConfidence });
+
+    [Fact]
+    public async Task MemoryAddEntity_BelowThreshold_ReturnsPersistedFalseWithReason()
+    {
+        // Service returns the input unchanged (mirrors the skip path returning the un-stored record).
+        _longTermMemory.AddEntityAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<Entity>());
+
+        var result = await CoreMemoryTools.MemoryAddEntity(
+            _longTermMemory, _idGenerator, _clock, _options, Threshold(0.5),
+            "Faint", "Person", confidence: 0.3);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("reason").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task MemoryAddPreference_BelowThreshold_ReturnsPersistedFalseWithReason()
+    {
+        _longTermMemory.AddPreferenceAsync(Arg.Any<Preference>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<Preference>());
+
+        var result = await CoreMemoryTools.MemoryAddPreference(
+            _longTermMemory, _idGenerator, _clock, _options, Threshold(0.5),
+            "style", "maybe dark mode", confidence: 0.3);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("reason").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task MemoryAddFact_BelowThreshold_ReturnsPersistedFalseWithReason()
+    {
+        _longTermMemory.AddFactAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<Fact>());
+
+        var result = await CoreMemoryTools.MemoryAddFact(
+            _longTermMemory, _idGenerator, _clock, _options, Threshold(0.5),
+            "Alice", "maybe_works_at", "Microsoft", confidence: 0.3);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("reason").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Theory]
+    [InlineData(0.5)]  // boundary: equal to threshold persists (gate is strict <)
+    [InlineData(0.9)]
+    public async Task MemoryAddFact_AtOrAboveThreshold_ReturnsPersistedTrueWithoutReason(double confidence)
+    {
+        _longTermMemory.AddFactAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<Fact>());
+
+        var result = await CoreMemoryTools.MemoryAddFact(
+            _longTermMemory, _idGenerator, _clock, _options, Threshold(0.5),
+            "Alice", "works_at", "Microsoft", confidence: confidence);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeTrue();
+        doc.RootElement.TryGetProperty("reason", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MemoryAddFact_DefaultConfidence_PersistsAgainstDefaultThreshold()
+    {
+        // No explicit confidence → DefaultConfidence (0.9); default threshold (0.5) → persisted.
+        _longTermMemory.AddFactAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<Fact>());
+
+        var result = await CoreMemoryTools.MemoryAddFact(
+            _longTermMemory, _idGenerator, _clock, _options, _longTermOptions,
+            "Alice", "works_at", "Microsoft");
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("persisted").GetBoolean().Should().BeTrue();
+        doc.RootElement.TryGetProperty("reason", out _).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## R5 #1 — MCP add tools report false success when a sub-threshold add is silently dropped

### Problem
PR #38 wired `LongTermMemoryOptions.MinConfidenceThreshold`: the `Add*` service layer **skips persistence** for any item whose confidence is below the threshold and returns the (un-stored) record. The three MCP add tools — `memory_add_entity`, `memory_add_preference`, `memory_add_fact` — serialized that returned record verbatim, so the caller saw a normal, populated response. **A low-confidence add looked like a success even though nothing was stored.** This is a confirmed regression introduced by our own #38 fix (root-cause class 2 from the Round 5 analysis: a prior fix changed behavior but its consumer was never audited).

### Fix
- Compute the effective confidence exactly once (`confidence ?? options.Value.DefaultConfidence`), stamp the record with it, and reuse that single value to evaluate the gate.
- Mirror the service's strict-`<` skip: emit `persisted` (bool) and `reason` (string; null/omitted when persisted) on every add response.
- Deliberately use the **stamped** confidence, not `result.Confidence` — the dedup/reinforce path can raise the stored confidence and would otherwise mask a genuine skip.

### Why this fix introduces no new problem
- Additive output fields only; no existing field renamed/removed. `reason` is omitted on the happy path (`WhenWritingNull`), so existing consumers that read `entityId`/`confidence`/etc. are unaffected.
- The predicate is a pure function of (stamped confidence, threshold) and exactly mirrors the service gate — it cannot disagree with what the service actually did.

### Tests
- Below-threshold (`0.3` vs `0.5`) → `persisted == false` + non-empty `reason`, for entity / preference / fact.
- Boundary `0.5` and `0.9`, plus default-confidence → `persisted == true`, `reason` **absent** (`TryGetProperty == false`).
- The three existing `ReturnsJson` add-tests now also assert `persisted == true`.
- Full file: 26/26 green; project builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)