### PR TITLE
fix(neo4j): align Fact UpsertBatch MERGE key with single-upsert triple (R5 #10)

### DIFF
--- a/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
@@ -45,7 +45,14 @@ public interface IFactRepository
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Adds or updates a batch of facts atomically.</summary>
+    /// <summary>
+    /// Adds or updates a batch of facts atomically. Facts are merged by their {subject, predicate, object}
+    /// triple scoped per owner — the same idempotency key as the single-fact upsert — so duplicate triples
+    /// (whether repeated within the batch or already in the store) collapse onto one node rather than
+    /// creating duplicates. The returned list is therefore deduplicated by triple: same-triple inputs are
+    /// folded to the last occurrence, and each returned fact carries the surviving node's stable id (the
+    /// first-created id, never a re-extraction's fresh id).
+    /// </summary>
     Task<IReadOnlyList<Fact>> UpsertBatchAsync(IReadOnlyList<Fact> facts, CancellationToken cancellationToken = default);
 
     /// <summary>Creates an EXTRACTED_FROM relationship from a fact to a source message.</summary>

--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -37,16 +37,22 @@ public static class FactQueries
 
     // ── UpsertBatchAsync ───────────────────────────────────────────────
 
-    /// <summary>Batch merge facts by id via UNWIND.</summary>
+    /// <summary>
+    /// Batch merge facts by the {subject, predicate, object, owner_key} triple via UNWIND — the SAME
+    /// idempotency key as the single-fact <see cref="Upsert"/> path, so both surfaces collapse duplicate
+    /// triples identically (R5 #10; previously this MERGEd on {id}, which let a re-extracted triple with a
+    /// fresh id create a second node). Like the single path: <c>id</c> is set ON CREATE only (a matched node
+    /// keeps its original primary key); subject/predicate/object/owner_id are immutable once set (they are
+    /// the merge key or a function of it); valid_from/valid_until are coalesced on ON MATCH (preserve
+    /// existing when incoming is null, so re-extraction never clears a supersession window); and
+    /// invalidated_at is reset on re-assert (a present-time positive assertion restores live recall).
+    /// </summary>
     public const string UpsertBatch = @"
             UNWIND $items AS item
-            MERGE (f:Fact {id: item.id})
+            MERGE (f:Fact {subject: item.subject, predicate: item.predicate, object: item.object, owner_key: item.owner_key})
             ON CREATE SET
-                f.subject            = item.subject,
-                f.predicate          = item.predicate,
-                f.object             = item.object,
+                f.id                 = item.id,
                 f.owner_id           = item.owner_id,
-                f.owner_key          = item.owner_key,
                 f.category           = item.category,
                 f.confidence         = item.confidence,
                 f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE null END,
@@ -55,15 +61,14 @@ public static class FactQueries
                 f.created_at         = datetime(item.created_at),
                 f.metadata           = item.metadata
             ON MATCH SET
-                f.subject            = item.subject,
-                f.predicate          = item.predicate,
-                f.object             = item.object,
                 f.category           = item.category,
                 f.confidence         = item.confidence,
-                f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE null END,
-                f.valid_until        = CASE WHEN item.valid_until IS NOT NULL THEN datetime(item.valid_until) ELSE null END,
+                f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE f.valid_from END,
+                f.valid_until        = CASE WHEN item.valid_until IS NOT NULL THEN datetime(item.valid_until) ELSE f.valid_until END,
                 f.source_message_ids = item.source_message_ids,
-                f.metadata           = item.metadata
+                f.updated_at         = datetime(item.updated_at),
+                f.metadata           = item.metadata,
+                f.invalidated_at     = null
             RETURN f";
 
     // ── GetByIdAsync ───────────────────────────────────────────────────

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -103,7 +103,18 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         _logger.LogDebug("Batch upserting {Count} facts", facts.Count);
 
-        var items = facts.Select(f => new Dictionary<string, object?>
+        // The query MERGEs on the {subject,predicate,object,owner_key} triple (parity with the single
+        // Upsert path). Collapse same-triple inputs up front (last-writer-wins) so each surviving node is
+        // fed by exactly one input: otherwise two inputs sharing a triple MERGE onto one node, leaving the
+        // loser id naming nothing and silently dropping its embedding/EXTRACTED_FROM. After dedup the
+        // returned list is 1:1 with distinct triples and provenance is deterministic (R5 #10).
+        var deduped = facts
+            .GroupBy(f => TripleKey(f.Subject, f.Predicate, f.Object, f.OwnerId ?? OwnerKeyShared))
+            .Select(g => g.Last())
+            .ToList();
+
+        var updatedAt = DateTimeOffset.UtcNow.ToString("O");
+        var items = deduped.Select(f => new Dictionary<string, object?>
         {
             ["id"]                = f.FactId,
             ["subject"]           = f.Subject,
@@ -117,6 +128,7 @@ public sealed class Neo4jFactRepository : IFactRepository
             ["valid_until"]       = (object?)(f.ValidUntil?.ToString("O")),
             ["source_message_ids"] = f.SourceMessageIds.ToList(),
             ["created_at"]        = f.CreatedAtUtc.ToString("O"),
+            ["updated_at"]        = updatedAt,
             ["metadata"]          = SerializeMetadata(f.Metadata)
         }).ToList();
 
@@ -125,32 +137,50 @@ public sealed class Neo4jFactRepository : IFactRepository
             var cursor = await runner.RunAsync(FactQueries.UpsertBatch, new { items });
             var records = await cursor.ToListAsync();
 
-            // Set embeddings individually — only for nodes with a real (non-empty) vector.
-            foreach (var fact in facts.Where(f => f.Embedding is { Length: > 0 }))
+            // The MERGE returns the SURVIVING node per triple; for a pre-existing triple that id is the
+            // ORIGINAL node id, not the caller's fresh FactId. Resolve the embedding/provenance sub-writes
+            // by triple so they land on the real node — mirroring the single-path mergedId fix (R5-A);
+            // keying them on fact.FactId would silently no-op whenever the triple already existed.
+            var nodeIdByTriple = new Dictionary<(string, string, string, string), string>();
+            foreach (var r in records)
             {
+                var n = r["f"].As<INode>();
+                nodeIdByTriple[TripleKey(n["subject"].As<string>(), n["predicate"].As<string>(),
+                                         n["object"].As<string>(), n["owner_key"].As<string>())] = n["id"].As<string>();
+            }
+
+            string? NodeIdFor(Fact f) =>
+                nodeIdByTriple.TryGetValue(
+                    TripleKey(f.Subject, f.Predicate, f.Object, f.OwnerId ?? OwnerKeyShared), out var nodeId)
+                    ? nodeId : null;
+
+            // Set embeddings individually — only for nodes with a real (non-empty) vector.
+            foreach (var fact in deduped.Where(f => f.Embedding is { Length: > 0 }))
+            {
+                if (NodeIdFor(fact) is not { } nodeId) continue;
                 await runner.RunAsync(
                     SharedFragments.SetFactEmbedding,
-                    new { id = fact.FactId, embedding = fact.Embedding!.ToList() });
+                    new { id = nodeId, embedding = fact.Embedding!.ToList() });
             }
 
-            // Auto-create EXTRACTED_FROM relationships
-            var factsWithSources = facts.Where(f => f.SourceMessageIds.Count > 0).ToList();
-            if (factsWithSources.Count > 0)
+            // Auto-create EXTRACTED_FROM relationships on the surviving node.
+            foreach (var fact in deduped.Where(f => f.SourceMessageIds.Count > 0))
             {
-                foreach (var fact in factsWithSources)
-                {
-                    await runner.RunAsync(
-                        SharedFragments.LinkFactExtractedFrom,
-                        new { id = fact.FactId, sourceMessageIds = fact.SourceMessageIds.ToList() });
-                }
+                if (NodeIdFor(fact) is not { } nodeId) continue;
+                await runner.RunAsync(
+                    SharedFragments.LinkFactExtractedFrom,
+                    new { id = nodeId, sourceMessageIds = fact.SourceMessageIds.ToList() });
             }
 
-            var embeddingMap = facts.ToDictionary(f => f.FactId, f => f.Embedding);
+            var embeddingByTriple = deduped.ToDictionary(
+                f => TripleKey(f.Subject, f.Predicate, f.Object, f.OwnerId ?? OwnerKeyShared),
+                f => f.Embedding);
             return records.Select(r =>
             {
                 var node = r["f"].As<INode>();
-                var id   = node["id"].As<string>();
-                return MapToFact(node, embeddingMap.TryGetValue(id, out var emb) ? emb : null);
+                var key  = TripleKey(node["subject"].As<string>(), node["predicate"].As<string>(),
+                                     node["object"].As<string>(), node["owner_key"].As<string>());
+                return MapToFact(node, embeddingByTriple.TryGetValue(key, out var emb) ? emb : null);
             }).ToList();
         }, cancellationToken);
     }
@@ -313,6 +343,13 @@ public sealed class Neo4jFactRepository : IFactRepository
                 new { conversationId, factId });
         }, cancellationToken);
     }
+
+    // The Fact idempotency key: the SPO triple scoped by owner_key (shared vs owned facts stay distinct, R1).
+    // String components compare ordinally — matching Neo4j's exact-string MERGE — so the same triple maps to
+    // the same surviving node both in the database and in the repository's by-triple lookups.
+    private static (string, string, string, string) TripleKey(
+        string subject, string predicate, string @object, string ownerKey)
+        => (subject, predicate, @object, ownerKey);
 
     private static Fact MapToFact(INode node, float[]? embedding) =>
         new()

--- a/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/FactRepositoryIntegrationTests.cs
@@ -244,6 +244,108 @@ public class FactRepositoryIntegrationTests : IAsyncLifetime
             .Which.Category.Should().Be("personal");
     }
 
+    // ── R5 #10: batch path collapses duplicate triples like the single path ──
+
+    private async Task<long> CountTripleAsync(string subject, string predicate, string @object) =>
+        await _fixture.TransactionRunner.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(
+                "MATCH (f:Fact {subject: $s, predicate: $p, object: $o}) RETURN count(f) AS c",
+                new { s = subject, p = predicate, o = @object });
+            var records = await cursor.ToListAsync();
+            return global::Neo4j.Driver.ValueExtensions.As<long>(records[0]["c"]);
+        });
+
+    [Fact]
+    public async Task UpsertBatchAsync_SameTripleDifferentIds_CollapsesToOneNode()
+    {
+        var subject = $"Subj-{Guid.NewGuid():N}";
+        await _repo.UpsertBatchAsync(new[]
+        {
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.8, CreatedAtUtc = DateTimeOffset.UtcNow },
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow },
+        });
+
+        (await CountTripleAsync(subject, "works_at", "Neo4j")).Should().Be(1,
+            "the batch path must merge same-triple inputs onto one node, like the single path");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_SameTripleDifferentOwners_ProducesDistinctNodes()
+    {
+        var subject = $"Subj-{Guid.NewGuid():N}";
+        await _repo.UpsertBatchAsync(new[]
+        {
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = subject, Predicate = "works_at", Object = "Neo4j", OwnerId = "alice", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow },
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = subject, Predicate = "works_at", Object = "Neo4j", OwnerId = "bob",   Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow },
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = subject, Predicate = "works_at", Object = "Neo4j", OwnerId = null,    Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow },
+        });
+
+        (await CountTripleAsync(subject, "works_at", "Neo4j")).Should().Be(3,
+            "owner_key keeps the same triple distinct per owner (and for shared/null), parity with the single path");
+    }
+
+    [Fact]
+    public async Task CrossPath_SingleThenBatch_SameTriple_NoDuplicate_KeepsOriginalId()
+    {
+        var subject = $"Subj-{Guid.NewGuid():N}";
+        var idA = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idA, Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        // Re-extract the SAME triple via the BATCH surface with a fresh id.
+        var idB = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertBatchAsync(new[]
+        {
+            new Fact { FactId = idB, Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.95, CreatedAtUtc = DateTimeOffset.UtcNow },
+        });
+
+        (await CountTripleAsync(subject, "works_at", "Neo4j")).Should().Be(1, "no duplicate across single+batch surfaces");
+        (await _repo.GetByIdAsync(idA)).Should().NotBeNull("the original node id must survive the batch re-upsert");
+        (await _repo.GetByIdAsync(idB)).Should().BeNull("the batch's fresh id must never become the node's id");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_ReExtractSupersededTriple_DoesNotClearValidUntil()
+    {
+        // Mirror the single-path bitemporal test via the batch surface: the ON MATCH must COALESCE
+        // valid_until (preserve the supersession window), not overwrite it to null.
+        var loserId = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = loserId, Subject = "Carol", Predicate = "lives_in", Object = "Paris", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+        var winnerId = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = winnerId, Subject = "Carol", Predicate = "lives_in", Object = "London", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+        (await _repo.SupersedeAsync(loserId, winnerId, scope: null)).Should().BeTrue();
+        (await HasValidUntilAsync(loserId)).Should().BeTrue();
+
+        await _repo.UpsertBatchAsync(new[]
+        {
+            new Fact { FactId = $"fact-{Guid.NewGuid():N}", Subject = "Carol", Predicate = "lives_in", Object = "Paris", Confidence = 0.95, CreatedAtUtc = DateTimeOffset.UtcNow },
+        });
+
+        (await HasValidUntilAsync(loserId)).Should().BeTrue(
+            "re-extracting a superseded triple via the batch path must NOT clear the valid_until supersession stamped");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_ReExtractWithEmbedding_LandsOnSurvivingNode_NotDiscardedId()
+    {
+        // The key R5-A-class proof for the batch path: when the triple already exists (id A, no vector),
+        // a batch re-upsert carrying a fresh id B AND a real embedding must write the vector onto node A —
+        // not the discarded id B. Keying the sub-write on the caller id would silently no-op here.
+        var subject = $"Subj-{Guid.NewGuid():N}";
+        var idA = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertAsync(new Fact { FactId = idA, Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow });
+
+        var idB = $"fact-{Guid.NewGuid():N}";
+        await _repo.UpsertBatchAsync(new[]
+        {
+            new Fact { FactId = idB, Subject = subject, Predicate = "works_at", Object = "Neo4j", Confidence = 0.95, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow },
+        });
+
+        var hits = await _repo.SearchByVectorAsync(QueryEmbedding, limit: 5);
+        hits.Select(h => h.Fact.FactId).Should().Contain(idA,
+            "the batch re-upsert's embedding must land on the surviving node so the fact becomes vector-searchable");
+    }
+
     [Fact]
     public async Task UpsertAsync_NullCategory_RoundTripsAsNull()
     {

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
@@ -328,13 +328,10 @@ MERGE (f:Fact {subject: $subject, predicate: $predicate, object: $object, owner_
 
 ## FactQueries.UpsertBatch
 UNWIND $items AS item
-            MERGE (f:Fact {id: item.id})
+            MERGE (f:Fact {subject: item.subject, predicate: item.predicate, object: item.object, owner_key: item.owner_key})
             ON CREATE SET
-                f.subject            = item.subject,
-                f.predicate          = item.predicate,
-                f.object             = item.object,
+                f.id                 = item.id,
                 f.owner_id           = item.owner_id,
-                f.owner_key          = item.owner_key,
                 f.category           = item.category,
                 f.confidence         = item.confidence,
                 f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE null END,
@@ -343,15 +340,14 @@ UNWIND $items AS item
                 f.created_at         = datetime(item.created_at),
                 f.metadata           = item.metadata
             ON MATCH SET
-                f.subject            = item.subject,
-                f.predicate          = item.predicate,
-                f.object             = item.object,
                 f.category           = item.category,
                 f.confidence         = item.confidence,
-                f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE null END,
-                f.valid_until        = CASE WHEN item.valid_until IS NOT NULL THEN datetime(item.valid_until) ELSE null END,
+                f.valid_from         = CASE WHEN item.valid_from IS NOT NULL THEN datetime(item.valid_from) ELSE f.valid_from END,
+                f.valid_until        = CASE WHEN item.valid_until IS NOT NULL THEN datetime(item.valid_until) ELSE f.valid_until END,
                 f.source_message_ids = item.source_message_ids,
-                f.metadata           = item.metadata
+                f.updated_at         = datetime(item.updated_at),
+                f.metadata           = item.metadata,
+                f.invalidated_at     = null
             RETURN f
 
 ## MessageQueries.Add

--- a/tests/AgentMemory.Tests.Unit/Repositories/Neo4jFactRepositoryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Repositories/Neo4jFactRepositoryTests.cs
@@ -1,8 +1,10 @@
+using System.Collections;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Neo4j.Infrastructure;
 using AgentMemory.Neo4j.Repositories;
+using AgentMemory.Tests.Unit.TestHelpers;
 using Neo4j.Driver;
 using NSubstitute;
 
@@ -48,14 +50,57 @@ public sealed class Neo4jFactRepositoryTests
                     .RunAsync(Arg.Any<string>(), Arg.Any<object>())
                     .Returns(ci =>
                     {
-                        calls.Add((ci.Arg<string>(), ci.ArgAt<object>(1)));
-                        var cursor = Substitute.For<IResultCursor>();
-                        cursor.FetchAsync().Returns(Task.FromResult(false));
+                        var cypher = ci.Arg<string>();
+                        var parameters = ci.ArgAt<object>(1);
+                        calls.Add((cypher, parameters));
+                        // Echo the merged nodes back for the UNWIND batch query, as real Neo4j does (one
+                        // RETURN row per surviving triple). The repository resolves each node's id from this
+                        // result to target its embedding/EXTRACTED_FROM sub-writes; an empty cursor would make
+                        // those sub-writes silently skip, hiding regressions.
+                        IResultCursor cursor = cypher.Contains("UNWIND $items")
+                            ? new FakeResultCursor(BuildMergedFactRecords(parameters))
+                            : new FakeResultCursor();
                         return Task.FromResult(cursor);
                     });
                 return await work(runner);
             });
         return (new Neo4jFactRepository(txRunner, NullLogger<Neo4jFactRepository>.Instance), calls);
+    }
+
+    // Builds one IRecord per UNWIND item, simulating the MERGE's "RETURN f" of the surviving node. Same-
+    // triple items are collapsed by the repository BEFORE the query runs, so each item here is already a
+    // distinct triple; the node simply echoes the item's key/identity properties.
+    private static IRecord[] BuildMergedFactRecords(object parameters)
+    {
+        var itemsObj = parameters.GetType().GetProperty("items")!.GetValue(parameters);
+        return ((IEnumerable)itemsObj!).Cast<IDictionary<string, object?>>()
+            .Select(BuildMergedFactRecord).ToArray();
+    }
+
+    private static IRecord BuildMergedFactRecord(IDictionary<string, object?> item)
+    {
+        object Val(string key) => item[key]!;
+        var node = Substitute.For<INode>();
+        node["id"].Returns(Val("id"));
+        node["subject"].Returns(Val("subject"));
+        node["predicate"].Returns(Val("predicate"));
+        node["object"].Returns(Val("object"));
+        node["owner_key"].Returns(Val("owner_key"));
+        node["confidence"].Returns(Val("confidence"));
+        node["created_at"].Returns(Val("created_at"));
+        node.Properties.Returns(new Dictionary<string, object>
+        {
+            ["id"]        = Val("id"),
+            ["subject"]   = Val("subject"),
+            ["predicate"] = Val("predicate"),
+            ["object"]    = Val("object"),
+            ["owner_key"] = Val("owner_key"),
+            ["confidence"] = Val("confidence"),
+            ["created_at"] = Val("created_at"),
+        });
+        var record = Substitute.For<IRecord>();
+        record["f"].Returns(node);
+        return record;
     }
 
     // ── CreateAboutRelationshipAsync ──
@@ -206,5 +251,100 @@ public sealed class Neo4jFactRepositoryTests
         var first = (IDictionary<string, object?>)items.Cast<object>().First();
         first.Should().ContainKey("category");
         first["category"].Should().Be("professional");
+    }
+
+    // ── R5 #10: batch MERGE key aligned with the single-upsert triple ──
+
+    private static Fact MakeFact(string id, string subject, string predicate, string @object,
+        string? ownerId = null) => new()
+        {
+            FactId = id, Subject = subject, Predicate = predicate, Object = @object,
+            OwnerId = ownerId, Confidence = 0.9, SourceMessageIds = Array.Empty<string>(),
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task UpsertBatchAsync_MergesOnTriple_NotOnId()
+    {
+        var (repo, calls) = CreateFactBatchWriteCapture();
+
+        await repo.UpsertBatchAsync(new[] { MakeFact("f1", "Alice", "works_at", "Neo4j") });
+
+        // Same idempotency key as the single Upsert path; must NOT merge on the (re-extraction-volatile) id.
+        calls[0].Cypher.Should().Contain(
+            "MERGE (f:Fact {subject: item.subject, predicate: item.predicate, object: item.object, owner_key: item.owner_key})");
+        calls[0].Cypher.Should().NotContain("MERGE (f:Fact {id:");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_SetsIdOnCreateOnly_NeverOnMatch()
+    {
+        var (repo, calls) = CreateFactBatchWriteCapture();
+
+        await repo.UpsertBatchAsync(new[] { MakeFact("f1", "Alice", "works_at", "Neo4j") });
+
+        var cypher = calls[0].Cypher;
+        cypher.Should().MatchRegex(@"ON CREATE SET[\s\S]*f\.id\s+=\s+item\.id");
+        // f.id must not be rewritten on a match — a matched triple keeps its original primary key.
+        var onMatch = cypher[cypher.IndexOf("ON MATCH SET", StringComparison.Ordinal)..];
+        onMatch.Should().NotContain("f.id");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_CoalescesValidWindow_OnMatch_AndStampsUpdatedAt()
+    {
+        var (repo, calls) = CreateFactBatchWriteCapture();
+
+        await repo.UpsertBatchAsync(new[] { MakeFact("f1", "Alice", "works_at", "Neo4j") });
+
+        var onMatch = calls[0].Cypher[calls[0].Cypher.IndexOf("ON MATCH SET", StringComparison.Ordinal)..];
+        // Preserve existing valid-time window when the incoming value is null (parity with single path),
+        // rather than the old behaviour that overwrote it to null.
+        onMatch.Should().Contain("ELSE f.valid_from");
+        onMatch.Should().Contain("ELSE f.valid_until");
+        onMatch.Should().Contain("f.updated_at         = datetime(item.updated_at)");
+        // And the per-item map must carry updated_at so datetime(item.updated_at) is non-null at runtime.
+        var parameters = calls[0].Parameters!;
+        var items = (IEnumerable<object>)parameters.GetType().GetProperty("items")!.GetValue(parameters)!;
+        ((IDictionary<string, object?>)items.Cast<object>().First()).Should().ContainKey("updated_at");
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_CollapsesSameTripleInputs_ToSingleItem_AndReturnsOne()
+    {
+        var (repo, calls) = CreateFactBatchWriteCapture();
+
+        // Two inputs, same triple+owner, different ids — must collapse to one UNWIND item and one result.
+        var result = await repo.UpsertBatchAsync(new[]
+        {
+            MakeFact("f-first",  "Alice", "works_at", "Neo4j"),
+            MakeFact("f-second", "Alice", "works_at", "Neo4j"),
+        });
+
+        var parameters = calls[0].Parameters!;
+        var items = ((IEnumerable)parameters.GetType().GetProperty("items")!.GetValue(parameters)!).Cast<object>().ToList();
+        items.Should().ContainSingle("same-triple inputs must be de-duplicated before the UNWIND");
+        // Last-writer-wins: the surviving item keeps the last occurrence's id.
+        ((IDictionary<string, object?>)items[0])["id"].Should().Be("f-second");
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsync_SameTripleDifferentOwners_ProducesDistinctItems()
+    {
+        var (repo, calls) = CreateFactBatchWriteCapture();
+
+        var result = await repo.UpsertBatchAsync(new[]
+        {
+            MakeFact("f-alice", "Alice", "works_at", "Neo4j", ownerId: "alice"),
+            MakeFact("f-bob",   "Alice", "works_at", "Neo4j", ownerId: "bob"),
+            MakeFact("f-shared", "Alice", "works_at", "Neo4j", ownerId: null),
+        });
+
+        var parameters = calls[0].Parameters!;
+        var items = ((IEnumerable)parameters.GetType().GetProperty("items")!.GetValue(parameters)!).Cast<object>().ToList();
+        // owner_key segregates the same triple per owner — none collapse.
+        items.Should().HaveCount(3);
+        result.Should().HaveCount(3);
     }
 }


### PR DESCRIPTION
## R5 #10 — `FactQueries.UpsertBatch` merged on `{id}` while the single path merges on the triple

### The divergence
The single-fact `Upsert` MERGEs on the `{subject, predicate, object, owner_key}` triple; the batch path MERGEd on `{id}`. So the two surfaces disagreed on *what a fact is*: re-extracting an existing triple through the batch path — which mints a fresh `FactId` per extraction — created a **second node** for the same fact, the exact duplicate the single path is designed to prevent. This is the last facet of the Round 5 "Fact triple-MERGE hazard family" (siblings #3/#5 were the single-path `mergedId` fix shipped in #54).

### The fix
Align the batch query to the triple, matching the single path **exactly**:
- `id` set **ON CREATE only** — a matched node keeps its stable primary key (the by-id handle callers hold stays valid).
- `subject/predicate/object/owner_id` dropped from `ON MATCH` (they're the merge key or a function of it).
- `valid_from`/`valid_until` **coalesced** on `ON MATCH` (`ELSE f.valid_*`) — re-extraction no longer wipes a supersession window. This closes a *second* latent divergence the old batch query had (it overwrote them to null).
- `updated_at` stamped and `invalidated_at` reset on `ON MATCH`, for full parity (re-assert restores live recall).

### Guarding against the regression the fix could introduce
Two repository-level hardenings (no public-surface change), each closing a hole that naïvely swapping the MERGE key would open:

1. **Within-batch collapse → input-dedup.** Two inputs sharing a triple would MERGE onto one node, stranding the loser's id with no node and silently dropping its embedding/provenance. Inputs are now de-duplicated by triple up front (last-writer-wins), so the returned list is 1:1 with distinct triples.
2. **Pre-existing-triple sub-writes → resolve by returned node id.** The embedding/`EXTRACTED_FROM` sub-writes now target the **MERGE-returned** node id (resolved by triple), not the caller's `FactId` — mirroring the #54 single-path `mergedId` fix. Without this, a re-extraction's vector/provenance would no-op whenever the triple already existed (the very bug #54 fixed, freshly reintroduced on the batch path).

The fact batch path has **no production callers**; the behaviour change is limited to tests and any direct external consumer, now documented on `IFactRepository.UpsertBatchAsync`.

### Mandatory mitigations from the regression-check — all done
- ✅ **Cypher snapshot regenerated** (`UPDATE_CYPHER_SNAPSHOTS=1`); diff is confined to the `UpsertBatch` block. `ExpectedQueryCount` unchanged at 142.
- ✅ **`updated_at` per-item param added** so `datetime(item.updated_at)` is non-null at runtime (would throw against real Neo4j otherwise — proven by the live integration tests).
- ✅ **Collapse semantics decided & documented** — the defensive option (b): input-dedup + deterministic provenance, documented on the interface.

### Tests
**Unit (5):** triple-MERGE shape (not `{id}`), `id` on-create-only (regex asserts `f.id` absent after `ON MATCH SET`), valid-window coalesce + `updated_at` item, within-batch same-triple collapse to one item, per-owner distinct items. The batch capture mock now echoes merged nodes (as real Neo4j does) so sub-write id-resolution is actually exercised.

**Integration (5, live Neo4j):** same-triple-different-ids collapses to one node; same-triple-different-owners stays 3 distinct; single→batch cross-path no-duplicate keeps the original id; re-extracted superseded triple preserves `valid_until`; **re-extracted embedding lands on the surviving node** (the key proof the sub-writes resolve to the merged id, not the discarded one).

Full unit suite 2629 green; fact integration suite 23 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)