### PR TITLE
fix(context): keep newest messages, not oldest, on truncation (R6-D)

### DIFF
--- a/src/AgentMemory.AgentFramework/Mapping/MafTypeMapper.cs
+++ b/src/AgentMemory.AgentFramework/Mapping/MafTypeMapper.cs
@@ -106,10 +106,13 @@ internal static class MafTypeMapper
             memory.Add(new ChatMessage(ChatRole.System, context.GraphRagContext));
 
         // Fill the budget left over after the always-kept lead + memory with the MOST RECENT chat
-        // messages. Order is preserved (lead → chat → memory), matching the original layout.
+        // messages. chatMessages is newest-first (RecentMessages.Items is recall-ordered DESC), so the
+        // newest `chatBudget` items are the FRONT of the list — Take(chatBudget). (R6-D: the previous
+        // Skip(count - chatBudget) kept the TAIL, i.e. the OLDEST messages, dropping the newest turns
+        // first — the opposite of "most recent".) Order is preserved (lead → chat → memory).
         int chatBudget = Math.Max(0, options.MaxContextMessages - lead.Count - memory.Count);
         var keptChat = chatMessages.Count > chatBudget
-            ? chatMessages.Skip(chatMessages.Count - chatBudget).ToList()
+            ? chatMessages.Take(chatBudget).ToList()
             : chatMessages;
 
         var result = new List<ChatMessage>(lead.Count + keptChat.Count + memory.Count);

--- a/src/AgentMemory.Core/Services/ContextCompressor.cs
+++ b/src/AgentMemory.Core/Services/ContextCompressor.cs
@@ -67,10 +67,15 @@ public sealed class ContextCompressor : IContextCompressor
             "Context compression triggered: {Tokens} tokens exceeds threshold {Threshold}",
             originalTokenCount, options.TokenThreshold);
 
-        // Tier 3: keep the most recent messages verbatim
-        var recentCount = Math.Min(options.RecentMessageCount, messages.Count);
-        var recentMessages = messages.Skip(messages.Count - recentCount).ToList();
-        var olderMessages = messages.Take(messages.Count - recentCount).ToList();
+        // Tier 3: keep the most recent messages verbatim, summarize the older ones. This requires
+        // chronological (oldest-first) order, but callers may pass newest-first (GetRecentMessagesAsync /
+        // recall order DESC). Normalize by timestamp first (R6-D) — otherwise Skip(count - recentCount)
+        // kept the OLDEST verbatim and Take(...) fed the NEWEST turns to summarization, the exact inversion
+        // of the documented behavior.
+        var chronological = messages.OrderBy(m => m.TimestampUtc).ToList();
+        var recentCount = Math.Min(options.RecentMessageCount, chronological.Count);
+        var recentMessages = chronological.Skip(chronological.Count - recentCount).ToList();
+        var olderMessages = chronological.Take(chronological.Count - recentCount).ToList();
 
         // Tier 2: summarize older messages in chunks into observations
         var observations = new List<string>();

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/MafTypeMapperTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/MafTypeMapperTests.cs
@@ -278,6 +278,35 @@ public sealed class MafTypeMapperTests
     }
 
     [Fact]
+    public void ToContextMessages_OverBudget_KeepsNewestChatMessages_NotOldest()
+    {
+        // R6-D: RecentMessages.Items is newest-first (recall orders DESC). When the chat exceeds the budget,
+        // the MOST RECENT messages must be kept — the previous Skip(count - budget) kept the TAIL (oldest).
+        // Build newest-first: m20 (newest) ... m1 (oldest).
+        var messages = Enumerable.Range(1, 20).Reverse()
+            .Select(i => new Message
+            {
+                MessageId = $"m{i}", SessionId = "s1", ConversationId = "c1",
+                Role = "user", Content = $"msg {i}",
+                TimestampUtc = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMinutes(i)
+            })
+            .ToList();
+
+        var context = new MemoryContext
+        {
+            SessionId = "s1",
+            AssembledAtUtc = DateTimeOffset.UtcNow,
+            RecentMessages = new MemoryContextSection<Message> { Items = messages }
+        };
+
+        var result = MafTypeMapper.ToContextMessages(context, new ContextFormatOptions { MaxContextMessages = 3 });
+
+        var texts = result.Where(m => m.Text != null).Select(m => m.Text!).ToList();
+        texts.Should().Contain("msg 20", "the newest message must be kept");
+        texts.Should().NotContain("msg 1", "the oldest message must be dropped first when over budget");
+    }
+
+    [Fact]
     public void ToContextMessages_MemoryItemsSurviveBudget_WhenChatMessagesExceedIt()
     {
         // The whole point of the provider is to inject long-term memory. Even when chat messages exceed

--- a/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
@@ -197,6 +197,35 @@ public sealed class ContextCompressorTests
         TimestampUtc = DateTimeOffset.UtcNow
     };
 
+    // R6-D: Tier-3 keeps the MOST RECENT messages verbatim and summarizes older ones. The production caller
+    // (ObservationTools → GetRecentMessagesAsync) passes NEWEST-FIRST, so the method must normalize order —
+    // before the fix it kept the OLDEST verbatim and fed the NEWEST turns to summarization.
+    [Fact]
+    public async Task CompressAsync_NewestFirstInput_KeepsNewestVerbatim_SummarizesOldest()
+    {
+        var baseTime = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        // Newest-first: i=6 (newest) … i=1 (oldest). Each ~100 chars so 6 msgs (150 tokens) exceed threshold.
+        var messages = Enumerable.Range(1, 6).Reverse()
+            .Select(i => new Message
+            {
+                MessageId = $"m{i}",
+                ConversationId = "conv-1",
+                SessionId = "session-1",
+                Role = "user",
+                Content = $"MSG{i}-" + new string('x', 100),
+                TimestampUtc = baseTime.AddMinutes(i)
+            })
+            .ToList();
+
+        var result = await _sut.CompressAsync(messages, _defaultOptions); // RecentMessageCount = 3
+
+        result.WasCompressed.Should().BeTrue();
+        var keptIds = result.RecentMessages.Select(m => m.MessageId).ToList();
+        keptIds.Should().BeEquivalentTo(new[] { "m4", "m5", "m6" },
+            "the 3 most-recent messages (by timestamp) must be kept verbatim, regardless of input order");
+        keptIds.Should().NotContain("m1", "the oldest message must be summarized away, not kept verbatim");
+    }
+
     [Fact]
     public async Task CompressAsync_CallerCancellation_PropagatesInsteadOfFallbackText()
     {


### PR DESCRIPTION
## R6-D — two truncation paths kept the wrong end of a newest-first list

Both bugs are ordering inversions: the data is **newest-first**, but the truncation kept the *tail* (oldest).

### `MafTypeMapper.ToContextMessages`
`chatMessages` is built from `RecentMessages.Items`, which recall orders **DESC (newest-first)**. The over-budget path used `chatMessages.Skip(count - chatBudget)` — that keeps the **last** `chatBudget` items = the **oldest** messages, dropping the newest turns first. The method's own comment says "fill … with the MOST RECENT chat messages." Fixed to `Take(chatBudget)` (the newest are at the front of a newest-first list).

### `ContextCompressor.CompressAsync` (Tier-3)
Documented to "keep the most recent messages verbatim" and summarize the older ones — but it assumed **chronological** (oldest-first) order. Its sole production caller, `ObservationTools` → `GetRecentMessagesAsync`, passes **newest-first**, so `Skip(count - recentCount)` kept the **oldest** verbatim and `Take(...)` fed the **newest** turns to summarization. Fixed by normalizing the input by `TimestampUtc` at the top, so the method is correct regardless of caller ordering (the robust fix — it can't silently invert again if another caller passes a different order).

### Why these slipped 6 rounds
The existing tests asserted only **counts** — and every message shared `DateTimeOffset.UtcNow`, so *which* messages survived was untestable. Classic happy-path coverage that hides an ordering bug.

### Tests (fail before the fix)
- `ToContextMessages_OverBudget_KeepsNewestChatMessages_NotOldest` — newest-first input, budget 3 → asserts `"msg 20"` kept, `"msg 1"` dropped.
- `CompressAsync_NewestFirstInput_KeepsNewestVerbatim_SummarizesOldest` — newest-first input with distinct timestamps → asserts `RecentMessages` == the 3 newest (`m4/m5/m6`), `m1` summarized away.

Full unit suite 2647 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)