### PR TITLE
fix(agentframework): honor caller cancellation across MAF adapters (R6-A)

### DIFF
--- a/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
@@ -82,6 +82,10 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
                 .Select(MafTypeMapper.ToChatMessage)
                 .ToList();
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex,
@@ -145,12 +149,20 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
                             UserId = userId
                         }, cancellationToken).ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex,
                         "Extraction failed for session {SessionId}; messages were persisted.", sessionId);
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
@@ -44,6 +44,10 @@ public sealed class Neo4jChatMessageStore
                 .AddMessageAsync(message.SessionId, message.ConversationId, message.Role, message.Content, message.Metadata, ct)
                 .ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to add message for session {SessionId}.", sessionId);
@@ -84,6 +88,10 @@ public sealed class Neo4jChatMessageStore
                 .Select(MafTypeMapper.ToChatMessage)
                 .ToList();
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to retrieve messages for session {SessionId}.", sessionId);
@@ -99,6 +107,10 @@ public sealed class Neo4jChatMessageStore
         try
         {
             await _memoryService.ClearSessionAsync(sessionId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -88,6 +88,10 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                     .EmbedQueryAsync(queryText, cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to generate query embedding; proceeding without semantic search.");
@@ -108,6 +112,10 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                     .RecallAsync(recallRequest, cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Memory recall failed for session {SessionId}; returning empty context.", sessionId);
@@ -120,6 +128,10 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                 return new AIContext();
 
             return new AIContext { Messages = contextMessages };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -188,12 +200,20 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                             UserId = userId
                         }, cancellationToken).ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex,
                         "Extraction failed for session {SessionId}; messages were persisted.", sessionId);
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
@@ -68,6 +68,10 @@ public sealed class Neo4jMicrosoftMemoryFacade
                 .Select(MafTypeMapper.ToChatMessage)
                 .ToList();
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to get context for session {SessionId}.", sessionId);
@@ -111,11 +115,19 @@ public sealed class Neo4jMicrosoftMemoryFacade
                             UserId = userId
                         }, ct).ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Extraction failed for session {SessionId}; messages were persisted.", sessionId);
                 }
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -374,6 +374,10 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             };
             return await _graphRag!.GetContextAsync(graphRagRequest, cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "GraphRAG retrieval failed for session {SessionId}", request.SessionId);

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
@@ -172,4 +172,48 @@ public sealed class Neo4jChatMessageStoreTests
 
         await act.Should().NotThrowAsync();
     }
+
+    // ── R6-A: caller cancellation must propagate, not be swallowed as fabricated/empty success ──
+    // Before the OCE guard, a cancelled add returned a fabricated (never-persisted) Message; a cancelled
+    // get/clear returned empty/normally — silently reporting success for a cancelled operation.
+
+    [Fact]
+    public async Task AddMessageAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await _sut.AddMessageAsync(new ChatMessage(ChatRole.User, "Hello"), "s1", "c1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetMessagesAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await _sut.GetMessagesAsync("s1", ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ClearSessionAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.ClearSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await _sut.ClearSessionAsync("s1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -420,4 +420,58 @@ public sealed class Neo4jMemoryContextProviderTests
 
         await act.Should().NotThrowAsync();
     }
+
+    // ── R6-A: caller cancellation must propagate, not be swallowed as empty-context / silent success ──
+    // Before the OCE guards, a cancelled turn surfaced as an empty AIContext (BuildContext) or a silent
+    // "stored" (PerformStore) — the agent ran on no memory / believed a cancelled write succeeded.
+
+    [Fact]
+    public async Task BuildContextAsync_RecallCancelled_PropagatesOperationCanceled()
+    {
+        var sut = CreateSut();
+        var messages = new List<ChatMessage> { new(ChatRole.User, "Tell me about Neo4j.") };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new float[] { 0.5f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await sut.BuildContextAsync(messages, "s1", "c1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_EmbeddingCancelled_PropagatesOperationCanceled()
+    {
+        var sut = CreateSut();
+        var messages = new List<ChatMessage> { new(ChatRole.User, "Tell me about Neo4j.") };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        // The embedding sub-try has its own broad catch; the guard must let cancellation escape rather than
+        // log "proceeding without semantic search" and continue.
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await sut.BuildContextAsync(messages, "s1", "c1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        var sut = CreateSut();
+        var messages = new List<ChatMessage> { new(ChatRole.Assistant, "Important data.") };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await sut.PerformStoreAsync(messages, "s1", "c1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
@@ -177,4 +177,35 @@ public sealed class Neo4jMicrosoftMemoryFacadeTests
 
         await _memoryService.Received(1).ClearSessionAsync("s1", Arg.Any<CancellationToken>());
     }
+
+    // ── R6-A: caller cancellation must propagate, not be swallowed as empty/success ──
+
+    [Fact]
+    public async Task GetContextForRunAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "find relevant history") };
+        var act = async () => await _sut.GetContextForRunAsync(messages, "s1", "c1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task PersistAfterRunAsync_CallerCancels_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _memoryService.AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "Hello") };
+        var act = async () => await _sut.PersistAfterRunAsync(messages, "s1", "c1", ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
@@ -7,6 +7,7 @@ using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Core.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace AgentMemory.Tests.Unit.Services;
 
@@ -182,6 +183,25 @@ public sealed class MemoryContextAssemblerTests
         result.RelevantEntities.Items.Should().BeEmpty();
         result.GraphRagContext.Should().Contain("graph-only context");
         result.BlendMode.Should().Be(RetrievalBlendMode.GraphRagOnly);
+    }
+
+    // R6-A: FetchGraphRagAsync had a broad catch that re-buried the OCE the GraphRAG source deliberately
+    // rethrows on cancellation. In GraphRagOnly mode that swallow was authoritative: a cancelled recall
+    // returned a normal (empty-graph) context instead of honoring cancellation.
+    [Fact]
+    public async Task AssembleContextAsync_GraphRagCancelled_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _graphRag.GetContextAsync(Arg.Any<GraphRagContextRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var options = Options.Create(new MemoryOptions { EnableGraphRag = true });
+        var sut = CreateSut(options: options, graphRag: _graphRag);
+
+        var act = async () => await sut.AssembleContextAsync(
+            CreateRequest(queryEmbedding: null, blendMode: RetrievalBlendMode.GraphRagOnly), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]


### PR DESCRIPTION
## R6-A — the MAF integration layer swallowed every cancellation

The convergence sweep (a deliberately exhaustive re-hunt after 5 rounds) surfaced a coherent, never-hunted **10-site cancellation cluster**: the entire `AgentMemory.AgentFramework` package had **zero** `OperationCanceledException` handling. Every public op wrapped its `IMemoryService`/`IEmbeddingOrchestrator` call in a broad `catch (Exception)` that logged a warning and returned a **fabricated or empty success**:

- a cancelled `AddMessageAsync` returned a freshly-minted, **never-persisted** `Message`;
- a cancelled `GetMessagesAsync`/`ProvideChatHistoryAsync`/`GetContextForRunAsync` returned **empty history** as if authoritative;
- a cancelled `ClearSessionAsync` returned **normally** (looked done);
- a cancelled embedding/recall in `Neo4jMemoryContextProvider` returned an **empty `AIContext`** so the agent ran on no memory.

Prior OCE sweeps (#31/#34/#42/#43/#57) all landed in Core/Extraction/Enrichment — this adapter package, the very integration host a preview showcases, was never covered. (Root-cause class 1: rotating lenses *sample* shapes; this one was never swept here.)

## Fix
The established repo idiom — `catch (OperationCanceledException) when (token.IsCancellationRequested) { throw; }` before each broad catch — applied to all 10 MAF sites plus `MemoryContextAssembler.FetchGraphRagAsync` (which re-buried the OCE the GraphRAG source deliberately rethrows; cancellation was lost in `GraphRagOnly` blend mode).

## Why this introduces no new problem
- Purely additive: a more-specific catch placed before the existing broad catch. Non-cancellation exceptions still hit the broad catch and degrade exactly as before.
- The guard fires **only** when the caller's own token is cancelled (`when (token.IsCancellationRequested)`), so an unrelated/library OCE on a non-cancelled token still degrades gracefully — matching the convention used in 20+ sibling adapters.

## Tests (fail before the guard)
9 trigger-tests asserting a cancelled token propagates `OperationCanceledException` instead of returning fabricated/empty success: `Neo4jChatMessageStore` (Add/Get/Clear), `Neo4jMicrosoftMemoryFacade` (GetContextForRun/PersistAfterRun), `Neo4jMemoryContextProvider` (BuildContext recall-cancel, BuildContext embedding-cancel, PerformStore), and `MemoryContextAssembler` (GraphRagOnly cancel). Affected test classes: 66/66 green; AgentFramework project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)