### PR TITLE
fix(reasoning): handle concurrent trace deletion in update/add-step (R6-E)

### DIFF
--- a/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
@@ -11,8 +11,12 @@ public interface IReasoningTraceRepository
     /// <summary>Adds a reasoning trace.</summary>
     Task<ReasoningTrace> AddAsync(ReasoningTrace trace, CancellationToken cancellationToken = default);
 
-    /// <summary>Updates a reasoning trace.</summary>
-    Task<ReasoningTrace> UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Updates a reasoning trace. Returns <c>null</c> if no trace with the given id exists — e.g. it was
+    /// concurrently deleted (a session clear / retention prune) between a read and this write — so callers
+    /// can surface a clean "not found" rather than an opaque sequence-empty exception (R6-E).
+    /// </summary>
+    Task<ReasoningTrace?> UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken = default);
 
     /// <summary>Gets a trace by identifier.</summary>
     Task<ReasoningTrace?> GetByIdAsync(string traceId, CancellationToken cancellationToken = default);

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -214,7 +214,14 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         };
 
         _logger.LogDebug("Completing trace {TraceId}, success={Success}", traceId, success);
-        return await _traceRepo.UpdateAsync(completed, cancellationToken);
+        // The trace can be concurrently deleted (session clear / retention prune) between the read above and
+        // this write; UpdateAsync returns null in that case. Surface the same typed TraceNotFound as the
+        // read-miss path rather than letting an opaque sequence-empty exception escape (R6-E).
+        return await _traceRepo.UpdateAsync(completed, cancellationToken)
+            ?? throw MemoryError.Create($"Trace '{traceId}' not found.")
+                .WithCode(MemoryErrorCodes.TraceNotFound)
+                .WithMetadata("traceId", traceId)
+                .Build();
     }
 
     /// <inheritdoc/>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
@@ -37,8 +37,15 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
             };
 
             var cursor = await runner.RunAsync(ReasoningQueries.AddStep, parameters);
-            var record = await cursor.SingleAsync();
-            var node = record["s"].As<INode>();
+            // AddStep MATCHes the parent trace before CREATE; if the parent was concurrently deleted the
+            // MATCH yields no rows and the step cannot be attached. Failing is correct — but surface a clear,
+            // actionable error instead of SingleAsync's opaque "sequence contains no elements" (R6-E).
+            var records = await cursor.ToListAsync();
+            if (records.Count == 0)
+                throw new InvalidOperationException(
+                    $"Cannot add reasoning step '{step.StepId}': parent trace '{step.TraceId}' does not exist " +
+                    "(it may have been concurrently deleted).");
+            var node = records[0]["s"].As<INode>();
 
             // Only persist a real (non-empty) vector; a degraded empty embedding leaves `embedding` NULL.
             if (step.Embedding is { Length: > 0 })

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -44,16 +44,20 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         }, cancellationToken);
     }
 
-    public async Task<ReasoningTrace> UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken = default)
+    public async Task<ReasoningTrace?> UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Updating reasoning trace {Id}", trace.TraceId);
 
-        return await _tx.WriteAsync(async runner =>
+        return await _tx.WriteAsync<ReasoningTrace?>(async runner =>
         {
             var parameters = BuildTraceParameters(trace);
             var cursor = await runner.RunAsync(ReasoningQueries.UpdateTrace, parameters);
-            var record = await cursor.SingleAsync();
-            var node = record["t"].As<INode>();
+            // The UpdateTrace MATCH returns no rows if the trace was concurrently deleted (session clear /
+            // retention prune) between the caller's read and this write. Return null instead of letting
+            // SingleAsync throw an opaque "sequence contains no elements" (R6-E).
+            var records = await cursor.ToListAsync();
+            if (records.Count == 0) return null;
+            var node = records[0]["t"].As<INode>();
 
             // Only persist a real (non-empty) vector; a degraded empty embedding leaves it NULL.
             if (trace.TaskEmbedding is { Length: > 0 })

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningStepTouchedIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningStepTouchedIntegrationTests.cs
@@ -149,4 +149,25 @@ public class ReasoningStepTouchedIntegrationTests : IAsyncLifetime
 
         touched.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task AddAsync_ParentTraceMissing_ThrowsActionableError()
+    {
+        // R6-E: a step's AddStep MATCHes its parent trace. If the parent was concurrently deleted (or never
+        // existed), the step can't be attached — failing is correct, but the error must be actionable, not
+        // the driver's opaque "sequence contains no elements".
+        var orphanStep = new ReasoningStep
+        {
+            StepId = $"step-{Guid.NewGuid():N}",
+            TraceId = $"trace-{Guid.NewGuid():N}",   // no such trace
+            StepNumber = 1,
+            Thought = "Orphan step"
+        };
+
+        var act = async () => await _stepRepo.AddAsync(orphanStep);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain(orphanStep.TraceId,
+                "the error must name the missing parent trace so the failure is diagnosable");
+    }
 }

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
@@ -146,6 +146,26 @@ public class ReasoningTraceRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpdateAsync_NonexistentTrace_ReturnsNull_DoesNotThrow()
+    {
+        // R6-E: updating a trace that doesn't exist (e.g. concurrently deleted by a session clear / prune
+        // between read and write) must return null, not throw an opaque sequence-empty exception.
+        var ghost = new ReasoningTrace
+        {
+            TraceId = $"trace-{Guid.NewGuid():N}",   // never added
+            SessionId = $"session-{Guid.NewGuid():N}",
+            Task = "Update of a deleted trace",
+            Outcome = "done",
+            Success = true,
+            StartedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        var result = await _repo.UpdateAsync(ghost);
+
+        result.Should().BeNull("UpdateAsync on a missing trace returns null rather than throwing");
+    }
+
+    [Fact]
     public async Task SearchByTaskVectorAsync_ReturnsTraces_WhenEmbeddingMatches()
     {
         var trace = new ReasoningTrace

--- a/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ReasoningMemoryServiceTests.cs
@@ -39,7 +39,7 @@ public sealed class ReasoningMemoryServiceTests
 
         _traceRepo
             .UpdateAsync(Arg.Any<ReasoningTrace>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(ci.Arg<ReasoningTrace>()));
+            .Returns(ci => Task.FromResult<ReasoningTrace?>(ci.Arg<ReasoningTrace>()));
 
         _stepRepo
             .AddAsync(Arg.Any<ReasoningStep>(), Arg.Any<CancellationToken>())
@@ -271,6 +271,27 @@ public sealed class ReasoningMemoryServiceTests
 
         result.CompletedAtUtc.Should().Be(_fixedTime);
         await _traceRepo.Received(1).UpdateAsync(Arg.Any<ReasoningTrace>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteTraceAsync_TraceConcurrentlyDeleted_ThrowsTypedTraceNotFound()
+    {
+        // R6-E: the trace exists at GetById but is concurrently deleted (session clear / retention prune)
+        // before UpdateAsync, which now returns null. The service must surface the SAME typed TraceNotFound
+        // as the read-miss path — not let an opaque sequence-empty exception escape.
+        var existingTrace = CreateTrace("trace-1", "session-1");
+        _traceRepo
+            .GetByIdAsync("trace-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ReasoningTrace?>(existingTrace));
+        _traceRepo
+            .UpdateAsync(Arg.Any<ReasoningTrace>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ReasoningTrace?>(null));
+        var sut = CreateSut();
+
+        var act = async () => await sut.CompleteTraceAsync("trace-1", outcome: "done", success: true);
+
+        (await act.Should().ThrowAsync<AgentMemory.Abstractions.Exceptions.MemoryException>())
+            .Which.Code.Should().Be(AgentMemory.Abstractions.Exceptions.MemoryErrorCodes.TraceNotFound);
     }
 
     [Fact]


### PR DESCRIPTION
## R6-E — `CompleteTrace` and `AddStep` threw opaque exceptions on a concurrent delete

`CompleteTraceAsync` reads a trace (returning a clean typed `TraceNotFound` if absent), then calls `UpdateAsync` in a **separate transaction**. If the trace is concurrently deleted — a session clear (R6-C) or retention prune (#40) — between the read and the write, `UpdateAsync`'s `MATCH` returned 0 rows and `SingleAsync()` threw an opaque `InvalidOperationException` ("sequence contains no elements") instead of the typed not-found error. A classic read-then-write-across-transactions race (same shape as the #46 `MarkDeduplicatedAsync` fix).

### Fix
- **`IReasoningTraceRepository.UpdateAsync` → `Task<ReasoningTrace?>`** — returns `null` when no trace matches (`ToListAsync` + count check, mirroring `MarkDeduplicatedAsync`). `CompleteTraceAsync` translates `null` into the **same** typed `TraceNotFound` `MemoryException` as its read-miss path, so the contract is identical no matter when the delete races in.
- **`Neo4jReasoningStepRepository.AddAsync` (LOW)** — `AddStep` `MATCH`es the parent trace before `CREATE`; if the parent was concurrently deleted, the step can't attach. Failing is correct, but the opaque `SingleAsync` exception is replaced with an actionable `InvalidOperationException` that names the missing parent trace.

### Regression-safety
- `UpdateAsync`'s only production caller is `CompleteTraceAsync`, which now handles `null` explicitly. The nullable return is additive (callers ignoring the value are unaffected). One service mock updated for the new signature; full solution builds with **0 warnings**.
- `AddAsync` keeps its throw-on-failure contract (a step with no parent is still an error) — only the exception *quality* improves.

### Tests
- **Unit:** `CompleteTraceAsync_TraceConcurrentlyDeleted_ThrowsTypedTraceNotFound` — `UpdateAsync` returns null → asserts a `MemoryException` with `Code == TraceNotFound`.
- **Integration (live Neo4j):** `UpdateAsync_NonexistentTrace_ReturnsNull_DoesNotThrow`; `AddAsync_ParentTraceMissing_ThrowsActionableError` (message names the trace id).

Full unit suite 2646 green; reasoning integration 16 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)