### PR TITLE
fix(neo4j): exclude soft-invalidated entities from resolution/dedup (R6-B)

### DIFF
--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -135,6 +135,7 @@ public sealed class AdvancedMemoryTools
         const string query = """
             MATCH (a:Entity), (b:Entity)
             WHERE elementId(a) < elementId(b)
+              AND a.invalidated_at IS NULL AND b.invalidated_at IS NULL
               AND NOT (a)-[:SAME_AS]-(b)
               AND (toLower(a.name) CONTAINS toLower(b.name)
                    OR toLower(b.name) CONTAINS toLower(a.name))

--- a/src/AgentMemory.Neo4j/Queries/ConsolidationQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ConsolidationQueries.cs
@@ -59,9 +59,15 @@ public static class ConsolidationQueries
 
     // ── Detect duplicate entities (report only) ──────────────────────────
 
-    /// <summary>Counts redundant entities (per owner+name+type group, all but one). Detection only.</summary>
+    /// <summary>
+    /// Counts redundant entities (per owner+name+type group, all but one). Detection only. Only live
+    /// (not already-invalidated) entities are grouped (<c>invalidated_at IS NULL</c>) — mirroring
+    /// <see cref="CountDuplicatePreferences"/> — so the count reflects what a non-destructive collapse
+    /// would close and does not over-report tombstoned duplicates after decay (R6-B).
+    /// </summary>
     public const string CountDuplicateEntities = @"
             MATCH (e:Entity)
+            WHERE e.invalidated_at IS NULL
             WITH coalesce(e.owner_id, '*') AS ownerKey, toLower(e.name) AS name, e.type AS type, collect(e) AS grp
             WHERE size(grp) >= $minGroupSize
             RETURN coalesce(sum(size(grp) - 1), 0) AS count";

--- a/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
@@ -117,7 +117,10 @@ public static class EntityQueries
         var owner = !hasOwnerFilter ? string.Empty
             : includeShared ? " AND (e.owner_id = $ownerId OR e.owner_id IS NULL)"
                             : " AND e.owner_id = $ownerId";
-        return $"MATCH (e:Entity {{type: $type}}) WHERE true{owner} RETURN e";
+        // Exclude soft-invalidated/superseded entities (R6-B): this is the entity-resolution candidate set,
+        // so a re-extracted entity must not resolve onto (and merge into) a tombstoned node — which would
+        // make the live re-assertion invisible. Mirrors the invalidated_at guard on SearchByVector.
+        return $"MATCH (e:Entity {{type: $type}}) WHERE e.invalidated_at IS NULL{owner} RETURN e";
     }
 
     // ── SearchByNameAsync ──────────────────────────────────────────────
@@ -366,11 +369,13 @@ public static class EntityQueries
         var owner = !hasOwnerFilter ? string.Empty
             : includeShared ? " AND (node.owner_id = $ownerId OR node.owner_id IS NULL)"
                             : " AND node.owner_id = $ownerId";
+        // Exclude soft-invalidated/superseded entities (R6-B) so a "find duplicates of my entity" surface
+        // does not present tombstoned nodes as live duplicate candidates. Mirrors FactQueries.FindDuplicate.
         return $@"
             MATCH (source:Entity {{id: $entityId}}) WHERE source.embedding IS NOT NULL
             CALL db.index.vector.queryNodes('entity_embedding_idx', $topK, source.embedding)
             YIELD node, score
-            WHERE node.id <> $entityId AND score >= $minSimilarity{owner}
+            WHERE node.id <> $entityId AND score >= $minSimilarity AND node.invalidated_at IS NULL{owner}
             RETURN node, score
             ORDER BY score DESC
             LIMIT $limit";

--- a/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
@@ -488,4 +488,61 @@ public class EntityRepositoryIntegrationTests : IAsyncLifetime
         results.Should().Contain(e => e.EntityId == entityPerson.EntityId);
         results.Should().NotContain(e => e.EntityId == entityOrg.EntityId);
     }
+
+    // ── R6-B: tombstoned entities must drop out of the resolution/dedup candidate sets ──
+
+    [Fact]
+    public async Task GetByTypeAsync_ExcludesInvalidatedEntities()
+    {
+        var live = new Entity
+        {
+            EntityId = $"entity-{Guid.NewGuid():N}", Name = "Live Person", Type = "Person",
+            Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        var tombstoned = new Entity
+        {
+            EntityId = $"entity-{Guid.NewGuid():N}", Name = "Tombstoned Person", Type = "Person",
+            Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        await _repo.UpsertAsync(live);
+        await _repo.UpsertAsync(tombstoned);
+        (await _repo.InvalidateAsync(tombstoned.EntityId)).Should().BeTrue();
+
+        var results = await _repo.GetByTypeAsync("Person");
+
+        results.Should().Contain(e => e.EntityId == live.EntityId);
+        results.Should().NotContain(e => e.EntityId == tombstoned.EntityId,
+            "a soft-invalidated entity must not be a resolution candidate (else a re-extracted entity merges into a tombstone)");
+    }
+
+    [Fact]
+    public async Task FindSimilarByEmbeddingAsync_ExcludesInvalidatedCandidates()
+    {
+        var source = new Entity
+        {
+            EntityId = $"entity-{Guid.NewGuid():N}", Name = "Source", Type = "Concept",
+            Confidence = 0.9, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        var liveDup = new Entity
+        {
+            EntityId = $"entity-{Guid.NewGuid():N}", Name = "Live Dup", Type = "Concept",
+            Confidence = 0.9, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        var tombstonedDup = new Entity
+        {
+            EntityId = $"entity-{Guid.NewGuid():N}", Name = "Tombstoned Dup", Type = "Concept",
+            Confidence = 0.9, Embedding = TestEmbedding, CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        await _repo.UpsertAsync(source);
+        await _repo.UpsertAsync(liveDup);
+        await _repo.UpsertAsync(tombstonedDup);
+        (await _repo.InvalidateAsync(tombstonedDup.EntityId)).Should().BeTrue();
+
+        var results = await _repo.FindSimilarByEmbeddingAsync(source.EntityId, minSimilarity: 0.0, limit: 10);
+
+        var ids = results.Select(r => r.Entity.EntityId).ToList();
+        ids.Should().Contain(liveDup.EntityId);
+        ids.Should().NotContain(tombstonedDup.EntityId,
+            "a soft-invalidated entity must not be presented as a live duplicate candidate");
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
@@ -22,6 +22,7 @@ MATCH (c:Conversation)
 
 ## ConsolidationQueries.CountDuplicateEntities
 MATCH (e:Entity)
+            WHERE e.invalidated_at IS NULL
             WITH coalesce(e.owner_id, '*') AS ownerKey, toLower(e.name) AS name, e.type AS type, collect(e) AS grp
             WHERE size(grp) >= $minGroupSize
             RETURN coalesce(sum(size(grp) - 1), 0) AS count

--- a/tests/AgentMemory.Tests.Unit/Queries/ScopedNonVectorReadQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/ScopedNonVectorReadQueryTests.cs
@@ -31,7 +31,9 @@ public sealed class ScopedNonVectorReadQueryTests
     public void GetByType_ScopedExcludeShared_MatchesOwnerOnly()
     {
         var cypher = EntityQueries.GetByType(hasOwnerFilter: true, includeShared: false);
-        cypher.Should().Contain("e.owner_id = $ownerId").And.NotContain("IS NULL");
+        // The OWNER clause must be own-only (no shared-OR). Assert specifically against the owner predicate,
+        // not a bare "IS NULL" — the query also carries the R6-B `e.invalidated_at IS NULL` live-set guard.
+        cypher.Should().Contain("e.owner_id = $ownerId").And.NotContain("owner_id IS NULL");
     }
 
     // ── EntityQueries.FindSimilarByEmbedding (dedup) ──
@@ -54,7 +56,9 @@ public sealed class ScopedNonVectorReadQueryTests
     public void FindSimilarByEmbedding_ScopedExcludeShared_MatchesOwnerOnly()
     {
         var cypher = EntityQueries.FindSimilarByEmbedding(hasOwnerFilter: true, includeShared: false);
-        cypher.Should().Contain("node.owner_id = $ownerId").And.NotContain("IS NULL");
+        // Own-only owner clause (no shared-OR). Assert against the owner predicate specifically — the query
+        // also carries the R6-B `node.invalidated_at IS NULL` live-candidate guard.
+        cypher.Should().Contain("node.owner_id = $ownerId").And.NotContain("owner_id IS NULL");
     }
 
     // ── EntityQueries.SearchByNameFiltered (name search) ──

--- a/tests/AgentMemory.Tests.Unit/Queries/TemporalAndDecayQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/TemporalAndDecayQueryTests.cs
@@ -192,4 +192,31 @@ public sealed class DecayQueryTests
         DecayQueries.PrunePreferences(hasOwnerFilter: true).Should().Contain("p.owner_id = $ownerId");
         DecayQueries.PrunePreferences(hasOwnerFilter: false).Should().NotContain("owner_id");
     }
+
+    // ── R6-B: entity read/dedup/consolidation queries must exclude soft-invalidated nodes ──
+    // The resolution candidate set (GetByType) and dedup candidates (FindSimilarByEmbedding) must not
+    // surface tombstoned entities, or a re-extracted entity resolves into a dead node and goes invisible.
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void EntityGetByType_ExcludesInvalidated(bool hasOwner, bool includeShared)
+        => EntityQueries.GetByType(hasOwner, includeShared)
+            .Should().Contain("e.invalidated_at IS NULL");
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void EntityFindSimilarByEmbedding_ExcludesInvalidated(bool hasOwner, bool includeShared)
+        => EntityQueries.FindSimilarByEmbedding(hasOwner, includeShared)
+            .Should().Contain("node.invalidated_at IS NULL");
+
+    [Fact]
+    public void CountDuplicateEntities_ExcludesInvalidated_LikeItsPreferenceSibling()
+    {
+        ConsolidationQueries.CountDuplicateEntities.Should().Contain("e.invalidated_at IS NULL");
+        ConsolidationQueries.CountDuplicatePreferences.Should().Contain("p.invalidated_at IS NULL");
+    }
 }


### PR DESCRIPTION
## R6-B — the `invalidated_at IS NULL` guard was never swept onto the Entity resolution path

The Fact and Preference live-recall/dedup queries all filter `invalidated_at IS NULL`, and so does `EntityQueries.SearchByVector` — but the Entity **resolution** and **dedup** queries never got it. So a tombstoned (soft-invalidated / superseded) entity stayed a live candidate. This is the same shape prior rounds fixed for Fact/Preference (`FactQueries.FindDuplicate` in #33), never swept onto Entity.

### Sites fixed (shape swept to exhaustion)
| Query | Path | Impact |
|---|---|---|
| `EntityQueries.GetByType` | resolution candidate set (`CompositeEntityResolver`) | a re-extracted entity could **resolve onto and merge into a tombstone**, making the live re-assertion invisible |
| `EntityQueries.FindSimilarByEmbedding` | "find duplicates of my entity" | presented tombstoned nodes as **live duplicate candidates** |
| `ConsolidationQueries.CountDuplicateEntities` | report-only dup count | over-reported tombstoned dups after decay; its **Preference sibling already filtered** — the asymmetry was the tell |
| `AdvancedMemoryTools.memory_find_duplicates` (inline) | MCP report | suggested tombstoned entities as duplicates |

All four now exclude `invalidated_at IS NULL`, mirroring `SearchByVector`/`FactQueries.FindDuplicate`.

### Deliberate scope boundaries (the exhaustion call)
- **`EntityQueries.GetByName` left unscoped** — it's a general-purpose by-name lookup, *not* a resolution/recall candidate path (the resolver uses only `GetByType`). Filtering there would be an unforced behavior change with no confirmed defect.
- **Entity `Upsert` ON MATCH `invalidated_at = null` reset deliberately NOT included.** That's the Fact R5-A mirror, but Entity MERGEs on `{id}` (not a triple), so re-assert-by-same-id is rare and overlaps the merge/supersede *loser* flow — it needs its own consumer audit before changing. Calling it out rather than silently doing it.

### Regression-safety
Additive `WHERE` predicates only; no query removed/renamed. The two static builders (`GetByType`, `FindSimilarByEmbedding`) are excluded from the Cypher snapshot inventory; the one const (`CountDuplicateEntities`) regenerated the snapshot — **diff is exactly one line**, `ExpectedQueryCount` unchanged.

### Tests
- **Unit (shape):** `GetByType`/`FindSimilarByEmbedding` contain the predicate across all owner/shared combos; `CountDuplicateEntities` matches its Preference sibling.
- **Integration (live Neo4j, trigger-tests):** a soft-invalidated entity is **absent** from both the `GetByType` and `FindSimilarByEmbedding` candidate sets, while the live sibling is present.

Unit shape+snapshot: 580 green. Entity integration suite: 24 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)