### PR TITLE
chore(src): enforce ConfigureAwait(false) in library code via CA2007 (R6 cleanup)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,8 @@
+# Analyzer rules for the production library projects under src/ (apps/tests/tools are excluded — they are
+# not consumed on arbitrary synchronization contexts, so ConfigureAwait is not required there).
+
+[*.cs]
+# CA2007: library code must not capture the caller's synchronization context — await with
+# ConfigureAwait(false). Enforced (TreatWarningsAsErrors is on for src) so the drift that left ~68 files
+# inconsistent can never recur. (R6 cleanup, 2026-06-21.)
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/AgentMemory.Analytics/GdsAvailability.cs
+++ b/src/AgentMemory.Analytics/GdsAvailability.cs
@@ -41,8 +41,8 @@ public sealed class GdsAvailability : IGdsAvailability
         {
             var version = await _tx.ReadAsync(async runner =>
             {
-                var cursor = await runner.RunAsync(GdsQueries.ProbeVersion);
-                var record = await cursor.SingleAsync();
+                var cursor = await runner.RunAsync(GdsQueries.ProbeVersion).ConfigureAwait(false);
+                var record = await cursor.SingleAsync().ConfigureAwait(false);
                 return record["version"].As<string>();
             }).ConfigureAwait(false);
 

--- a/src/AgentMemory.Analytics/GdsGraphScope.cs
+++ b/src/AgentMemory.Analytics/GdsGraphScope.cs
@@ -26,7 +26,7 @@ internal static class GdsGraphScope
             // Defensive drop first: ExecuteWriteAsync auto-retries this lambda on a transient error, and the
             // graph name is fixed per call — without this, a retry after the catalog write would fail with
             // "graph already exists" and leak the partial graph. Drop is a no-op when the graph is absent.
-            await (await runner.RunAsync(GdsQueries.DropGraph, new { graphName })).ConsumeAsync();
+            await (await runner.RunAsync(GdsQueries.DropGraph, new { graphName }).ConfigureAwait(false)).ConsumeAsync().ConfigureAwait(false);
 
             var parameters = new Dictionary<string, object?>
             {
@@ -35,14 +35,14 @@ internal static class GdsGraphScope
                 ["relQuery"] = relQuery,
             };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            await runner.RunAsync(GdsQueries.ProjectCypher(hasOwner), parameters);
-        }, cancellationToken);
+            await runner.RunAsync(GdsQueries.ProjectCypher(hasOwner), parameters).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         try
         {
             // Run the stream under a WRITE session too: under a routing (cluster/Aura) URI this pins it to
             // the same member (the leader) that holds the just-created, member-local GDS catalog graph.
-            return await tx.WriteAsync(algorithm, cancellationToken);
+            return await tx.WriteAsync(algorithm, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -51,8 +51,8 @@ internal static class GdsGraphScope
             {
                 await tx.WriteAsync(async runner =>
                 {
-                    await runner.RunAsync(GdsQueries.DropGraph, new { graphName });
-                }, CancellationToken.None);
+                    await runner.RunAsync(GdsQueries.DropGraph, new { graphName }).ConfigureAwait(false);
+                }, CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/AgentMemory.Analytics/MemoryCommunityService.cs
+++ b/src/AgentMemory.Analytics/MemoryCommunityService.cs
@@ -25,7 +25,7 @@ public sealed class MemoryCommunityService : IMemoryCommunityService
     public async Task<IReadOnlyList<EntityCommunity>> DetectCommunitiesAsync(
         MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
-        if (!await _gds.IsAvailableAsync(cancellationToken))
+        if (!await _gds.IsAvailableAsync(cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("Community detection skipped — Neo4j GDS plugin not installed; returning no communities.");
             return Array.Empty<EntityCommunity>();
@@ -35,11 +35,11 @@ public sealed class MemoryCommunityService : IMemoryCommunityService
 
         return await GdsGraphScope.WithProjectionAsync(_tx, graphName, scope, async runner =>
         {
-            var cursor = await runner.RunAsync(GdsQueries.LouvainStream, new { graphName });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(GdsQueries.LouvainStream, new { graphName }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return (IReadOnlyList<EntityCommunity>)records
                 .Select(r => new EntityCommunity(r["entityId"].As<string>(), r["communityId"].As<long>()))
                 .ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Analytics/MemoryPageRankService.cs
+++ b/src/AgentMemory.Analytics/MemoryPageRankService.cs
@@ -29,7 +29,7 @@ public sealed class MemoryPageRankService : IMemoryPageRankService
     public async Task<IReadOnlyList<EntityRank>> RankEntitiesAsync(
         int? topN = null, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
-        if (!await _gds.IsAvailableAsync(cancellationToken))
+        if (!await _gds.IsAvailableAsync(cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("PageRank skipped — Neo4j GDS plugin not installed; returning no ranks.");
             return Array.Empty<EntityRank>();
@@ -40,11 +40,11 @@ public sealed class MemoryPageRankService : IMemoryPageRankService
 
         return await GdsGraphScope.WithProjectionAsync(_tx, graphName, scope, async runner =>
         {
-            var cursor = await runner.RunAsync(GdsQueries.PageRankStream, new { graphName, topN = limit });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(GdsQueries.PageRankStream, new { graphName, topN = limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return (IReadOnlyList<EntityRank>)records
                 .Select(r => new EntityRank(r["entityId"].As<string>(), r["score"].As<double>()))
                 .ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -76,12 +76,12 @@ internal sealed class ExtractionStage : IExtractionStage
                 strategy, MergeStrategyFactory.CreateRelationshipStrategy, "relationship", cancellationToken)
             : Task.FromResult<IReadOnlyList<ExtractedRelationship>>(Array.Empty<ExtractedRelationship>());
 
-        await Task.WhenAll(entityTask, factTask, prefTask, relTask);
+        await Task.WhenAll(entityTask, factTask, prefTask, relTask).ConfigureAwait(false);
 
-        var rawEntities = await entityTask;
-        var rawFacts = await factTask;
-        var rawPreferences = await prefTask;
-        var rawRelationships = await relTask;
+        var rawEntities = await entityTask.ConfigureAwait(false);
+        var rawFacts = await factTask.ConfigureAwait(false);
+        var rawPreferences = await prefTask.ConfigureAwait(false);
+        var rawRelationships = await relTask.ConfigureAwait(false);
 
         // 2. Filter + validate + resolve entities; build name→Entity map for relationship resolution.
         var resolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase);
@@ -104,7 +104,7 @@ internal sealed class ExtractionStage : IExtractionStage
             try
             {
                 var entity = await _entityResolver.ResolveEntityAsync(
-                    extracted, sourceMessageIds, scope, cancellationToken);
+                    extracted, sourceMessageIds, scope, cancellationToken).ConfigureAwait(false);
                 resolvedEntityMap[extracted.Name] = entity;
                 _logger.LogDebug("Resolved entity '{Name}' (id={Id}).", entity.Name, entity.EntityId);
             }
@@ -210,16 +210,16 @@ internal sealed class ExtractionStage : IExtractionStage
             return Array.Empty<T>();
 
         if (extractors.Count == 1)
-            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName, cancellationToken);
+            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName, cancellationToken).ConfigureAwait(false);
 
         var tasks = extractors
             .Select(e => ExtractSafeAsync(() => extractFn(e), extractorTypeName, cancellationToken))
             .ToList();
-        await Task.WhenAll(tasks);
+        await Task.WhenAll(tasks).ConfigureAwait(false);
 
         var allResults = new List<IReadOnlyList<T>>(tasks.Count);
         foreach (var task in tasks)
-            allResults.Add(await task);
+            allResults.Add(await task.ConfigureAwait(false));
 
         var mergeStrategy = strategyFactory(strategyType);
         var merged = mergeStrategy.Merge(allResults);
@@ -238,7 +238,7 @@ internal sealed class ExtractionStage : IExtractionStage
     {
         try
         {
-            return await extractor();
+            return await extractor().ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/AgentMemory.Core/Extraction/ExtractorBase.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractorBase.cs
@@ -51,7 +51,7 @@ public abstract class ExtractorBase<T>
         if (messages.Count == 0) return Array.Empty<T>();
         try
         {
-            return await ExtractCoreAsync(messages, ct);
+            return await ExtractCoreAsync(messages, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -57,11 +57,11 @@ internal sealed class PersistenceStage : IPersistenceStage
                 if (entityToSave.Embedding is null)
                 {
                     var embedding = await _embeddingOrchestrator.EmbedEntityAsync(
-                        entityToSave.Name, cancellationToken);
+                        entityToSave.Name, cancellationToken).ConfigureAwait(false);
                     entityToSave = entityToSave with { Embedding = embedding };
                 }
 
-                entityToSave = await _entityRepository.UpsertAsync(entityToSave, cancellationToken);
+                entityToSave = await _entityRepository.UpsertAsync(entityToSave, cancellationToken).ConfigureAwait(false);
                 persistedEntityMap[name] = entityToSave;
 
                 foreach (var msgId in sourceMessageIds)
@@ -69,7 +69,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                     try
                     {
                         await _entityRepository.CreateExtractedFromRelationshipAsync(
-                            entityToSave.EntityId, msgId, cancellationToken: cancellationToken);
+                            entityToSave.EntityId, msgId, cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
@@ -96,7 +96,7 @@ internal sealed class PersistenceStage : IPersistenceStage
             try
             {
                 var factEmbedding = await _embeddingOrchestrator.EmbedFactAsync(
-                    extracted.Subject, extracted.Predicate, extracted.Object, cancellationToken);
+                    extracted.Subject, extracted.Predicate, extracted.Object, cancellationToken).ConfigureAwait(false);
 
                 var fact = new Fact
                 {
@@ -113,14 +113,14 @@ internal sealed class PersistenceStage : IPersistenceStage
                     CreatedAtUtc = _clock.UtcNow
                 };
 
-                await _factRepository.UpsertAsync(fact, cancellationToken);
+                await _factRepository.UpsertAsync(fact, cancellationToken).ConfigureAwait(false);
 
                 foreach (var msgId in sourceMessageIds)
                 {
                     try
                     {
                         await _factRepository.CreateExtractedFromRelationshipAsync(
-                            fact.FactId, msgId, cancellationToken);
+                            fact.FactId, msgId, cancellationToken).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
@@ -150,7 +150,7 @@ internal sealed class PersistenceStage : IPersistenceStage
             try
             {
                 var prefEmbedding = await _embeddingOrchestrator.EmbedPreferenceAsync(
-                    extracted.PreferenceText, cancellationToken);
+                    extracted.PreferenceText, cancellationToken).ConfigureAwait(false);
 
                 var preference = new Preference
                 {
@@ -165,14 +165,14 @@ internal sealed class PersistenceStage : IPersistenceStage
                     CreatedAtUtc = _clock.UtcNow
                 };
 
-                await _preferenceRepository.UpsertAsync(preference, cancellationToken);
+                await _preferenceRepository.UpsertAsync(preference, cancellationToken).ConfigureAwait(false);
 
                 foreach (var msgId in sourceMessageIds)
                 {
                     try
                     {
                         await _preferenceRepository.CreateExtractedFromRelationshipAsync(
-                            preference.PreferenceId, msgId, cancellationToken);
+                            preference.PreferenceId, msgId, cancellationToken).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
                     catch (Exception ex)
@@ -229,7 +229,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                     CreatedAtUtc = _clock.UtcNow
                 };
 
-                await _relationshipRepository.UpsertAsync(relationship, cancellationToken);
+                await _relationshipRepository.UpsertAsync(relationship, cancellationToken).ConfigureAwait(false);
                 persistedRelCount++;
 
                 _logger.LogDebug(

--- a/src/AgentMemory.Core/Services/ContextCompressor.cs
+++ b/src/AgentMemory.Core/Services/ContextCompressor.cs
@@ -90,7 +90,7 @@ public sealed class ContextCompressor : IContextCompressor
 
             foreach (var chunk in chunks)
             {
-                var observation = await SummarizeChunkAsync(chunk, cancellationToken);
+                var observation = await SummarizeChunkAsync(chunk, cancellationToken).ConfigureAwait(false);
                 if (!string.IsNullOrWhiteSpace(observation))
                     observations.Add(observation);
             }
@@ -100,7 +100,7 @@ public sealed class ContextCompressor : IContextCompressor
         var reflections = new List<string>();
         if (options.EnableReflections && observations.Count > 0)
         {
-            var reflection = await GenerateReflectionAsync(observations, cancellationToken);
+            var reflection = await GenerateReflectionAsync(observations, cancellationToken).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(reflection))
                 reflections.Add(reflection);
         }
@@ -140,7 +140,7 @@ public sealed class ContextCompressor : IContextCompressor
                 new(ChatRole.User, conversationText)
             };
 
-            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken);
+            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Text?.Trim() ?? string.Empty;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -171,7 +171,7 @@ public sealed class ContextCompressor : IContextCompressor
                 new(ChatRole.User, $"Observations:\n{observationText}")
             };
 
-            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken);
+            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Text?.Trim() ?? string.Empty;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -116,7 +116,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _entityRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken);
+        var scored = await _entityRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Entity).ToList();
     }
 
@@ -139,7 +139,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         if (_options.GeneratePreferenceEmbeddings && embedding is null)
         {
             _logger.LogDebug("Generating embedding for preference {PreferenceId}", preference.PreferenceId);
-            embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(preference.PreferenceText, cancellationToken);
+            embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(preference.PreferenceText, cancellationToken).ConfigureAwait(false);
         }
 
         // Dedup-on-create: reinforce an existing same-category, same-owner near-duplicate instead of
@@ -152,11 +152,11 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         {
             var dup = await _prefRepo.FindDuplicateAsync(
                 preference.Category, embedding, preference.OwnerId,
-                _options.DeduplicationSimilarityThreshold, cancellationToken);
+                _options.DeduplicationSimilarityThreshold, cancellationToken).ConfigureAwait(false);
             if (dup is not null)
             {
                 var reinforced = BumpConfidence(dup.Confidence, preference.Confidence);
-                var marked = await _prefRepo.MarkDeduplicatedAsync(dup.PreferenceId, reinforced, cancellationToken);
+                var marked = await _prefRepo.MarkDeduplicatedAsync(dup.PreferenceId, reinforced, cancellationToken).ConfigureAwait(false);
                 if (marked is not null)
                 {
                     _logger.LogDebug("Deduplicated preference in '{Category}' onto {Id} (confidence→{C}).",
@@ -170,7 +170,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         }
 
         var toSave = embedding is null ? preference : preference with { Embedding = embedding };
-        return await _prefRepo.UpsertAsync(toSave, cancellationToken);
+        return await _prefRepo.UpsertAsync(toSave, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -190,7 +190,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _prefRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken);
+        var scored = await _prefRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Preference).ToList();
     }
 
@@ -213,7 +213,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         if (_options.GenerateFactEmbeddings && embedding is null)
         {
             _logger.LogDebug("Generating embedding for fact {FactId}", fact.FactId);
-            embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, cancellationToken);
+            embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, cancellationToken).ConfigureAwait(false);
         }
 
         // Dedup-on-create: reinforce an existing same-subject+predicate, same-owner near-duplicate
@@ -227,11 +227,11 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         {
             var dup = await _factRepo.FindDuplicateAsync(
                 fact.Subject, fact.Predicate, embedding, fact.OwnerId,
-                _options.DeduplicationSimilarityThreshold, cancellationToken);
+                _options.DeduplicationSimilarityThreshold, cancellationToken).ConfigureAwait(false);
             if (dup is not null)
             {
                 var reinforced = BumpConfidence(dup.Confidence, fact.Confidence);
-                var marked = await _factRepo.MarkDeduplicatedAsync(dup.FactId, reinforced, cancellationToken);
+                var marked = await _factRepo.MarkDeduplicatedAsync(dup.FactId, reinforced, cancellationToken).ConfigureAwait(false);
                 if (marked is not null)
                 {
                     _logger.LogDebug("Deduplicated fact '{S} {P}' onto {Id} (confidence→{C}).",
@@ -245,7 +245,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         }
 
         var toSave = embedding is null ? fact : fact with { Embedding = embedding };
-        return await _factRepo.UpsertAsync(toSave, cancellationToken);
+        return await _factRepo.UpsertAsync(toSave, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Reinforced confidence on a dedup hit: max(existing, incoming) + configured bump, capped at 1.0.</summary>
@@ -267,10 +267,10 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         var final = item;
         if (shouldEmbed)
         {
-            var embedding = await embed(cancellationToken);
+            var embedding = await embed(cancellationToken).ConfigureAwait(false);
             final = withEmbedding(item, embedding);
         }
-        return await upsert(final, cancellationToken);
+        return await upsert(final, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -290,7 +290,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _factRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken);
+        var scored = await _factRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Fact).ToList();
     }
 
@@ -331,7 +331,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _entityRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, cancellationToken);
+        var scored = await _entityRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Entity).ToList();
     }
 
@@ -345,7 +345,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         DateTimeOffset? systemAsOf = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _factRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, systemAsOf, cancellationToken);
+        var scored = await _factRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, systemAsOf, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Fact).ToList();
     }
 
@@ -358,7 +358,7 @@ public sealed class LongTermMemoryService : ILongTermMemoryService
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
-        var scored = await _prefRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, cancellationToken);
+        var scored = await _prefRepo.SearchByVectorAsOfAsync(queryEmbedding, asOf, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Preference).ToList();
     }
 

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -141,7 +141,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
         {
             // Generate embedding if not provided (only needed for memory-layer semantic search).
             var queryEmbedding = request.QueryEmbedding
-                ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken);
+                ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken).ConfigureAwait(false);
 
             // Vector searches require a non-empty embedding. A blank query (e.g. a history-only
             // recall via the chat-history provider) yields an empty embedding — skip the semantic
@@ -184,23 +184,23 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
 
             await Task.WhenAll(
                 recentTask, relevantTask, entitiesTask,
-                preferencesTask, factsTask, tracesTask);
+                preferencesTask, factsTask, tracesTask).ConfigureAwait(false);
 
-            recentMessages = await recentTask;
-            relevantMessages = await relevantTask;
-            entities = await entitiesTask;
-            preferences = await preferencesTask;
-            facts = await factsTask;
-            traces = await tracesTask;
+            recentMessages = await recentTask.ConfigureAwait(false);
+            relevantMessages = await relevantTask.ConfigureAwait(false);
+            entities = await entitiesTask.ConfigureAwait(false);
+            preferences = await preferencesTask.ConfigureAwait(false);
+            facts = await factsTask.ConfigureAwait(false);
+            traces = await tracesTask.ConfigureAwait(false);
         }
 
         if (graphRagTask != null)
-            await graphRagTask;
+            await graphRagTask.ConfigureAwait(false);
 
         string? graphRagContext = null;
         if (graphRagTask != null)
         {
-            var graphRagResult = await graphRagTask;
+            var graphRagResult = await graphRagTask.ConfigureAwait(false);
             if (graphRagResult?.Items is { Count: > 0 } items)
                 graphRagContext = string.Join("\n\n", items.Select(i => i.Text));
         }
@@ -273,7 +273,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             ?? (string.IsNullOrEmpty(request.UserId) ? null : MemoryScope.For(request.UserId));
 
         var queryEmbedding = request.QueryEmbedding
-            ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken);
+            ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken).ConfigureAwait(false);
 
         // Vector searches require a non-empty embedding. A blank query, or a transient embedding-generation
         // failure (degrades to an empty vector), would otherwise issue a zero-dimension vector query which
@@ -305,13 +305,13 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
             ? _reasoning.SearchSimilarTracesAsOfAsync(queryEmbedding, systemAsOf, null, recallOpts.MaxTraces, minScore, scope, cancellationToken)
             : Empty<ReasoningTrace>();
 
-        await Task.WhenAll(recentTask, entitiesTask, preferencesTask, factsTask, tracesTask);
+        await Task.WhenAll(recentTask, entitiesTask, preferencesTask, factsTask, tracesTask).ConfigureAwait(false);
 
-        var recentMessages = await recentTask;
-        var entities = await entitiesTask;
-        var preferences = await preferencesTask;
-        var facts = await factsTask;
-        var traces = await tracesTask;
+        var recentMessages = await recentTask.ConfigureAwait(false);
+        var entities = await entitiesTask.ConfigureAwait(false);
+        var preferences = await preferencesTask.ConfigureAwait(false);
+        var facts = await factsTask.ConfigureAwait(false);
+        var traces = await tracesTask.ConfigureAwait(false);
 
         // Enforce the same context budget as the live recall path so temporal recall cannot blow
         // past the configured token/char limit. (Relevant messages are not part of the temporal
@@ -372,7 +372,7 @@ public sealed class MemoryContextAssembler : IMemoryContextAssembler
                 Query = request.Query,
                 TopK = recallOpts.MaxGraphRagItems
             };
-            return await _graphRag!.GetContextAsync(graphRagRequest, cancellationToken);
+            return await _graphRag!.GetContextAsync(graphRagRequest, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
+++ b/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
@@ -47,9 +47,9 @@ public sealed class MemoryExtractionPipeline : IMemoryExtractionPipeline
         var scope = string.IsNullOrEmpty(request.UserId) ? null : MemoryScope.For(request.UserId);
 
         var staged = await _extractionStage.ExtractAsync(
-            request.Messages, request.TypesToExtract, scope, cancellationToken);
+            request.Messages, request.TypesToExtract, scope, cancellationToken).ConfigureAwait(false);
 
-        var persisted = await _persistenceStage.PersistAsync(staged, request.UserId, cancellationToken);
+        var persisted = await _persistenceStage.PersistAsync(staged, request.UserId, cancellationToken).ConfigureAwait(false);
 
         sw.Stop();
         _logger.LogInformation(

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -78,13 +78,13 @@ public sealed class MemoryService : IMemoryService
     {
         ArgumentNullException.ThrowIfNull(request);
         _logger.LogDebug("Recalling memory for session {SessionId}", request.SessionId);
-        var context = await _assembler.AssembleContextAsync(request, cancellationToken);
+        var context = await _assembler.AssembleContextAsync(request, cancellationToken).ConfigureAwait(false);
 
         // Update access timestamps for recalled long-term memories (awaited so failures and
         // cancellation are observed; the method itself is resilient and logs internally).
         if (_decayService is not null)
         {
-            await UpdateAccessTimestampsAsync(context, cancellationToken);
+            await UpdateAccessTimestampsAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         int totalItems = context.RecentMessages.Items.Count
@@ -136,7 +136,7 @@ public sealed class MemoryService : IMemoryService
         _logger.LogDebug(
             "Recalling memory for session {SessionId} validAsOf {ValidAsOf} systemAsOf {SystemAsOf}",
             request.SessionId, validAsOf, systemAsOf);
-        var context = await _assembler.AssembleContextAsOfAsync(request, validAsOf, systemAsOf, cancellationToken);
+        var context = await _assembler.AssembleContextAsOfAsync(request, validAsOf, systemAsOf, cancellationToken).ConfigureAwait(false);
 
         // Count every populated section so TotalItemsRetrieved matches the documented "across all sections"
         // contract and the live RecallAsync path. SimilarTraces is populated on the as-of path too, so it
@@ -187,7 +187,7 @@ public sealed class MemoryService : IMemoryService
             Metadata = metadata ?? new Dictionary<string, object>()
         };
 
-        return await _shortTerm.AddMessageAsync(message, cancellationToken);
+        return await _shortTerm.AddMessageAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -232,7 +232,7 @@ public sealed class MemoryService : IMemoryService
         // Must use the uncapped, chronological session fetch: routing this through GetRecentMessagesAsync
         // would silently clamp to MaxMessagesPerQuery (default 100) and drop the oldest messages of a long
         // session, so the bulk of its knowledge would never be extracted.
-        var messages = await _shortTerm.GetAllSessionMessagesAsync(sessionId, cancellationToken);
+        var messages = await _shortTerm.GetAllSessionMessagesAsync(sessionId, cancellationToken).ConfigureAwait(false);
         if (messages.Count == 0)
         {
             _logger.LogDebug("No messages found for session {SessionId} — skipping extraction.", sessionId);
@@ -241,7 +241,7 @@ public sealed class MemoryService : IMemoryService
 
         await _extraction.ExtractAsync(
             new ExtractionRequest { Messages = messages, SessionId = sessionId, UserId = userId },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -253,7 +253,7 @@ public sealed class MemoryService : IMemoryService
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         _logger.LogDebug("Retroactive extraction for conversation {ConversationId}, owner={Owner}", conversationId, userId);
 
-        var messages = await _shortTerm.GetConversationMessagesAsync(conversationId, cancellationToken);
+        var messages = await _shortTerm.GetConversationMessagesAsync(conversationId, cancellationToken).ConfigureAwait(false);
         if (messages.Count == 0)
         {
             _logger.LogDebug("No messages found for conversation {ConversationId} — skipping extraction.", conversationId);
@@ -267,14 +267,14 @@ public sealed class MemoryService : IMemoryService
         var ownerId = userId;
         if (string.IsNullOrEmpty(ownerId) && _conversationRepository is not null)
         {
-            var conversation = await _conversationRepository.GetByIdAsync(conversationId, cancellationToken);
+            var conversation = await _conversationRepository.GetByIdAsync(conversationId, cancellationToken).ConfigureAwait(false);
             ownerId = conversation?.UserId;
         }
 
         var sessionId = messages[0].SessionId;
         await _extraction.ExtractAsync(
             new ExtractionRequest { Messages = messages, SessionId = sessionId, UserId = ownerId },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -288,9 +288,9 @@ public sealed class MemoryService : IMemoryService
 
         return nodeLabel switch
         {
-            "Entity"     => await BackfillEntityEmbeddingsAsync(batchSize, cancellationToken),
-            "Fact"       => await BackfillFactEmbeddingsAsync(batchSize, cancellationToken),
-            "Preference" => await BackfillPreferenceEmbeddingsAsync(batchSize, cancellationToken),
+            "Entity"     => await BackfillEntityEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
+            "Fact"       => await BackfillFactEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
+            "Preference" => await BackfillPreferenceEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
             _ => throw new ArgumentException(
                 $"Unsupported node label '{nodeLabel}'. Supported values: Entity, Fact, Preference.",
                 nameof(nodeLabel))
@@ -303,12 +303,12 @@ public sealed class MemoryService : IMemoryService
         PagedResult<Entity> page;
         do
         {
-            page = await _entityRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            page = await _entityRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var entity in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, ct);
-                await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, ct);
+                var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, ct).ConfigureAwait(false);
+                await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, ct).ConfigureAwait(false);
                 // Count only nodes actually updated: the repo skips persisting an empty (degraded) embedding,
                 // so a skipped node must not inflate the "nodes updated" return value.
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
@@ -327,12 +327,12 @@ public sealed class MemoryService : IMemoryService
         PagedResult<Fact> page;
         do
         {
-            page = await _factRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            page = await _factRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var fact in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, ct);
-                await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, ct);
+                var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, ct).ConfigureAwait(false);
+                await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, ct).ConfigureAwait(false);
                 // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
@@ -350,12 +350,12 @@ public sealed class MemoryService : IMemoryService
         PagedResult<Preference> page;
         do
         {
-            page = await _preferenceRepository.GetPageWithoutEmbeddingAsync(batchSize, ct);
+            page = await _preferenceRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var pref in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, ct);
-                await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, ct);
+                var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, ct).ConfigureAwait(false);
+                await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, ct).ConfigureAwait(false);
                 // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
@@ -401,7 +401,7 @@ public sealed class MemoryService : IMemoryService
             foreach (var pref in context.RelevantPreferences.Items)
                 tasks.Add(_decayService!.UpdateAccessTimestampAsync(pref.PreferenceId, "Preference", cancellationToken));
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -61,7 +61,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         if (effectiveEmbedding is null && _options.GenerateTaskEmbeddings && !string.IsNullOrWhiteSpace(task))
         {
             _logger.LogDebug("Generating task embedding for new trace in session {SessionId}", sessionId);
-            effectiveEmbedding = await _embeddingOrchestrator.EmbedAsync(task, cancellationToken);
+            effectiveEmbedding = await _embeddingOrchestrator.EmbedAsync(task, cancellationToken).ConfigureAwait(false);
         }
 
         var trace = new ReasoningTrace
@@ -76,7 +76,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         };
 
         _logger.LogDebug("Starting trace {TraceId} for session {SessionId}", trace.TraceId, sessionId);
-        var added = await _traceRepo.AddAsync(trace, cancellationToken);
+        var added = await _traceRepo.AddAsync(trace, cancellationToken).ConfigureAwait(false);
 
         // Retention cap (H): when MaxTracesPerSession is configured, prune older traces beyond the cap so a
         // session's reasoning history cannot grow without bound. The prune confines to exactly the just-added
@@ -86,7 +86,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         {
             try
             {
-                var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, cap, ownerId, cancellationToken);
+                var pruned = await _traceRepo.PruneSessionTracesAsync(sessionId, cap, ownerId, cancellationToken).ConfigureAwait(false);
                 if (pruned > 0)
                     _logger.LogDebug("Pruned {Pruned} trace(s) beyond MaxTracesPerSession={Cap} for session {SessionId}.",
                         pruned, cap, sessionId);
@@ -126,7 +126,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         };
 
         _logger.LogDebug("Adding step {StepNumber} to trace {TraceId}", stepNumber, traceId);
-        return await _stepRepo.AddAsync(step, cancellationToken);
+        return await _stepRepo.AddAsync(step, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -162,7 +162,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         }
 
         _logger.LogDebug("Recording tool call {ToolName} for step {StepId}", toolName, stepId);
-        return await _toolCallRepo.AddAsync(toolCall, cancellationToken);
+        return await _toolCallRepo.AddAsync(toolCall, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -200,7 +200,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         bool? success = null,
         CancellationToken cancellationToken = default)
     {
-        var existing = await _traceRepo.GetByIdAsync(traceId, cancellationToken)
+        var existing = await _traceRepo.GetByIdAsync(traceId, cancellationToken).ConfigureAwait(false)
             ?? throw MemoryError.Create($"Trace '{traceId}' not found.")
                 .WithCode(MemoryErrorCodes.TraceNotFound)
                 .WithMetadata("traceId", traceId)
@@ -217,7 +217,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         // The trace can be concurrently deleted (session clear / retention prune) between the read above and
         // this write; UpdateAsync returns null in that case. Surface the same typed TraceNotFound as the
         // read-miss path rather than letting an opaque sequence-empty exception escape (R6-E).
-        return await _traceRepo.UpdateAsync(completed, cancellationToken)
+        return await _traceRepo.UpdateAsync(completed, cancellationToken).ConfigureAwait(false)
             ?? throw MemoryError.Create($"Trace '{traceId}' not found.")
                 .WithCode(MemoryErrorCodes.TraceNotFound)
                 .WithMetadata("traceId", traceId)
@@ -232,14 +232,14 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         var traceTask = _traceRepo.GetByIdAsync(traceId, cancellationToken);
         var stepsTask = _stepRepo.GetByTraceAsync(traceId, cancellationToken);
 
-        await Task.WhenAll(traceTask, stepsTask);
+        await Task.WhenAll(traceTask, stepsTask).ConfigureAwait(false);
 
-        var trace = await traceTask
+        var trace = await traceTask.ConfigureAwait(false)
             ?? throw MemoryError.Create($"Trace '{traceId}' not found.")
                 .WithCode(MemoryErrorCodes.TraceNotFound)
                 .WithMetadata("traceId", traceId)
                 .Build();
-        var steps = await stepsTask;
+        var steps = await stepsTask.ConfigureAwait(false);
 
         return (trace, steps);
     }
@@ -264,7 +264,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         CancellationToken cancellationToken = default)
     {
         var scored = await _traceRepo.SearchByTaskVectorAsync(
-            taskEmbedding, successFilter, limit, minScore, scope, cancellationToken);
+            taskEmbedding, successFilter, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Trace).ToList();
     }
 
@@ -279,7 +279,7 @@ public sealed class ReasoningMemoryService : IReasoningMemoryService
         CancellationToken cancellationToken = default)
     {
         var scored = await _traceRepo.SearchByTaskVectorAsOfAsync(
-            taskEmbedding, asOf, successFilter, limit, minScore, scope, cancellationToken);
+            taskEmbedding, asOf, successFilter, limit, minScore, scope, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Trace).ToList();
     }
 }

--- a/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
@@ -64,7 +64,7 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         };
 
         _logger.LogDebug("Upserting conversation {ConversationId} for session {SessionId}", conversationId, sessionId);
-        return await _conversationRepo.UpsertAsync(conversation, cancellationToken);
+        return await _conversationRepo.UpsertAsync(conversation, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -77,11 +77,11 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         if (_options.GenerateEmbeddings && message.Embedding is null)
         {
             _logger.LogDebug("Generating embedding for message {MessageId}", message.MessageId);
-            var embedding = await _embeddingOrchestrator.EmbedMessageAsync(message.Content, cancellationToken);
+            var embedding = await _embeddingOrchestrator.EmbedMessageAsync(message.Content, cancellationToken).ConfigureAwait(false);
             finalMessage = message with { Embedding = embedding };
         }
 
-        return await _messageRepo.AddAsync(finalMessage, cancellationToken);
+        return await _messageRepo.AddAsync(finalMessage, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -97,14 +97,14 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
             var finalMessage = message;
             if (_options.GenerateEmbeddings && message.Embedding is null)
             {
-                var embedding = await _embeddingOrchestrator.EmbedMessageAsync(message.Content, cancellationToken);
+                var embedding = await _embeddingOrchestrator.EmbedMessageAsync(message.Content, cancellationToken).ConfigureAwait(false);
                 finalMessage = message with { Embedding = embedding };
             }
             results.Add(finalMessage);
         }
 
         _logger.LogDebug("Batch adding {Count} messages", results.Count);
-        return await _messageRepo.AddBatchAsync(results, cancellationToken);
+        return await _messageRepo.AddBatchAsync(results, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -118,7 +118,7 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         // 10", which is why DefaultRecentMessageLimit was previously unreadable.)
         var requested = limit ?? _options.DefaultRecentMessageLimit;
         var cappedLimit = Math.Min(requested, _options.MaxMessagesPerQuery);
-        return await _messageRepo.GetRecentBySessionAsync(sessionId, cappedLimit, cancellationToken);
+        return await _messageRepo.GetRecentBySessionAsync(sessionId, cappedLimit, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -148,7 +148,7 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         CancellationToken cancellationToken = default)
     {
         var scored = await _messageRepo.SearchByVectorAsync(
-            queryEmbedding, sessionId, limit, minScore, null, cancellationToken);
+            queryEmbedding, sessionId, limit, minScore, null, cancellationToken).ConfigureAwait(false);
         return scored.Select(r => r.Message).ToList();
     }
 
@@ -159,11 +159,11 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Clearing session {SessionId}, owner={Owner}", sessionId, ownerId);
-        await _messageRepo.DeleteBySessionAsync(sessionId, cancellationToken);
-        await _conversationRepo.DeleteBySessionAsync(sessionId, cancellationToken);
+        await _messageRepo.DeleteBySessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        await _conversationRepo.DeleteBySessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
         // ReasoningTrace carries owner_id (R1): confine the delete to the calling owner's bucket so a
         // shared session_id can't let one owner's clear evict another owner's traces.
-        await _reasoningTraceRepo.DeleteBySessionAsync(sessionId, ownerId, cancellationToken);
+        await _reasoningTraceRepo.DeleteBySessionAsync(sessionId, ownerId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -174,6 +174,6 @@ public sealed class ShortTermMemoryService : IShortTermMemoryService
         CancellationToken cancellationToken = default)
     {
         var cappedLimit = Math.Min(limit, _options.MaxMessagesPerQuery);
-        return await _messageRepo.GetRecentBySessionAsOfAsync(sessionId, asOf, cappedLimit, cancellationToken);
+        return await _messageRepo.GetRecentBySessionAsOfAsync(sessionId, asOf, cappedLimit, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Core/Stubs/StubExtractionPipeline.cs
+++ b/src/AgentMemory.Core/Stubs/StubExtractionPipeline.cs
@@ -45,19 +45,19 @@ public sealed class StubExtractionPipeline : IMemoryExtractionPipeline
         var types = request.TypesToExtract;
 
         var entities = types.HasFlag(ExtractionTypes.Entities)
-            ? await _entityExtractor.ExtractAsync(request.Messages, cancellationToken)
+            ? await _entityExtractor.ExtractAsync(request.Messages, cancellationToken).ConfigureAwait(false)
             : Array.Empty<ExtractedEntity>();
 
         var facts = types.HasFlag(ExtractionTypes.Facts)
-            ? await _factExtractor.ExtractAsync(request.Messages, cancellationToken)
+            ? await _factExtractor.ExtractAsync(request.Messages, cancellationToken).ConfigureAwait(false)
             : Array.Empty<ExtractedFact>();
 
         var preferences = types.HasFlag(ExtractionTypes.Preferences)
-            ? await _preferenceExtractor.ExtractAsync(request.Messages, cancellationToken)
+            ? await _preferenceExtractor.ExtractAsync(request.Messages, cancellationToken).ConfigureAwait(false)
             : Array.Empty<ExtractedPreference>();
 
         var relationships = types.HasFlag(ExtractionTypes.Relationships)
-            ? await _relationshipExtractor.ExtractAsync(request.Messages, cancellationToken)
+            ? await _relationshipExtractor.ExtractAsync(request.Messages, cancellationToken).ConfigureAwait(false)
             : Array.Empty<ExtractedRelationship>();
 
         var sourceIds = request.Messages

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
@@ -41,7 +41,7 @@ public sealed class AzureLanguageEntityExtractor : ExtractorBase<ExtractedEntity
                     continue;
 
                 var entities = await _context.GetOrRecognizeEntitiesAsync(
-                    message.Content, _options.DefaultLanguage, _client, ct);
+                    message.Content, _options.DefaultLanguage, _client, ct).ConfigureAwait(false);
                 allEntities.AddRange(entities);
             }
         }

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
@@ -36,8 +36,8 @@ public sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>, I
             if (string.IsNullOrWhiteSpace(message.Content))
                 continue;
 
-            await AddKeyPhraseFacts(message, facts, ct);
-            await AddLinkedEntityFacts(message, facts, ct);
+            await AddKeyPhraseFacts(message, facts, ct).ConfigureAwait(false);
+            await AddLinkedEntityFacts(message, facts, ct).ConfigureAwait(false);
         }
 
         return facts;
@@ -46,7 +46,7 @@ public sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>, I
     private async Task AddKeyPhraseFacts(Message message, List<ExtractedFact> facts, CancellationToken ct)
     {
         var keyPhrases = await _client.ExtractKeyPhrasesAsync(
-            message.Content, _options.DefaultLanguage, ct);
+            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
 
         var context = message.Content.Length > 100
             ? message.Content[..100] + "..."
@@ -70,7 +70,7 @@ public sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>, I
     private async Task AddLinkedEntityFacts(Message message, List<ExtractedFact> facts, CancellationToken ct)
     {
         var linkedEntities = await _client.RecognizeLinkedEntitiesAsync(
-            message.Content, _options.DefaultLanguage, ct);
+            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
 
         foreach (var entity in linkedEntities)
         {

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
@@ -36,7 +36,7 @@ public sealed class AzureLanguagePreferenceExtractor : ExtractorBase<ExtractedPr
             if (string.IsNullOrWhiteSpace(message.Content))
                 continue;
 
-            await ExtractPreferencesFromMessage(message, preferences, ct);
+            await ExtractPreferencesFromMessage(message, preferences, ct).ConfigureAwait(false);
         }
 
         return preferences;
@@ -48,10 +48,10 @@ public sealed class AzureLanguagePreferenceExtractor : ExtractorBase<ExtractedPr
         CancellationToken ct)
     {
         var sentiment = await _client.AnalyzeSentimentAsync(
-            message.Content, _options.DefaultLanguage, ct);
+            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
 
         var keyPhrases = await _client.ExtractKeyPhrasesAsync(
-            message.Content, _options.DefaultLanguage, ct);
+            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
 
         var stronglyPositive = sentiment.PositiveScore >= _options.PreferenceSentimentThreshold;
         var stronglyNegative = sentiment.NegativeScore >= _options.PreferenceSentimentThreshold;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
@@ -40,7 +40,7 @@ public sealed class AzureLanguageRelationshipExtractor : ExtractorBase<Extracted
                 continue;
 
             var entityList = await _context.GetOrRecognizeEntitiesAsync(
-                message.Content, _options.DefaultLanguage, _client, ct);
+                message.Content, _options.DefaultLanguage, _client, ct).ConfigureAwait(false);
 
             for (int i = 0; i < entityList.Count - 1; i++)
             {

--- a/src/AgentMemory.Extraction.AzureLanguage/Internal/AzureExtractionContext.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/Internal/AzureExtractionContext.cs
@@ -22,7 +22,7 @@ internal sealed class AzureExtractionContext
         if (_entityCache.TryGetValue(cacheKey, out var cached))
             return cached;
 
-        var result = await client.RecognizeEntitiesAsync(content, language, ct);
+        var result = await client.RecognizeEntitiesAsync(content, language, ct).ConfigureAwait(false);
         var list = result.ToList();
         _entityCache.TryAdd(cacheKey, list);
         return list;

--- a/src/AgentMemory.Extraction.AzureLanguage/Internal/TextAnalyticsClientWrapper.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/Internal/TextAnalyticsClientWrapper.cs
@@ -14,7 +14,7 @@ internal sealed class TextAnalyticsClientWrapper : ITextAnalyticsClientWrapper
     public async Task<IReadOnlyList<AzureRecognizedEntity>> RecognizeEntitiesAsync(
         string document, string? language, CancellationToken ct)
     {
-        var response = await _client.RecognizeEntitiesAsync(document, language, ct);
+        var response = await _client.RecognizeEntitiesAsync(document, language, ct).ConfigureAwait(false);
         return response.Value
             .Select(e => new AzureRecognizedEntity(e.Text, e.Category.ToString(), e.ConfidenceScore, e.SubCategory))
             .ToList();
@@ -23,14 +23,14 @@ internal sealed class TextAnalyticsClientWrapper : ITextAnalyticsClientWrapper
     public async Task<IReadOnlyList<string>> ExtractKeyPhrasesAsync(
         string document, string? language, CancellationToken ct)
     {
-        var response = await _client.ExtractKeyPhrasesAsync(document, language, ct);
+        var response = await _client.ExtractKeyPhrasesAsync(document, language, ct).ConfigureAwait(false);
         return response.Value.ToList();
     }
 
     public async Task<IReadOnlyList<AzureLinkedEntity>> RecognizeLinkedEntitiesAsync(
         string document, string? language, CancellationToken ct)
     {
-        var response = await _client.RecognizeLinkedEntitiesAsync(document, language, ct);
+        var response = await _client.RecognizeLinkedEntitiesAsync(document, language, ct).ConfigureAwait(false);
         return response.Value
             .Select(e => new AzureLinkedEntity(e.Name, e.Url?.ToString()))
             .ToList();
@@ -39,7 +39,7 @@ internal sealed class TextAnalyticsClientWrapper : ITextAnalyticsClientWrapper
     public async Task<AzureSentimentResult> AnalyzeSentimentAsync(
         string document, string? language, CancellationToken ct)
     {
-        var response = await _client.AnalyzeSentimentAsync(document, language, cancellationToken: ct);
+        var response = await _client.AnalyzeSentimentAsync(document, language, cancellationToken: ct).ConfigureAwait(false);
         var doc = response.Value;
         return new AzureSentimentResult(
             doc.Sentiment.ToString().ToLowerInvariant(),

--- a/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
@@ -57,7 +57,7 @@ public sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEntity
             "Extract entities from this conversation:",
             conversationText,
             ProjectEntities,
-            ct);
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
@@ -54,7 +54,7 @@ public sealed class LlmFactExtractor : ExtractorBase<ExtractedFact>, IFactExtrac
             "Extract facts from this conversation:",
             conversationText,
             ProjectFacts,
-            ct);
+            ct).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedFact> ProjectFacts(LlmExtractionResponse dto)

--- a/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
@@ -53,7 +53,7 @@ public sealed class LlmPreferenceExtractor : ExtractorBase<ExtractedPreference>,
             "Extract preferences from this conversation:",
             conversationText,
             ProjectPreferences,
-            ct);
+            ct).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedPreference> ProjectPreferences(LlmExtractionResponse dto)

--- a/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
@@ -53,7 +53,7 @@ public sealed class LlmRelationshipExtractor : ExtractorBase<ExtractedRelationsh
             "Extract relationships from this conversation:",
             conversationText,
             ProjectRelationships,
-            ct);
+            ct).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedRelationship> ProjectRelationships(LlmExtractionResponse dto)

--- a/src/AgentMemory.McpServer/Resources/ContextResource.cs
+++ b/src/AgentMemory.McpServer/Resources/ContextResource.cs
@@ -33,7 +33,7 @@ public sealed class ContextResource
             Options = new RecallOptions { MaxRecentMessages = maxRecentMessages }
         };
 
-        var context = await contextAssembler.AssembleContextAsync(request, cancellationToken);
+        var context = await contextAssembler.AssembleContextAsync(request, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Resources/ConversationListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/ConversationListResource.cs
@@ -42,7 +42,7 @@ public sealed class ConversationListResource
         };
         if (hasOwner) parameters["userId"] = userId;
 
-        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken);
+        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Resources/EntityListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/EntityListResource.cs
@@ -53,7 +53,7 @@ public sealed class EntityListResource
         };
         if (hasOwner) parameters["ownerId"] = userId;
 
-        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken);
+        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Resources/MemoryStatusResource.cs
+++ b/src/AgentMemory.McpServer/Resources/MemoryStatusResource.cs
@@ -36,7 +36,7 @@ public sealed class MemoryStatusResource
             RETURN entityCount, factCount, preferenceCount, conversationCount, messageCount, count(t) AS traceCount
             """;
 
-        var results = await graphQueryService.QueryAsync(countQuery, cancellationToken: cancellationToken);
+        var results = await graphQueryService.QueryAsync(countQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
         var row = results.FirstOrDefault();
 
         return ToolJsonContext.Serialize(new

--- a/src/AgentMemory.McpServer/Resources/PreferenceListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/PreferenceListResource.cs
@@ -48,7 +48,7 @@ public sealed class PreferenceListResource
         };
         if (hasOwner) parameters["ownerId"] = userId;
 
-        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken);
+        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Resources/SchemaInfoResource.cs
+++ b/src/AgentMemory.McpServer/Resources/SchemaInfoResource.cs
@@ -21,9 +21,9 @@ public sealed class SchemaInfoResource
         var relTypesQuery = "CALL db.relationshipTypes() YIELD relationshipType RETURN collect(relationshipType) AS relationshipTypes";
         var propKeysQuery = "CALL db.propertyKeys() YIELD propertyKey RETURN collect(propertyKey) AS propertyKeys";
 
-        var labelsResult = await graphQueryService.QueryAsync(labelsQuery, cancellationToken: cancellationToken);
-        var relTypesResult = await graphQueryService.QueryAsync(relTypesQuery, cancellationToken: cancellationToken);
-        var propKeysResult = await graphQueryService.QueryAsync(propKeysQuery, cancellationToken: cancellationToken);
+        var labelsResult = await graphQueryService.QueryAsync(labelsQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var relTypesResult = await graphQueryService.QueryAsync(relTypesQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var propKeysResult = await graphQueryService.QueryAsync(propKeysQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var labels = labelsResult.FirstOrDefault()?.TryGetValue("labels", out var l) == true
             ? l as IEnumerable<object> ?? Array.Empty<object>()

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -41,7 +41,7 @@ public sealed class AdvancedMemoryTools
 
         var toolCall = await reasoningMemory.RecordToolCallAsync(
             stepId, toolName, input, output, toolStatus,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {
@@ -91,8 +91,8 @@ public sealed class AdvancedMemoryTools
             ["sessionId"] = (object?)sessionId
         };
 
-        var nodes = await graphQueryService.QueryAsync(nodeQuery, parameters, cancellationToken);
-        var relationships = await graphQueryService.QueryAsync(relQuery, parameters, cancellationToken);
+        var nodes = await graphQueryService.QueryAsync(nodeQuery, parameters, cancellationToken).ConfigureAwait(false);
+        var relationships = await graphQueryService.QueryAsync(relQuery, parameters, cancellationToken).ConfigureAwait(false);
 
         if (format.Equals("cypher", StringComparison.OrdinalIgnoreCase))
         {
@@ -158,7 +158,7 @@ public sealed class AdvancedMemoryTools
             ["limit"] = (long)limit
         };
 
-        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken);
+        var results = await graphQueryService.QueryAsync(query, parameters, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {
@@ -200,7 +200,7 @@ public sealed class AdvancedMemoryTools
                 Messages = new[] { message },
                 SessionId = sid,
                 UserId = userId
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {
@@ -226,7 +226,7 @@ public sealed class AdvancedMemoryTools
     {
         var sid = sessionId ?? options.Value.DefaultSessionId;
 
-        await memoryService.ExtractFromSessionAsync(sid, userId, cancellationToken);
+        await memoryService.ExtractFromSessionAsync(sid, userId, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {
@@ -242,7 +242,7 @@ public sealed class AdvancedMemoryTools
         [Description("Number of nodes to process per batch (default: 100)")] int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
-        var count = await memoryService.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken);
+        var count = await memoryService.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Tools/ConversationTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ConversationTools.cs
@@ -25,7 +25,7 @@ public sealed class ConversationTools
         // messages. Conversations carry user_id; deny when the conversation is owned by someone else.
         if (!string.IsNullOrEmpty(userId))
         {
-            var conversation = await conversationRepo.GetByIdAsync(conversationId, cancellationToken);
+            var conversation = await conversationRepo.GetByIdAsync(conversationId, cancellationToken).ConfigureAwait(false);
             if (conversation is null ||
                 (conversation.UserId is not null && conversation.UserId != userId))
             {
@@ -33,7 +33,7 @@ public sealed class ConversationTools
             }
         }
 
-        var messages = await shortTermMemory.GetConversationMessagesAsync(conversationId, cancellationToken);
+        var messages = await shortTermMemory.GetConversationMessagesAsync(conversationId, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(messages.Select(m => new
         {
             m.MessageId,
@@ -54,7 +54,7 @@ public sealed class ConversationTools
         CancellationToken cancellationToken = default)
     {
         var sid = sessionId ?? options.Value.DefaultSessionId;
-        var conversations = await conversationRepo.GetBySessionAsync(sid, cancellationToken);
+        var conversations = await conversationRepo.GetBySessionAsync(sid, cancellationToken).ConfigureAwait(false);
 
         // R1: a session id is shareable/guessable, so a scoped caller sees only their own (or un-attributed)
         // conversations — never another owner's. null userId ⇒ unscoped (admin/single-tenant).

--- a/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
@@ -31,7 +31,7 @@ public sealed class CoreMemoryTools
             Query = query
         };
 
-        var result = await memoryService.RecallAsync(request, cancellationToken);
+        var result = await memoryService.RecallAsync(request, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             result.TotalItemsRetrieved,
@@ -68,7 +68,7 @@ public sealed class CoreMemoryTools
             Query = query
         };
 
-        var result = await memoryService.RecallAsync(request, cancellationToken);
+        var result = await memoryService.RecallAsync(request, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(result);
     }
 
@@ -85,7 +85,7 @@ public sealed class CoreMemoryTools
         var sid = sessionId ?? options.Value.DefaultSessionId;
         var cid = conversationId ?? sid;
 
-        var message = await memoryService.AddMessageAsync(sid, cid, role, content, cancellationToken: cancellationToken);
+        var message = await memoryService.AddMessageAsync(sid, cid, role, content, cancellationToken: cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             message.MessageId,
@@ -123,7 +123,7 @@ public sealed class CoreMemoryTools
             CreatedAtUtc = clock.UtcNow
         };
 
-        var result = await longTermMemory.AddEntityAsync(entity, cancellationToken);
+        var result = await longTermMemory.AddEntityAsync(entity, cancellationToken).ConfigureAwait(false);
         var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {
@@ -164,7 +164,7 @@ public sealed class CoreMemoryTools
             CreatedAtUtc = clock.UtcNow
         };
 
-        var result = await longTermMemory.AddPreferenceAsync(preference, cancellationToken);
+        var result = await longTermMemory.AddPreferenceAsync(preference, cancellationToken).ConfigureAwait(false);
         var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {
@@ -209,7 +209,7 @@ public sealed class CoreMemoryTools
             Metadata = ParseMetadata(metadataJson) ?? new Dictionary<string, object>()
         };
 
-        var result = await longTermMemory.AddFactAsync(fact, cancellationToken);
+        var result = await longTermMemory.AddFactAsync(fact, cancellationToken).ConfigureAwait(false);
         var (persisted, reason) = PersistenceOutcome(confidenceValue, longTermOptions.Value.MinConfidenceThreshold);
         return ToolJsonContext.Serialize(new
         {

--- a/src/AgentMemory.McpServer/Tools/EntityTools.cs
+++ b/src/AgentMemory.McpServer/Tools/EntityTools.cs
@@ -22,7 +22,7 @@ public sealed class EntityTools
         CancellationToken cancellationToken = default)
     {
         var scope = string.IsNullOrEmpty(userId) ? null : MemoryScope.For(userId);
-        var provenance = await extractorRepository.GetProvenanceAsync(entityId, scope, cancellationToken);
+        var provenance = await extractorRepository.GetProvenanceAsync(entityId, scope, cancellationToken).ConfigureAwait(false);
         if (provenance is null)
             return ToolJsonContext.Serialize(new { entityId, found = false });
 
@@ -43,7 +43,7 @@ public sealed class EntityTools
         CancellationToken cancellationToken = default)
     {
         var scope = string.IsNullOrEmpty(userId) ? null : MemoryScope.For(userId);
-        var entities = await longTermMemory.GetEntitiesByNameAsync(name, includeAliases: true, scope, cancellationToken);
+        var entities = await longTermMemory.GetEntitiesByNameAsync(name, includeAliases: true, scope, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(entities.Select(e => new
         {
             e.EntityId,
@@ -69,7 +69,7 @@ public sealed class EntityTools
         CancellationToken cancellationToken = default)
     {
         var scope = string.IsNullOrEmpty(userId) ? null : MemoryScope.For(userId);
-        var entity = await longTermMemory.RecordEntityFeedbackAsync(entityId, positive, delta, scope, cancellationToken);
+        var entity = await longTermMemory.RecordEntityFeedbackAsync(entityId, positive, delta, scope, cancellationToken).ConfigureAwait(false);
         if (entity is null)
             return ToolJsonContext.Serialize(new { entityId, found = false });
 
@@ -108,7 +108,7 @@ public sealed class EntityTools
             CreatedAtUtc = clock.UtcNow
         };
 
-        var result = await longTermMemory.AddRelationshipAsync(relationship, cancellationToken);
+        var result = await longTermMemory.AddRelationshipAsync(relationship, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             result.RelationshipId,

--- a/src/AgentMemory.McpServer/Tools/GraphQueryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/GraphQueryTools.cs
@@ -24,7 +24,7 @@ public sealed class GraphQueryTools
             throw new McpException("The graph_query tool is disabled. Enable it in McpServerOptions.EnableGraphQuery.");
         }
 
-        var results = await graphQueryService.QueryAsync(cypherQuery, cancellationToken: cancellationToken);
+        var results = await graphQueryService.QueryAsync(cypherQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             rowCount = results.Count,

--- a/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
+++ b/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
@@ -27,9 +27,9 @@ public sealed class MaintenanceTools
 
         bool? invalidated = kind switch
         {
-            "fact" => await longTerm.InvalidateFactAsync(id, scope, cancellationToken),
-            "entity" => await longTerm.InvalidateEntityAsync(id, scope, cancellationToken),
-            "preference" or "pref" => await longTerm.InvalidatePreferenceAsync(id, scope, cancellationToken),
+            "fact" => await longTerm.InvalidateFactAsync(id, scope, cancellationToken).ConfigureAwait(false),
+            "entity" => await longTerm.InvalidateEntityAsync(id, scope, cancellationToken).ConfigureAwait(false),
+            "preference" or "pref" => await longTerm.InvalidatePreferenceAsync(id, scope, cancellationToken).ConfigureAwait(false),
             _ => null,
         };
 
@@ -52,8 +52,8 @@ public sealed class MaintenanceTools
 
         bool? superseded = kind switch
         {
-            "fact" => await longTerm.SupersedeFactAsync(loserId, winnerId, scope, cancellationToken),
-            "preference" or "pref" => await longTerm.SupersedePreferenceAsync(loserId, winnerId, scope, cancellationToken),
+            "fact" => await longTerm.SupersedeFactAsync(loserId, winnerId, scope, cancellationToken).ConfigureAwait(false),
+            "preference" or "pref" => await longTerm.SupersedePreferenceAsync(loserId, winnerId, scope, cancellationToken).ConfigureAwait(false),
             _ => null,
         };
 

--- a/src/AgentMemory.McpServer/Tools/ObservationTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ObservationTools.cs
@@ -30,7 +30,7 @@ public sealed class ObservationTools
         var sid = sessionId ?? options.Value.DefaultSessionId;
         maxTokens = Math.Clamp(maxTokens, 256, 100_000); // a non-positive/absurd budget would break compression
 
-        var messages = await shortTermMemory.GetRecentMessagesAsync(sid, limit: 100, cancellationToken);
+        var messages = await shortTermMemory.GetRecentMessagesAsync(sid, limit: 100, cancellationToken).ConfigureAwait(false);
 
         if (messages.Count == 0)
         {
@@ -55,7 +55,7 @@ public sealed class ObservationTools
             EnableReflections = true
         };
 
-        var compressed = await compressor.CompressAsync(messages, compressionOptions, cancellationToken);
+        var compressed = await compressor.CompressAsync(messages, compressionOptions, cancellationToken).ConfigureAwait(false);
 
         var observations = new List<string>();
         if (compressed.WasCompressed)

--- a/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
@@ -20,7 +20,7 @@ public sealed class ReasoningTools
         CancellationToken cancellationToken = default)
     {
         var sid = sessionId ?? options.Value.DefaultSessionId;
-        var trace = await reasoningMemory.StartTraceAsync(sid, task, cancellationToken: cancellationToken);
+        var trace = await reasoningMemory.StartTraceAsync(sid, task, cancellationToken: cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             trace.TraceId,
@@ -45,7 +45,7 @@ public sealed class ReasoningTools
     {
         var step = await reasoningMemory.AddStepAsync(
             traceId, stepNumber, thought, action, observation,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             step.StepId,
@@ -65,7 +65,7 @@ public sealed class ReasoningTools
         [Description("Whether the task was successful (optional)")] bool? success = null,
         CancellationToken cancellationToken = default)
     {
-        var trace = await reasoningMemory.CompleteTraceAsync(traceId, outcome, success, cancellationToken);
+        var trace = await reasoningMemory.CompleteTraceAsync(traceId, outcome, success, cancellationToken).ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             trace.TraceId,

--- a/src/AgentMemory.Neo4j/Infrastructure/MigrationRunner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/MigrationRunner.cs
@@ -43,19 +43,19 @@ public sealed class MigrationRunner : IMigrationRunner
             return;
         }
 
-        await EnsureMigrationConstraintAsync(cancellationToken);
+        await EnsureMigrationConstraintAsync(cancellationToken).ConfigureAwait(false);
 
         foreach (var (version, filePath) in migrationFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (await IsMigrationAppliedAsync(version, cancellationToken))
+            if (await IsMigrationAppliedAsync(version, cancellationToken).ConfigureAwait(false))
             {
                 _logger.LogDebug("Migration {Version} already applied, skipping.", version);
                 continue;
             }
 
-            await ApplyMigrationAsync(version, filePath, cancellationToken);
+            await ApplyMigrationAsync(version, filePath, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -73,7 +73,7 @@ public sealed class MigrationRunner : IMigrationRunner
 
     private async Task EnsureMigrationConstraintAsync(CancellationToken cancellationToken)
     {
-        await _txRunner.WriteAsync(async tx => { await tx.RunAsync(SchemaQueries.MigrationVersionConstraint); }, cancellationToken);
+        await _txRunner.WriteAsync(async tx => { await tx.RunAsync(SchemaQueries.MigrationVersionConstraint).ConfigureAwait(false); }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> IsMigrationAppliedAsync(string version, CancellationToken cancellationToken)
@@ -82,14 +82,14 @@ public sealed class MigrationRunner : IMigrationRunner
         {
             var cursor = await tx.RunAsync(
                 SchemaQueries.IsMigrationApplied,
-                new { version });
-            return await cursor.FetchAsync();
-        }, cancellationToken);
+                new { version }).ConfigureAwait(false);
+            return await cursor.FetchAsync().ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ApplyMigrationAsync(string version, string filePath, CancellationToken cancellationToken)
     {
-        var fileContent = await File.ReadAllTextAsync(filePath, cancellationToken);
+        var fileContent = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
         var statements = ParseStatements(fileContent);
 
         _logger.LogInformation(
@@ -103,15 +103,15 @@ public sealed class MigrationRunner : IMigrationRunner
         foreach (var statement in statements)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _txRunner.WriteAsync(async tx => { await tx.RunAsync(statement); }, cancellationToken);
+            await _txRunner.WriteAsync(async tx => { await tx.RunAsync(statement).ConfigureAwait(false); }, cancellationToken).ConfigureAwait(false);
         }
 
         await _txRunner.WriteAsync(async tx =>
         {
             await tx.RunAsync(
                 SchemaQueries.RecordMigration,
-                new { version, appliedAtUtc = DateTime.UtcNow.ToString("O") });
-        }, cancellationToken);
+                new { version, appliedAtUtc = DateTime.UtcNow.ToString("O") }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Migration {Version} applied successfully.", version);
     }

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jDriverFactory.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jDriverFactory.cs
@@ -34,6 +34,6 @@ public sealed class Neo4jDriverFactory : INeo4jDriverFactory
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing Neo4j driver.");
-        await _driver.DisposeAsync();
+        await _driver.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jMemoryStoreProvisioner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jMemoryStoreProvisioner.cs
@@ -62,8 +62,8 @@ public sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
             return;
         }
 
-        await CreateDatabaseAsync(database, cancellationToken);
-        await BootstrapDatabaseAsync(database, cancellationToken);
+        await CreateDatabaseAsync(database, cancellationToken).ConfigureAwait(false);
+        await BootstrapDatabaseAsync(database, cancellationToken).ConfigureAwait(false);
 
         _provisioned.TryAdd(database, 0);
         _logger.LogInformation("Provisioned memory store database '{Database}' for application '{App}'.",
@@ -76,10 +76,11 @@ public sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
         // WAIT blocks until the database is online, so the subsequent bootstrap can connect.
         // The name must be backtick-quoted: StoreDatabaseNaming yields legal-charset names, but the
         // default 'mem-' prefix contains a dash, and unquoted dashes are a Cypher syntax error.
-        await using var session = _sessionFactory.OpenSession(SystemDatabase, AccessMode.Write);
+        var session = _sessionFactory.OpenSession(SystemDatabase, AccessMode.Write);
+        await using var _ = session.ConfigureAwait(false); // ConfigureAwait the disposal without rebinding session's type
         try
         {
-            await session.ExecuteWriteAsync(tx => tx.RunAsync($"CREATE DATABASE {QuoteName(database)} IF NOT EXISTS WAIT"));
+            await session.ExecuteWriteAsync(tx => tx.RunAsync($"CREATE DATABASE {QuoteName(database)} IF NOT EXISTS WAIT")).ConfigureAwait(false);
         }
         catch (Neo4jException ex) when (IsMultiDatabaseUnsupported(ex))
         {
@@ -96,14 +97,15 @@ public sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
         // Each schema statement runs in its own transaction against the freshly created database.
         // All statements are idempotent (IF NOT EXISTS), so re-provisioning is safe.
         var statements = SchemaQueries.BootstrapStatements(_embeddingDimensions);
-        await using var session = _sessionFactory.OpenSession(database, AccessMode.Write);
+        var session = _sessionFactory.OpenSession(database, AccessMode.Write);
+        await using var _ = session.ConfigureAwait(false); // ConfigureAwait the disposal without rebinding session's type
         foreach (var statement in statements)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await session.ExecuteWriteAsync(tx => tx.RunAsync(statement));
+            await session.ExecuteWriteAsync(tx => tx.RunAsync(statement)).ConfigureAwait(false);
         }
 
-        await ValidateVectorIndexDimensionsAsync(session, cancellationToken);
+        await ValidateVectorIndexDimensionsAsync(session, cancellationToken).ConfigureAwait(false);
     }
 
     // Mirrors SchemaBootstrapper's guard for the shared database: a per-app database that already
@@ -119,10 +121,10 @@ public sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
 
         var existing = await session.ExecuteReadAsync(async tx =>
         {
-            var cursor = await tx.RunAsync(SchemaQueries.ShowVectorIndexDimensions);
-            var records = await cursor.ToListAsync();
+            var cursor = await tx.RunAsync(SchemaQueries.ShowVectorIndexDimensions).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return VectorIndexDimensionValidator.MapRows(records);
-        }) ?? [];
+        }).ConfigureAwait(false) ?? [];
 
         VectorIndexDimensionValidator.EnsureMatches(_embeddingDimensions, existing);
     }

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
@@ -27,10 +27,11 @@ public sealed class Neo4jTransactionRunner : INeo4jTransactionRunner
     public async Task<T> ReadAsync<T>(Func<IAsyncQueryRunner, Task<T>> work, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        await using var session = _sessionFactory.OpenSession(AccessMode.Read);
+        var session = _sessionFactory.OpenSession(AccessMode.Read);
+        await using var _ = session.ConfigureAwait(false); // ConfigureAwait the disposal without rebinding session's type
         try
         {
-            return await session.ExecuteReadAsync(work);
+            return await session.ExecuteReadAsync(work).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -43,18 +44,19 @@ public sealed class Neo4jTransactionRunner : INeo4jTransactionRunner
     {
         await ReadAsync(async tx =>
         {
-            await work(tx);
+            await work(tx).ConfigureAwait(false);
             return true;
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<T> WriteAsync<T>(Func<IAsyncQueryRunner, Task<T>> work, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        await using var session = _sessionFactory.OpenSession(AccessMode.Write);
+        var session = _sessionFactory.OpenSession(AccessMode.Write);
+        await using var _ = session.ConfigureAwait(false); // ConfigureAwait the disposal without rebinding session's type
         try
         {
-            return await session.ExecuteWriteAsync(work);
+            return await session.ExecuteWriteAsync(work).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -67,8 +69,8 @@ public sealed class Neo4jTransactionRunner : INeo4jTransactionRunner
     {
         await WriteAsync(async tx =>
         {
-            await work(tx);
+            await work(tx).ConfigureAwait(false);
             return true;
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Neo4j/Infrastructure/SchemaBootstrapper.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/SchemaBootstrapper.cs
@@ -38,31 +38,31 @@ public sealed class SchemaBootstrapper : ISchemaBootstrapper
         foreach (var constraint in SchemaQueries.Constraints)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await RunStatementAsync(constraint, cancellationToken);
+            await RunStatementAsync(constraint, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var index in SchemaQueries.FulltextIndexes)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await RunStatementAsync(index, cancellationToken);
+            await RunStatementAsync(index, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var index in _vectorIndexes)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await RunStatementAsync(index, cancellationToken);
+            await RunStatementAsync(index, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var index in SchemaQueries.PropertyIndexes)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await RunStatementAsync(index, cancellationToken);
+            await RunStatementAsync(index, cancellationToken).ConfigureAwait(false);
         }
 
         // Fail-fast guard: a CREATE VECTOR INDEX ... IF NOT EXISTS above is a no-op when the index
         // already exists, so an embedder/dimension change leaves stale indexes that would only fail at
         // query time. Verify dimensions now and surface an actionable error listing every mismatch.
-        await ValidateVectorIndexDimensionsAsync(cancellationToken);
+        await ValidateVectorIndexDimensionsAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Schema bootstrap complete.");
     }
@@ -77,11 +77,11 @@ public sealed class SchemaBootstrapper : ISchemaBootstrapper
         var existing = await _txRunner.ReadAsync(
             async runner =>
             {
-                var cursor = await runner.RunAsync(SchemaQueries.ShowVectorIndexDimensions);
-                var records = await cursor.ToListAsync();
+                var cursor = await runner.RunAsync(SchemaQueries.ShowVectorIndexDimensions).ConfigureAwait(false);
+                var records = await cursor.ToListAsync().ConfigureAwait(false);
                 return VectorIndexDimensionValidator.MapRows(records);
             },
-            cancellationToken) ?? [];
+            cancellationToken).ConfigureAwait(false) ?? [];
 
         VectorIndexDimensionValidator.EnsureMatches(_embeddingDimensions, existing);
         _logger.LogDebug(
@@ -94,8 +94,8 @@ public sealed class SchemaBootstrapper : ISchemaBootstrapper
         try
         {
             await _txRunner.WriteAsync(
-                async tx => { await tx.RunAsync(cypher); },
-                cancellationToken);
+                async tx => { await tx.RunAsync(cypher).ConfigureAwait(false); },
+                cancellationToken).ConfigureAwait(false);
 
             _logger.LogDebug("Executed schema statement: {Cypher}", cypher);
         }

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
@@ -36,10 +36,10 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ConversationQueries.Upsert, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(ConversationQueries.Upsert, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return MapToConversation(record["c"].As<INode>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Conversation?> GetByIdAsync(string conversationId, CancellationToken cancellationToken = default)
@@ -48,10 +48,10 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ConversationQueries.GetById, new { id = conversationId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ConversationQueries.GetById, new { id = conversationId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count == 0 ? null : MapToConversation(records[0]["c"].As<INode>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Conversation>> GetBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
@@ -60,10 +60,10 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ConversationQueries.GetBySession, new { sessionId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ConversationQueries.GetBySession, new { sessionId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToConversation(r["c"].As<INode>())).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(string conversationId, CancellationToken cancellationToken = default)
@@ -72,8 +72,8 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(ConversationQueries.Delete, new { id = conversationId });
-        }, cancellationToken);
+            await runner.RunAsync(ConversationQueries.Delete, new { id = conversationId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
@@ -82,8 +82,8 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(ConversationQueries.DeleteBySession, new { sessionId });
-        }, cancellationToken);
+            await runner.RunAsync(ConversationQueries.DeleteBySession, new { sessionId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<SessionSummary>> ListSessionsAsync(int limit = 50, CancellationToken ct = default)
@@ -92,8 +92,8 @@ public sealed class Neo4jConversationRepository : IConversationRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ConversationQueries.ListSessions, new { limit });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ConversationQueries.ListSessions, new { limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var sessionId = r["sessionId"].As<string>();
@@ -105,7 +105,7 @@ public sealed class Neo4jConversationRepository : IConversationRepository
                     : null;
                 return new SessionSummary(sessionId, convCount, msgCount, lastPreview, lastActivity);
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     private static Conversation MapToConversation(INode node) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -59,8 +59,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 ["metadata"]       = SerializeMetadata(entity.Metadata)
             };
 
-            var cursor = await runner.RunAsync(EntityQueries.Upsert, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.Upsert, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             var node = records.Count > 0 ? records[0]["e"].As<INode>() : null;
 
             // Persist geospatial location if provided
@@ -68,7 +68,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetEntityLocation,
-                    new { id = entity.EntityId, lat = entity.Latitude.Value, lon = entity.Longitude.Value });
+                    new { id = entity.EntityId, lat = entity.Latitude.Value, lon = entity.Longitude.Value }).ConfigureAwait(false);
             }
 
             // Only persist a real (non-empty) vector. A zero-length embedding (the orchestrator's
@@ -79,7 +79,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetEntityEmbedding,
-                    new { id = entity.EntityId, embedding = entity.Embedding.ToList() });
+                    new { id = entity.EntityId, embedding = entity.Embedding.ToList() }).ConfigureAwait(false);
             }
 
             // Dynamically add POLE+O type labels
@@ -87,7 +87,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             if (labels.Count > 0)
             {
                 var labelClause = string.Join(", ", labels.Select(l => $"e:{SanitizeLabel(l)}"));
-                await runner.RunAsync($"MATCH (e:Entity {{id: $id}}) SET {labelClause}", new { id = entity.EntityId });
+                await runner.RunAsync($"MATCH (e:Entity {{id: $id}}) SET {labelClause}", new { id = entity.EntityId }).ConfigureAwait(false);
             }
 
             // Auto-create EXTRACTED_FROM relationships for all source messages
@@ -95,7 +95,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.LinkEntityExtractedFrom,
-                    new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() });
+                    new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() }).ConfigureAwait(false);
             }
 
             // The `node` was captured from the MERGE BEFORE the geospatial location was written in a
@@ -104,7 +104,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             return node is not null
                 ? MapToEntity(node, entity.Embedding) with { Latitude = entity.Latitude, Longitude = entity.Longitude }
                 : entity;
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Entity?> GetByIdAsync(string entityId, CancellationToken cancellationToken = default)
@@ -113,12 +113,12 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetById, new { id = entityId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetById, new { id = entityId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["e"].As<INode>();
             return MapToEntity(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> GetByNameAsync(
@@ -135,14 +135,14 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Score)>> SearchByVectorAsync(
@@ -174,15 +174,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToEntity(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> GetByTypeAsync(string type, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -196,15 +196,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["type"] = type, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { type });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["type"] = type, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { type }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> SearchByNameAsync(string name, string? type = null, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -218,15 +218,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object?> { ["name"] = name, ["type"] = type, ["ownerId"] = scope!.OwnerId })
-                : await runner.RunAsync(cypher, new { name, type });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object?> { ["name"] = name, ["type"] = type, ["ownerId"] = scope!.OwnerId }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { name, type }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task AddMentionAsync(string messageId, string entityId, double? confidence = null, int? startPos = null, int? endPos = null, string? context = null, CancellationToken cancellationToken = default)
@@ -235,8 +235,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(EntityQueries.AddMention, new { messageId, entityId, confidence = (object?)confidence, startPos = (object?)startPos, endPos = (object?)endPos, context = (object?)context });
-        }, cancellationToken);
+            await runner.RunAsync(EntityQueries.AddMention, new { messageId, entityId, confidence = (object?)confidence, startPos = (object?)startPos, endPos = (object?)endPos, context = (object?)context }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task AddMentionsBatchAsync(string messageId, IReadOnlyList<string> entityIds, double? confidence = null, CancellationToken cancellationToken = default)
@@ -245,8 +245,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(EntityQueries.AddMentionsBatch, new { messageId, entityIds = entityIds.ToList(), confidence = (object?)confidence });
-        }, cancellationToken);
+            await runner.RunAsync(EntityQueries.AddMentionsBatch, new { messageId, entityIds = entityIds.ToList(), confidence = (object?)confidence }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task AddSameAsRelationshipAsync(string entityId1, string entityId2, double confidence, string matchType, string status = "pending", CancellationToken cancellationToken = default)
@@ -256,8 +256,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(EntityQueries.AddSameAs, new { entityId1, entityId2, confidence, matchType, status });
-        }, cancellationToken);
+            await runner.RunAsync(EntityQueries.AddSameAs, new { entityId1, entityId2, confidence, matchType, status }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Confidence, string MatchType)>> GetSameAsEntitiesAsync(string entityId, CancellationToken cancellationToken = default)
@@ -266,8 +266,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetSameAsEntities, new { entityId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetSameAsEntities, new { entityId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node       = r["other"].As<INode>();
@@ -275,7 +275,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 var matchType  = r["matchType"].As<string>();
                 return (MapToEntity(node, ReadEmbedding(node)), confidence, matchType);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> UpsertBatchAsync(IReadOnlyList<Entity> entities, CancellationToken cancellationToken = default)
@@ -303,8 +303,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.UpsertBatch, new { items });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.UpsertBatch, new { items }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
 
             // Set embeddings individually — only for nodes with a real (non-empty) vector, so a degraded
             // empty embedding leaves `embedding` NULL and re-queueable for the back-fill (see UpsertAsync).
@@ -312,7 +312,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetEntityEmbedding,
-                    new { id = entity.EntityId, embedding = entity.Embedding!.ToList() });
+                    new { id = entity.EntityId, embedding = entity.Embedding!.ToList() }).ConfigureAwait(false);
             }
 
             // Persist geospatial location individually (parity with single UpsertAsync — the UNWIND
@@ -321,7 +321,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetEntityLocation,
-                    new { id = entity.EntityId, lat = entity.Latitude!.Value, lon = entity.Longitude!.Value });
+                    new { id = entity.EntityId, lat = entity.Latitude!.Value, lon = entity.Longitude!.Value }).ConfigureAwait(false);
             }
 
             // Dynamically add POLE+O type labels
@@ -331,7 +331,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 if (labels.Count > 0)
                 {
                     var labelClause = string.Join(", ", labels.Select(l => $"e:{SanitizeLabel(l)}"));
-                    await runner.RunAsync($"MATCH (e:Entity {{id: $id}}) SET {labelClause}", new { id = entity.EntityId });
+                    await runner.RunAsync($"MATCH (e:Entity {{id: $id}}) SET {labelClause}", new { id = entity.EntityId }).ConfigureAwait(false);
                 }
             }
 
@@ -340,7 +340,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 await runner.RunAsync(
                     SharedFragments.LinkEntityExtractedFrom,
-                    new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() });
+                    new { id = entity.EntityId, sourceMessageIds = entity.SourceMessageIds.ToList() }).ConfigureAwait(false);
             }
 
             // Records were read before embeddings/location were written, so carry the caller-supplied
@@ -354,7 +354,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                     return MapToEntity(node, null);
                 return MapToEntity(node, src.Embedding) with { Latitude = src.Latitude, Longitude = src.Longitude };
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateExtractedFromRelationshipAsync(string entityId, string messageId, double? confidence = null, int? startPos = null, int? endPos = null, string? context = null, CancellationToken cancellationToken = default)
@@ -365,8 +365,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         {
             await runner.RunAsync(
                 EntityQueries.CreateExtractedFrom,
-                new { entityId, messageId, confidence = (object?)confidence, startPos = (object?)startPos, endPos = (object?)endPos, context = (object?)context });
-        }, cancellationToken);
+                new { entityId, messageId, confidence = (object?)confidence, startPos = (object?)startPos, endPos = (object?)endPos, context = (object?)context }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task MergeEntitiesAsync(string sourceEntityId, string targetEntityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -380,12 +380,12 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         await _tx.WriteAsync(async runner =>
         {
             if (hasOwner)
-                await runner.RunAsync(cypher, new Dictionary<string, object> { ["sourceEntityId"] = sourceEntityId, ["targetEntityId"] = targetEntityId, ["ownerId"] = scope!.OwnerId! });
+                await runner.RunAsync(cypher, new Dictionary<string, object> { ["sourceEntityId"] = sourceEntityId, ["targetEntityId"] = targetEntityId, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false);
             else
-                await runner.RunAsync(cypher, new { sourceEntityId, targetEntityId });
-        }, cancellationToken);
+                await runner.RunAsync(cypher, new { sourceEntityId, targetEntityId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
-        await RefreshEntitySearchFieldsAsync(targetEntityId, cancellationToken);
+        await RefreshEntitySearchFieldsAsync(targetEntityId, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task RefreshEntitySearchFieldsAsync(string entityId, CancellationToken cancellationToken = default)
@@ -398,8 +398,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
             {
                 entityId,
                 updatedAt = DateTimeOffset.UtcNow.ToString("O")
-            });
-        }, cancellationToken);
+            }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Entity MapToEntity(INode node, float[]? embedding)
@@ -455,12 +455,12 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["e"].As<INode>();
             return MapToEntity(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> SearchByLocationAsync(
@@ -483,15 +483,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 ? await runner.RunAsync(cypher, new Dictionary<string, object>
                 {
                     ["lat"] = latitude, ["lon"] = longitude, ["radiusMeters"] = radiusKm * 1000.0, ["limit"] = limit, ["ownerId"] = scope!.OwnerId!,
-                })
-                : await runner.RunAsync(cypher, new { lat = latitude, lon = longitude, radiusMeters = radiusKm * 1000.0, limit });
-            var records = await cursor.ToListAsync();
+                }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { lat = latitude, lon = longitude, radiusMeters = radiusKm * 1000.0, limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> SearchInBoundingBoxAsync(
@@ -516,15 +516,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 ? await runner.RunAsync(cypher, new Dictionary<string, object>
                 {
                     ["minLat"] = minLat, ["minLon"] = minLon, ["maxLat"] = maxLat, ["maxLon"] = maxLon, ["limit"] = limit, ["ownerId"] = scope!.OwnerId!,
-                })
-                : await runner.RunAsync(cypher, new { minLat, minLon, maxLat, maxLon, limit });
-            var records = await cursor.ToListAsync();
+                }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { minLat, minLon, maxLat, maxLon, limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<PagedResult<Entity>> GetPageWithoutEmbeddingAsync(
@@ -535,15 +535,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetPageWithoutEmbedding, new { limit = limit + 1 });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetPageWithoutEmbedding, new { limit = limit + 1 }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             var items = records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, null);
             }).ToList();
             return PaginationHelper.ApplyPagination(items, limit);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdateEmbeddingAsync(
@@ -566,8 +566,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         {
             await runner.RunAsync(
                 EntityQueries.UpdateEmbedding,
-                new { id = entityId, embedding = embedding.ToList() });
-        }, cancellationToken);
+                new { id = entityId, embedding = embedding.ToList() }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> DeleteAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -580,11 +580,11 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         return await _tx.WriteAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { entityId });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { entityId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> InvalidateAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -599,10 +599,10 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         {
             var parameters = new Dictionary<string, object?> { ["id"] = entityId, ["now"] = now };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["invalidated"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Similarity)>> FindSimilarByEmbeddingAsync(
@@ -620,16 +620,16 @@ public sealed class Neo4jEntityRepository : IEntityRepository
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["topK"] = topK, ["minSimilarity"] = minSimilarity, ["limit"] = limit, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { entityId, topK, minSimilarity, limit });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["topK"] = topK, ["minSimilarity"] = minSimilarity, ["limit"] = limit, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { entityId, topK, minSimilarity, limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToEntity(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<DuplicatePair>> GetPendingDuplicatesAsync(
@@ -639,8 +639,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetPendingDuplicates, new { limit });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetPendingDuplicates, new { limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var source = MapToEntity(r["a"].As<INode>(), ReadEmbedding(r["a"].As<INode>()));
@@ -649,7 +649,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 var status = r["status"].As<string>();
                 return new DuplicatePair(source, target, similarity, status);
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     public async Task<DeduplicationStats> GetDeduplicationStatsAsync(CancellationToken ct = default)
@@ -658,8 +658,8 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetDeduplicationStats, new { });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetDeduplicationStats, new { }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0)
                 return new DeduplicationStats(0, 0, 0, 0);
 
@@ -669,7 +669,7 @@ public sealed class Neo4jEntityRepository : IEntityRepository
                 ConfirmedCount: record["confirmed"].As<int>(),
                 RejectedCount: record["rejected"].As<int>(),
                 MergedCount: record["merged"].As<int>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> GetEntitiesFromMessageAsync(
@@ -679,14 +679,14 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(EntityQueries.GetEntitiesFromMessage, new { messageId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(EntityQueries.GetEntitiesFromMessage, new { messageId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Score)>> SearchByVectorAsOfAsync(
@@ -717,15 +717,15 @@ public sealed class Neo4jEntityRepository : IEntityRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToEntity(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static float[]? ReadEmbedding(INode node)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
@@ -39,12 +39,12 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
                 name = extractor.Name,
                 version = (object?)extractor.Version,
                 config = (object?)extractor.ConfigJson
-            });
-            var records = await cursor.ToListAsync();
+            }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count > 0)
                 return MapToExtractor(records[0]["ex"].As<INode>());
             return extractor;
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -54,11 +54,11 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.GetByName, new { name });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.GetByName, new { name }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             return MapToExtractor(records[0]["ex"].As<INode>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -68,10 +68,10 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.List, new { });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.List, new { }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToExtractor(r["ex"].As<INode>())).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -92,8 +92,8 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
                 extractor_name = extractorName,
                 confidence,
                 extraction_time_ms = (object?)extractionTimeMs
-            });
-        }, ct);
+            }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -106,15 +106,15 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.GetEntitiesByExtractor, new { extractor_name = extractorName, limit });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.GetEntitiesByExtractor, new { extractor_name = extractorName, limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["e"].As<INode>();
                 var conf = r["confidence"].As<double>();
                 return (MapToEntity(node), conf);
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -129,9 +129,9 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { entityId });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["entityId"] = entityId, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { entityId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
 
             var record = records[0];
@@ -158,7 +158,7 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
                 .ToList();
 
             return new EntityProvenance(id, sources, extractors);
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -168,8 +168,8 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.GetExtractionStats, new { });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.GetExtractionStats, new { }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return new ExtractionStats(0, 0, 0.0);
 
             var record = records[0];
@@ -177,7 +177,7 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
                 record["totalEntities"].As<int>(),
                 record["totalMessages"].As<int>(),
                 record["avgPerMessage"].As<double>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -187,8 +187,8 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.GetExtractorStats, new { extractorName });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.GetExtractorStats, new { extractorName }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
 
             var record = records[0];
@@ -200,7 +200,7 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
                 record["entityCount"].As<int>(),
                 record["avgConfidence"] is not null ? record["avgConfidence"].As<double>() : 0.0,
                 record["totalExtractions"].As<int>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -210,10 +210,10 @@ public sealed class Neo4jExtractorRepository : IExtractorRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ExtractorQueries.DeleteEntityProvenance, new { entityId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ExtractorQueries.DeleteEntityProvenance, new { entityId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 ? records[0]["deleted"].As<int>() : 0;
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     private static Extractor MapToExtractor(INode node)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -66,8 +66,8 @@ public sealed class Neo4jFactRepository : IFactRepository
                 ["metadata"]         = SerializeMetadata(fact.Metadata)
             };
 
-            var cursor = await runner.RunAsync(FactQueries.Upsert, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(FactQueries.Upsert, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             var node = record["f"].As<INode>();
 
             // The MERGE is on the {subject,predicate,object,owner_key} triple and ON MATCH deliberately never
@@ -82,7 +82,7 @@ public sealed class Neo4jFactRepository : IFactRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetFactEmbedding,
-                    new { id = mergedId, embedding = fact.Embedding.ToList() });
+                    new { id = mergedId, embedding = fact.Embedding.ToList() }).ConfigureAwait(false);
             }
 
             // Auto-create EXTRACTED_FROM relationships for all source messages
@@ -90,11 +90,11 @@ public sealed class Neo4jFactRepository : IFactRepository
             {
                 await runner.RunAsync(
                     SharedFragments.LinkFactExtractedFrom,
-                    new { id = mergedId, sourceMessageIds = fact.SourceMessageIds.ToList() });
+                    new { id = mergedId, sourceMessageIds = fact.SourceMessageIds.ToList() }).ConfigureAwait(false);
             }
 
             return MapToFact(node, fact.Embedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Fact>> UpsertBatchAsync(IReadOnlyList<Fact> facts, CancellationToken cancellationToken = default)
@@ -134,8 +134,8 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(FactQueries.UpsertBatch, new { items });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(FactQueries.UpsertBatch, new { items }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
 
             // The MERGE returns the SURVIVING node per triple; for a pre-existing triple that id is the
             // ORIGINAL node id, not the caller's fresh FactId. Resolve the embedding/provenance sub-writes
@@ -160,7 +160,7 @@ public sealed class Neo4jFactRepository : IFactRepository
                 if (NodeIdFor(fact) is not { } nodeId) continue;
                 await runner.RunAsync(
                     SharedFragments.SetFactEmbedding,
-                    new { id = nodeId, embedding = fact.Embedding!.ToList() });
+                    new { id = nodeId, embedding = fact.Embedding!.ToList() }).ConfigureAwait(false);
             }
 
             // Auto-create EXTRACTED_FROM relationships on the surviving node.
@@ -169,7 +169,7 @@ public sealed class Neo4jFactRepository : IFactRepository
                 if (NodeIdFor(fact) is not { } nodeId) continue;
                 await runner.RunAsync(
                     SharedFragments.LinkFactExtractedFrom,
-                    new { id = nodeId, sourceMessageIds = fact.SourceMessageIds.ToList() });
+                    new { id = nodeId, sourceMessageIds = fact.SourceMessageIds.ToList() }).ConfigureAwait(false);
             }
 
             var embeddingByTriple = deduped.ToDictionary(
@@ -182,7 +182,7 @@ public sealed class Neo4jFactRepository : IFactRepository
                                      node["object"].As<string>(), node["owner_key"].As<string>());
                 return MapToFact(node, embeddingByTriple.TryGetValue(key, out var emb) ? emb : null);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Fact?> GetByIdAsync(string factId, CancellationToken cancellationToken = default)
@@ -191,12 +191,12 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(FactQueries.GetById, new { id = factId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(FactQueries.GetById, new { id = factId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["f"].As<INode>();
             return MapToFact(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Fact>> GetBySubjectAsync(
@@ -212,14 +212,14 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["f"].As<INode>();
                 return MapToFact(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Fact Fact, double Score)>> SearchByVectorAsync(
@@ -251,15 +251,15 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToFact(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     // Small candidate set for dedup lookups: a near-duplicate by subject+predicate is rare, so a
@@ -285,27 +285,27 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["node"].As<INode>();
             return MapToFact(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Fact?> MarkDeduplicatedAsync(string factId, double confidence, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Reinforcing fact {FactId} via dedup (confidence={Confidence}).", factId, confidence);
-        return await _tx.WriteAsync<Fact?>(async runner =>
+        return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(FactQueries.MarkDeduplicated, new { id = factId, confidence });
+            var cursor = await runner.RunAsync(FactQueries.MarkDeduplicated, new { id = factId, confidence }).ConfigureAwait(false);
             // 0/1-row read (not SingleAsync): the node can be concurrently hard-deleted between the dedup
             // lookup and this write (e.g. a destructive decay prune), leaving an empty result.
-            var records = await cursor.ToListAsync();
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["f"].As<INode>();
             return MapToFact(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateExtractedFromRelationshipAsync(string factId, string messageId, CancellationToken cancellationToken = default)
@@ -316,8 +316,8 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             await runner.RunAsync(
                 FactQueries.CreateExtractedFrom,
-                new { factId, messageId });
-        }, cancellationToken);
+                new { factId, messageId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateAboutRelationshipAsync(string factId, string entityId, CancellationToken cancellationToken = default)
@@ -328,8 +328,8 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             await runner.RunAsync(
                 FactQueries.CreateAbout,
-                new { factId, entityId });
-        }, cancellationToken);
+                new { factId, entityId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateConversationFactRelationshipAsync(string conversationId, string factId, CancellationToken cancellationToken = default)
@@ -340,8 +340,8 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             await runner.RunAsync(
                 FactQueries.CreateConversationFact,
-                new { conversationId, factId });
-        }, cancellationToken);
+                new { conversationId, factId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     // The Fact idempotency key: the SPO triple scoped by owner_key (shared vs owned facts stay distinct, R1).
@@ -389,15 +389,15 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(FactQueries.GetPageWithoutEmbedding, new { limit = limit + 1 });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(FactQueries.GetPageWithoutEmbedding, new { limit = limit + 1 }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             var items = records.Select(r =>
             {
                 var node = r["f"].As<INode>();
                 return MapToFact(node, null);
             }).ToList();
             return PaginationHelper.ApplyPagination(items, limit);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdateEmbeddingAsync(
@@ -419,8 +419,8 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             await runner.RunAsync(
                 FactQueries.UpdateEmbedding,
-                new { id = factId, embedding = embedding.ToList() });
-        }, cancellationToken);
+                new { id = factId, embedding = embedding.ToList() }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> DeleteAsync(string factId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -433,11 +433,11 @@ public sealed class Neo4jFactRepository : IFactRepository
         return await _tx.WriteAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["factId"] = factId, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { factId });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["factId"] = factId, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { factId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> InvalidateAsync(string factId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -452,10 +452,10 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             var parameters = new Dictionary<string, object?> { ["id"] = factId, ["now"] = now };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["invalidated"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> SupersedeAsync(string loserFactId, string winnerFactId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -470,10 +470,10 @@ public sealed class Neo4jFactRepository : IFactRepository
         {
             var parameters = new Dictionary<string, object?> { ["loserId"] = loserFactId, ["winnerId"] = winnerFactId, ["now"] = now };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["superseded"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Fact?> FindByTripleAsync(string subject, string predicate, string @object, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -487,13 +487,13 @@ public sealed class Neo4jFactRepository : IFactRepository
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = hasOwner
-                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["subject"] = subject, ["predicate"] = predicate, ["object"] = @object, ["ownerId"] = scope!.OwnerId! })
-                : await runner.RunAsync(cypher, new { subject, predicate, @object });
-            var records = await cursor.ToListAsync();
+                ? await runner.RunAsync(cypher, new Dictionary<string, object> { ["subject"] = subject, ["predicate"] = predicate, ["object"] = @object, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false)
+                : await runner.RunAsync(cypher, new { subject, predicate, @object }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["f"].As<INode>();
             return MapToFact(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Fact Fact, double Score)>> SearchByVectorAsOfAsync(
@@ -528,14 +528,14 @@ public sealed class Neo4jFactRepository : IFactRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToFact(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
@@ -38,8 +38,8 @@ public sealed class Neo4jMessageRepository : IMessageRepository
                 ["metadata"]       = SerializeMetadata(message.Metadata)
             };
 
-            var cursor = await runner.RunAsync(MessageQueries.Add, createParams);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(MessageQueries.Add, createParams).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             var node = record["m"].As<INode>();
 
             // Only persist a real (non-empty) vector; a degraded empty embedding leaves `embedding` NULL.
@@ -47,19 +47,19 @@ public sealed class Neo4jMessageRepository : IMessageRepository
             {
                 await runner.RunAsync(
                     SharedFragments.SetMessageEmbedding,
-                    new { id = message.MessageId, embedding = message.Embedding.ToList() });
+                    new { id = message.MessageId, embedding = message.Embedding.ToList() }).ConfigureAwait(false);
             }
 
             // Create FIRST_MESSAGE if this is the first message in the conversation
             await runner.RunAsync(
                 MessageQueries.CreateFirstMessageLink,
-                new { conversationId = message.ConversationId, id = message.MessageId });
+                new { conversationId = message.ConversationId, id = message.MessageId }).ConfigureAwait(false);
 
             // Establish NEXT_MESSAGE link from the previous last message
-            await runner.RunAsync(MessageQueries.LinkNextMessage, new { conversationId = message.ConversationId, id = message.MessageId });
+            await runner.RunAsync(MessageQueries.LinkNextMessage, new { conversationId = message.ConversationId, id = message.MessageId }).ConfigureAwait(false);
 
             return MapToMessage(node, message.Embedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> AddBatchAsync(IEnumerable<Message> messages, CancellationToken cancellationToken = default)
@@ -83,16 +83,16 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(MessageQueries.AddBatch, new { messages = msgParams });
+            var cursor = await runner.RunAsync(MessageQueries.AddBatch, new { messages = msgParams }).ConfigureAwait(false);
             // consume result
-            await cursor.ConsumeAsync();
+            await cursor.ConsumeAsync().ConfigureAwait(false);
 
             // Set embeddings — only for messages with a real (non-empty) vector.
             foreach (var msg in ordered.Where(m => m.Embedding is { Length: > 0 }))
             {
                 await runner.RunAsync(
                     SharedFragments.SetMessageEmbedding,
-                    new { id = msg.MessageId, embedding = msg.Embedding!.ToList() });
+                    new { id = msg.MessageId, embedding = msg.Embedding!.ToList() }).ConfigureAwait(false);
             }
 
             // Create NEXT_MESSAGE chain within batch
@@ -100,7 +100,7 @@ public sealed class Neo4jMessageRepository : IMessageRepository
             {
                 await runner.RunAsync(
                     MessageQueries.CreateNextMessageLink,
-                    new { prevId = ordered[i - 1].MessageId, nextId = ordered[i].MessageId });
+                    new { prevId = ordered[i - 1].MessageId, nextId = ordered[i].MessageId }).ConfigureAwait(false);
             }
 
             // Connect first batch message to any existing last message in the conversation
@@ -113,14 +113,14 @@ public sealed class Neo4jMessageRepository : IMessageRepository
                         conversationId = ordered[0].ConversationId,
                         batchIds       = ordered.Select(m => m.MessageId).ToList(),
                         firstId        = ordered[0].MessageId
-                    });
+                    }).ConfigureAwait(false);
             }
 
             // Re-read all created messages
             var readCursor = await runner.RunAsync(
                 MessageQueries.GetByIds,
-                new { ids = ordered.Select(m => m.MessageId).ToList() });
-            var records = await readCursor.ToListAsync();
+                new { ids = ordered.Select(m => m.MessageId).ToList() }).ConfigureAwait(false);
+            var records = await readCursor.ToListAsync().ConfigureAwait(false);
 
             var embeddingMap = ordered.ToDictionary(m => m.MessageId, m => m.Embedding);
             return records.Select(r =>
@@ -129,7 +129,7 @@ public sealed class Neo4jMessageRepository : IMessageRepository
                 var id = node["id"].As<string>();
                 return MapToMessage(node, embeddingMap.TryGetValue(id, out var emb) ? emb : null);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Message?> GetByIdAsync(string messageId, CancellationToken cancellationToken = default)
@@ -138,12 +138,12 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(MessageQueries.GetById, new { id = messageId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(MessageQueries.GetById, new { id = messageId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["m"].As<INode>();
             return MapToMessage(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> GetByConversationAsync(string conversationId, CancellationToken cancellationToken = default)
@@ -152,14 +152,14 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(MessageQueries.GetByConversation, new { conversationId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(MessageQueries.GetByConversation, new { conversationId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["m"].As<INode>();
                 return MapToMessage(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> GetRecentBySessionAsync(string sessionId, int limit, CancellationToken cancellationToken = default)
@@ -168,14 +168,14 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(MessageQueries.GetRecentBySession, new { sessionId, limit });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(MessageQueries.GetRecentBySession, new { sessionId, limit }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["m"].As<INode>();
                 return MapToMessage(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> GetAllBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
@@ -184,14 +184,14 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(MessageQueries.GetAllBySession, new { sessionId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(MessageQueries.GetAllBySession, new { sessionId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["m"].As<INode>();
                 return MapToMessage(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Message Message, double Score)>> SearchByVectorAsync(
@@ -221,15 +221,15 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToMessage(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
@@ -238,8 +238,8 @@ public sealed class Neo4jMessageRepository : IMessageRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(MessageQueries.DeleteBySession, new { sessionId });
-        }, cancellationToken);
+            await runner.RunAsync(MessageQueries.DeleteBySession, new { sessionId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> DeleteAsync(string messageId, bool cascade = true, CancellationToken ct = default)
@@ -249,10 +249,10 @@ public sealed class Neo4jMessageRepository : IMessageRepository
         return await _tx.WriteAsync(async runner =>
         {
             var query = cascade ? MessageQueries.DeleteCascade : MessageQueries.DeleteSimple;
-            var cursor = await runner.RunAsync(query, new { id = messageId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(query, new { id = messageId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> GetRecentBySessionAsOfAsync(
@@ -270,14 +270,14 @@ public sealed class Neo4jMessageRepository : IMessageRepository
                 sessionId,
                 asOf = asOf.UtcDateTime.ToString("O"),
                 limit
-            });
-            var records = await cursor.ToListAsync();
+            }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["m"].As<INode>();
                 return MapToMessage(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Message MapToMessage(INode node, float[]? embedding) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
@@ -55,8 +55,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
                 ["metadata"]         = SerializeMetadata(preference.Metadata)
             };
 
-            var cursor = await runner.RunAsync(PreferenceQueries.Upsert, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(PreferenceQueries.Upsert, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             var node = record["p"].As<INode>();
 
             // Only persist a real (non-empty) vector so a degraded empty embedding leaves `embedding`
@@ -65,7 +65,7 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
             {
                 await runner.RunAsync(
                     PreferenceQueries.SetEmbedding,
-                    new { id = preference.PreferenceId, embedding = preference.Embedding.ToList() });
+                    new { id = preference.PreferenceId, embedding = preference.Embedding.ToList() }).ConfigureAwait(false);
             }
 
             // Auto-create EXTRACTED_FROM relationships for all source messages
@@ -73,11 +73,11 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
             {
                 await runner.RunAsync(
                     PreferenceQueries.CreateExtractedFromMessages,
-                    new { id = preference.PreferenceId, sourceMessageIds = preference.SourceMessageIds.ToList() });
+                    new { id = preference.PreferenceId, sourceMessageIds = preference.SourceMessageIds.ToList() }).ConfigureAwait(false);
             }
 
             return MapToPreference(node, preference.Embedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Preference?> GetByIdAsync(string preferenceId, CancellationToken cancellationToken = default)
@@ -86,12 +86,12 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(PreferenceQueries.GetById, new { id = preferenceId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(PreferenceQueries.GetById, new { id = preferenceId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["p"].As<INode>();
             return MapToPreference(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Preference>> GetByCategoryAsync(
@@ -107,14 +107,14 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["p"].As<INode>();
                 return MapToPreference(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Preference Preference, double Score)>> SearchByVectorAsync(
@@ -146,15 +146,15 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToPreference(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private const int DedupOverFetch = 10;
@@ -178,27 +178,27 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["node"].As<INode>();
             return MapToPreference(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Preference?> MarkDeduplicatedAsync(string preferenceId, double confidence, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Reinforcing preference {Id} via dedup (confidence={Confidence}).", preferenceId, confidence);
-        return await _tx.WriteAsync<Preference?>(async runner =>
+        return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(PreferenceQueries.MarkDeduplicated, new { id = preferenceId, confidence });
+            var cursor = await runner.RunAsync(PreferenceQueries.MarkDeduplicated, new { id = preferenceId, confidence }).ConfigureAwait(false);
             // 0/1-row read (not SingleAsync): the node can be concurrently hard-deleted between the dedup
             // lookup and this write (e.g. a destructive decay prune), leaving an empty result.
-            var records = await cursor.ToListAsync();
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["p"].As<INode>();
             return MapToPreference(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(string preferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -211,10 +211,10 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         await _tx.WriteAsync(async runner =>
         {
             if (hasOwner)
-                await runner.RunAsync(cypher, new Dictionary<string, object> { ["id"] = preferenceId, ["ownerId"] = scope!.OwnerId! });
+                await runner.RunAsync(cypher, new Dictionary<string, object> { ["id"] = preferenceId, ["ownerId"] = scope!.OwnerId! }).ConfigureAwait(false);
             else
-                await runner.RunAsync(cypher, new { id = preferenceId });
-        }, cancellationToken);
+                await runner.RunAsync(cypher, new { id = preferenceId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> InvalidateAsync(string preferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -229,10 +229,10 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             var parameters = new Dictionary<string, object?> { ["id"] = preferenceId, ["now"] = now };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["invalidated"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> SupersedeAsync(string loserPreferenceId, string winnerPreferenceId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -247,10 +247,10 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             var parameters = new Dictionary<string, object?> { ["loserId"] = loserPreferenceId, ["winnerId"] = winnerPreferenceId, ["now"] = now };
             if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["superseded"].As<bool>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateExtractedFromRelationshipAsync(string preferenceId, string messageId, CancellationToken cancellationToken = default)
@@ -261,8 +261,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             await runner.RunAsync(
                 PreferenceQueries.CreateExtractedFromRelationship,
-                new { preferenceId, messageId });
-        }, cancellationToken);
+                new { preferenceId, messageId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateAboutRelationshipAsync(string preferenceId, string entityId, CancellationToken cancellationToken = default)
@@ -273,8 +273,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             await runner.RunAsync(
                 PreferenceQueries.CreateAboutRelationship,
-                new { preferenceId, entityId });
-        }, cancellationToken);
+                new { preferenceId, entityId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateConversationPreferenceRelationshipAsync(string conversationId, string preferenceId, CancellationToken cancellationToken = default)
@@ -285,8 +285,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             await runner.RunAsync(
                 PreferenceQueries.CreateConversationPreferenceRelationship,
-                new { conversationId, preferenceId });
-        }, cancellationToken);
+                new { conversationId, preferenceId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Preference MapToPreference(INode node, float[]? embedding) =>
@@ -320,15 +320,15 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(PreferenceQueries.GetPageWithoutEmbedding, new { limit = limit + 1 });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(PreferenceQueries.GetPageWithoutEmbedding, new { limit = limit + 1 }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             var items = records.Select(r =>
             {
                 var node = r["p"].As<INode>();
                 return MapToPreference(node, null);
             }).ToList();
             return PaginationHelper.ApplyPagination(items, limit);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdateEmbeddingAsync(
@@ -350,8 +350,8 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
         {
             await runner.RunAsync(
                 PreferenceQueries.UpdateEmbedding,
-                new { id = preferenceId, embedding = embedding.ToList() });
-        }, cancellationToken);
+                new { id = preferenceId, embedding = embedding.ToList() }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Preference Preference, double Score)>> SearchByVectorAsOfAsync(
@@ -382,14 +382,14 @@ public sealed class Neo4jPreferenceRepository : IPreferenceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToPreference(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
@@ -36,11 +36,11 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
                 ["metadata"]    = SerializeMetadata(step.Metadata)
             };
 
-            var cursor = await runner.RunAsync(ReasoningQueries.AddStep, parameters);
+            var cursor = await runner.RunAsync(ReasoningQueries.AddStep, parameters).ConfigureAwait(false);
             // AddStep MATCHes the parent trace before CREATE; if the parent was concurrently deleted the
             // MATCH yields no rows and the step cannot be attached. Failing is correct — but surface a clear,
             // actionable error instead of SingleAsync's opaque "sequence contains no elements" (R6-E).
-            var records = await cursor.ToListAsync();
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0)
                 throw new InvalidOperationException(
                     $"Cannot add reasoning step '{step.StepId}': parent trace '{step.TraceId}' does not exist " +
@@ -52,11 +52,11 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
             {
                 await runner.RunAsync(
                     ReasoningQueries.SetStepEmbedding,
-                    new { id = step.StepId, embedding = step.Embedding.ToList() });
+                    new { id = step.StepId, embedding = step.Embedding.ToList() }).ConfigureAwait(false);
             }
 
             return MapToStep(node, step.Embedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<ReasoningStep>> GetByTraceAsync(string traceId, CancellationToken cancellationToken = default)
@@ -65,14 +65,14 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ReasoningQueries.GetStepsByTrace, new { traceId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ReasoningQueries.GetStepsByTrace, new { traceId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["s"].As<INode>();
                 return MapToStep(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ReasoningStep?> GetByIdAsync(string stepId, CancellationToken cancellationToken = default)
@@ -81,12 +81,12 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ReasoningQueries.GetStepById, new { id = stepId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ReasoningQueries.GetStepById, new { id = stepId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["s"].As<INode>();
             return MapToStep(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> LinkTouchedEntitiesAsync(
@@ -101,10 +101,10 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
         {
             var cursor = await runner.RunAsync(
                 ReasoningQueries.RecordTouchedEntitiesByIds,
-                new { stepId, entityIds = entityIds.ToList() });
-            var record = await cursor.SingleAsync();
+                new { stepId, entityIds = entityIds.ToList() }).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return (int)record["linked"].As<long>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<string>> GetTouchedEntityIdsAsync(
@@ -114,10 +114,10 @@ public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ReasoningQueries.GetTouchedEntityIds, new { stepId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ReasoningQueries.GetTouchedEntityIds, new { stepId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return (IReadOnlyList<string>)records.Select(r => r["id"].As<string>()).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static ReasoningStep MapToStep(INode node, float[]? embedding) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -28,8 +28,8 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         return await _tx.WriteAsync(async runner =>
         {
             var parameters = BuildTraceParameters(trace);
-            var cursor = await runner.RunAsync(ReasoningQueries.AddTrace, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(ReasoningQueries.AddTrace, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             var node = record["t"].As<INode>();
 
             // Only persist a real (non-empty) vector; a degraded empty embedding leaves it NULL.
@@ -37,25 +37,25 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
             {
                 await runner.RunAsync(
                     ReasoningQueries.SetTraceTaskEmbedding,
-                    new { id = trace.TraceId, taskEmbedding = trace.TaskEmbedding.ToList() });
+                    new { id = trace.TraceId, taskEmbedding = trace.TaskEmbedding.ToList() }).ConfigureAwait(false);
             }
 
             return MapToTrace(node, trace.TaskEmbedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ReasoningTrace?> UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Updating reasoning trace {Id}", trace.TraceId);
 
-        return await _tx.WriteAsync<ReasoningTrace?>(async runner =>
+        return await _tx.WriteAsync(async runner =>
         {
             var parameters = BuildTraceParameters(trace);
-            var cursor = await runner.RunAsync(ReasoningQueries.UpdateTrace, parameters);
+            var cursor = await runner.RunAsync(ReasoningQueries.UpdateTrace, parameters).ConfigureAwait(false);
             // The UpdateTrace MATCH returns no rows if the trace was concurrently deleted (session clear /
             // retention prune) between the caller's read and this write. Return null instead of letting
             // SingleAsync throw an opaque "sequence contains no elements" (R6-E).
-            var records = await cursor.ToListAsync();
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["t"].As<INode>();
 
@@ -64,11 +64,11 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
             {
                 await runner.RunAsync(
                     ReasoningQueries.SetTraceTaskEmbedding,
-                    new { id = trace.TraceId, taskEmbedding = trace.TaskEmbedding.ToList() });
+                    new { id = trace.TraceId, taskEmbedding = trace.TaskEmbedding.ToList() }).ConfigureAwait(false);
             }
 
             return MapToTrace(node, trace.TaskEmbedding);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ReasoningTrace?> GetByIdAsync(string traceId, CancellationToken cancellationToken = default)
@@ -77,12 +77,12 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ReasoningQueries.GetTraceById, new { id = traceId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ReasoningQueries.GetTraceById, new { id = traceId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             var node = records[0]["t"].As<INode>();
             return MapToTrace(node, ReadEmbedding(node));
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<ReasoningTrace>> ListBySessionAsync(string sessionId, int limit = 10, MemoryScope? scope = null, CancellationToken cancellationToken = default)
@@ -97,14 +97,14 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node = r["t"].As<INode>();
                 return MapToTrace(node, ReadEmbedding(node));
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(ReasoningTrace Trace, double Score)>> SearchByTaskVectorAsync(
@@ -140,15 +140,15 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToTrace(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(ReasoningTrace Trace, double Score)>> SearchByTaskVectorAsOfAsync(
@@ -185,15 +185,15 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r =>
             {
                 var node  = r["node"].As<INode>();
                 var score = r["score"].As<double>();
                 return (MapToTrace(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateInitiatedByRelationshipAsync(string traceId, string messageId, CancellationToken cancellationToken = default)
@@ -204,8 +204,8 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         {
             await runner.RunAsync(
                 ReasoningQueries.CreateInitiatedByRelationship,
-                new { traceId, messageId });
-        }, cancellationToken);
+                new { traceId, messageId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CreateConversationTraceRelationshipsAsync(string conversationId, string traceId, CancellationToken cancellationToken = default)
@@ -216,8 +216,8 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         {
             await runner.RunAsync(
                 ReasoningQueries.CreateConversationTraceRelationships,
-                new { conversationId, traceId });
-        }, cancellationToken);
+                new { conversationId, traceId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteBySessionAsync(string sessionId, string? ownerId = null, CancellationToken cancellationToken = default)
@@ -234,8 +234,8 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(cypher, parameters);
-        }, cancellationToken);
+            await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> PruneSessionTracesAsync(string sessionId, int maxToKeep, string? ownerId = null, CancellationToken cancellationToken = default)
@@ -256,10 +256,10 @@ public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return record["pruned"].As<int>();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static ReasoningTrace MapToTrace(INode node, float[]? taskEmbedding) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jRelationshipRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jRelationshipRepository.cs
@@ -45,10 +45,10 @@ public sealed class Neo4jRelationshipRepository : IRelationshipRepository
                 ["metadata"]         = SerializeMetadata(relationship.Metadata)
             };
 
-            var cursor = await runner.RunAsync(RelationshipQueries.Upsert, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(RelationshipQueries.Upsert, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return MapToRelationship(record["r"].As<IRelationship>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Relationship?> GetByIdAsync(string relationshipId, CancellationToken cancellationToken = default)
@@ -57,11 +57,11 @@ public sealed class Neo4jRelationshipRepository : IRelationshipRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(RelationshipQueries.GetById, new { id = relationshipId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(RelationshipQueries.GetById, new { id = relationshipId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             return MapToRelationship(records[0]["r"].As<IRelationship>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Relationship>> GetByEntityAsync(
@@ -77,10 +77,10 @@ public sealed class Neo4jRelationshipRepository : IRelationshipRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToRelationship(r["r"].As<IRelationship>())).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Relationship>> GetBySourceEntityAsync(
@@ -96,10 +96,10 @@ public sealed class Neo4jRelationshipRepository : IRelationshipRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToRelationship(r["r"].As<IRelationship>())).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Relationship>> GetByTargetEntityAsync(
@@ -115,10 +115,10 @@ public sealed class Neo4jRelationshipRepository : IRelationshipRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToRelationship(r["r"].As<IRelationship>())).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Relationship MapToRelationship(IRelationship r) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
@@ -26,8 +26,8 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
         return await _tx.WriteAsync(async runner =>
         {
             var parameters = BuildToolCallParameters(toolCall);
-            var cursor = await runner.RunAsync(ToolCallQueries.Add, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(ToolCallQueries.Add, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             var tcNode = record["tc"].As<INode>();
 
             // Create INSTANCE_OF relationship to a Tool node (auto-created on first encounter)
@@ -36,10 +36,10 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
                 new { id = toolCall.ToolCallId, toolName = toolCall.ToolName,
                       status = toolCall.Status.ToString().ToLowerInvariant(),
                       durationMs = (object?)toolCall.DurationMs,
-                      description = (object?)toolCall.Description });
+                      description = (object?)toolCall.Description }).ConfigureAwait(false);
 
             return MapToToolCall(tcNode);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ToolCall> UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken = default)
@@ -49,10 +49,10 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
         return await _tx.WriteAsync(async runner =>
         {
             var parameters = BuildToolCallParameters(toolCall);
-            var cursor = await runner.RunAsync(ToolCallQueries.Update, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(ToolCallQueries.Update, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return MapToToolCall(record["tc"].As<INode>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<ToolCall>> GetByStepAsync(string stepId, CancellationToken cancellationToken = default)
@@ -61,10 +61,10 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ToolCallQueries.GetByStep, new { stepId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ToolCallQueries.GetByStep, new { stepId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToToolCall(r["tc"].As<INode>())).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ToolCall?> GetByIdAsync(string toolCallId, CancellationToken cancellationToken = default)
@@ -73,11 +73,11 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(ToolCallQueries.GetById, new { id = toolCallId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ToolCallQueries.GetById, new { id = toolCallId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             return MapToToolCall(records[0]["tc"].As<INode>());
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static ToolCall MapToToolCall(INode node) =>
@@ -123,7 +123,7 @@ public sealed class Neo4jToolCallRepository : IToolCallRepository
         {
             await runner.RunAsync(
                 ToolCallQueries.CreateTriggeredByRelationship,
-                new { toolCallId, messageId });
-        }, cancellationToken);
+                new { toolCallId, messageId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
@@ -35,7 +35,7 @@ public sealed class Neo4jConflictDetectionService : IConflictDetectionService
         var ranAt = _clock.UtcNow;
 
         var factConflicts = opts.DetectFactContradictions
-            ? await DetectFactContradictionsAsync(opts, cancellationToken)
+            ? await DetectFactContradictionsAsync(opts, cancellationToken).ConfigureAwait(false)
             : Array.Empty<FactConflict>();
 
         _logger.LogInformation("Conflict detection complete: {FactConflicts} fact contradiction group(s).", factConflicts.Count);
@@ -63,7 +63,7 @@ public sealed class Neo4jConflictDetectionService : IConflictDetectionService
                 MinConfidence = null,
                 MaxConflicts = opts.MaxConflicts,
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
 
         int groupsResolved = 0;
         int factsSuperseded = 0;
@@ -98,12 +98,12 @@ public sealed class Neo4jConflictDetectionService : IConflictDetectionService
                         ["now"] = now,
                     };
                     if (hasOwner) parameters["ownerId"] = conflict.OwnerId;
-                    var cursor = await runner.RunAsync(cypher, parameters);
-                    var records = await cursor.ToListAsync();
+                    var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+                    var records = await cursor.ToListAsync().ConfigureAwait(false);
                     if (records.Count > 0 && records[0]["superseded"].As<bool>()) closed++;
                 }
                 return closed;
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
 
             if (closedInGroup > 0)
             {
@@ -134,8 +134,8 @@ public sealed class Neo4jConflictDetectionService : IConflictDetectionService
                 ["limit"] = opts.MaxConflicts,
             };
 
-            var cursor = await runner.RunAsync(ConflictQueries.DetectFactContradictions, parameters);
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(ConflictQueries.DetectFactContradictions, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
 
             return (IReadOnlyList<FactConflict>)records.Select(r =>
             {

--- a/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
@@ -53,25 +53,25 @@ public sealed class Neo4jConsolidationService : IConsolidationService
         if (opts.ArchiveExpiredConversations)
         {
             conversationsArchived = opts.DryRun
-                ? await ReadCountAsync(ConsolidationQueries.CountExpiredConversations, new { cutoff }, cancellationToken)
-                : await WriteCountAsync(ConsolidationQueries.ArchiveExpiredConversations, new { cutoff }, cancellationToken);
+                ? await ReadCountAsync(ConsolidationQueries.CountExpiredConversations, new { cutoff }, cancellationToken).ConfigureAwait(false)
+                : await WriteCountAsync(ConsolidationQueries.ArchiveExpiredConversations, new { cutoff }, cancellationToken).ConfigureAwait(false);
         }
 
         if (opts.RemoveDuplicatePreferences)
         {
             duplicatePreferencesRemoved = opts.DryRun
-                ? await ReadCountAsync(ConsolidationQueries.CountDuplicatePreferences, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken)
-                : await WriteCountAsync(ConsolidationQueries.RemoveDuplicatePreferences, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken);
+                ? await ReadCountAsync(ConsolidationQueries.CountDuplicatePreferences, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken).ConfigureAwait(false)
+                : await WriteCountAsync(ConsolidationQueries.RemoveDuplicatePreferences, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken).ConfigureAwait(false);
         }
 
         // Detection-only operations (no apply path): entity merge needs careful edge redirection and
         // trace summarization needs an LLM — both are reported here as candidates and left as follow-ups.
         if (opts.DetectDuplicateEntities)
-            duplicateEntities = await ReadCountAsync(ConsolidationQueries.CountDuplicateEntities, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken);
+            duplicateEntities = await ReadCountAsync(ConsolidationQueries.CountDuplicateEntities, new { minGroupSize = DuplicateGroupMinSize }, cancellationToken).ConfigureAwait(false);
 
         if (opts.DetectLongTraces)
             longTraceCandidates = await ReadCountAsync(
-                ConsolidationQueries.CountLongTraces, new { threshold = opts.LongTraceStepThreshold }, cancellationToken);
+                ConsolidationQueries.CountLongTraces, new { threshold = opts.LongTraceStepThreshold }, cancellationToken).ConfigureAwait(false);
 
         var report = new ConsolidationReport
         {
@@ -85,7 +85,7 @@ public sealed class Neo4jConsolidationService : IConsolidationService
         };
 
         if (!opts.DryRun)
-            await RecordRunAsync(report, ranAt, cancellationToken);
+            await RecordRunAsync(report, ranAt, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Consolidation run {RunId} complete (dryRun={DryRun}): {Archived} archived, {PrefsRemoved} dup-prefs, " +
@@ -98,16 +98,16 @@ public sealed class Neo4jConsolidationService : IConsolidationService
     private Task<int> ReadCountAsync(string cypher, object parameters, CancellationToken ct) =>
         _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return record["count"].As<int>();
         }, ct);
 
     private Task<int> WriteCountAsync(string cypher, object parameters, CancellationToken ct) =>
         _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, parameters);
-            var record = await cursor.SingleAsync();
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
             return record["count"].As<int>();
         }, ct);
 
@@ -122,6 +122,6 @@ public sealed class Neo4jConsolidationService : IConsolidationService
                 preferencesRemoved = report.DuplicatePreferencesRemoved,
                 duplicateEntities = report.DuplicateEntitiesDetected,
                 longTraceCandidates = report.LongTraceCandidates,
-            });
+            }).ConfigureAwait(false);
         }, ct);
 }

--- a/src/AgentMemory.Neo4j/Services/Neo4jGraphQueryService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jGraphQueryService.cs
@@ -29,8 +29,8 @@ public sealed class Neo4jGraphQueryService : IGraphQueryService
                 ? parameters.ToDictionary(kv => kv.Key, kv => kv.Value)
                 : new Dictionary<string, object?>();
 
-            var cursor = await runner.RunAsync(cypherQuery, driverParams);
-            var records = await cursor.ToListAsync(cancellationToken);
+            var cursor = await runner.RunAsync(cypherQuery, driverParams).ConfigureAwait(false);
+            var records = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);
 
             return records.Select(r =>
             {
@@ -41,7 +41,7 @@ public sealed class Neo4jGraphQueryService : IGraphQueryService
                 }
                 return (IReadOnlyDictionary<string, object?>)dict;
             }).ToList();
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static object? ConvertValue(object? value)

--- a/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
@@ -84,8 +84,8 @@ public sealed class Neo4jMemoryDecayService : IMemoryDecayService
                 };
                 if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
 
-                var cursor = await runner.RunAsync(cypher, parameters);
-                var records = await cursor.ToListAsync();
+                var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+                var records = await cursor.ToListAsync().ConfigureAwait(false);
                 if (records.Count > 0)
                     total += Convert.ToInt32(records[0]["pruned"]);
             }
@@ -94,7 +94,7 @@ public sealed class Neo4jMemoryDecayService : IMemoryDecayService
                 "{Mode} {Count} expired memory node(s), owner={Owner}",
                 nonDestructive ? "Soft-invalidated" : "Pruned", total, scope?.OwnerId);
             return total;
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -109,8 +109,8 @@ public sealed class Neo4jMemoryDecayService : IMemoryDecayService
 
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(cypher, new { id = nodeId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(cypher, new { id = nodeId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return 0.0;
 
             var r = records[0];
@@ -124,7 +124,7 @@ public sealed class Neo4jMemoryDecayService : IMemoryDecayService
             int accessCount = r["accessCount"] is null ? 0 : Convert.ToInt32(r["accessCount"]);
 
             return ComputeScore(confidence, createdAt, lastAccessedAt, accessCount);
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -140,8 +140,8 @@ public sealed class Neo4jMemoryDecayService : IMemoryDecayService
 
         await _tx.WriteAsync(async runner =>
         {
-            await runner.RunAsync(cypher, new { id = nodeId, now });
-        }, cancellationToken);
+            await runner.RunAsync(cypher, new { id = nodeId, now }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug("Bumped access timestamp for {Label} {NodeId}", label, nodeId);
     }

--- a/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
@@ -40,10 +40,10 @@ public sealed class Neo4jSchemaManager : ISchemaManager
     {
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadActiveByName, new { name });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadActiveByName, new { name }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count == 0 ? null : MapToConfig(records[0]["s"].As<INode>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -51,10 +51,10 @@ public sealed class Neo4jSchemaManager : ISchemaManager
     {
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadByNameVersion, new { name, version });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadByNameVersion, new { name, version }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count == 0 ? null : MapToConfig(records[0]["s"].As<INode>());
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -69,7 +69,7 @@ public sealed class Neo4jSchemaManager : ISchemaManager
         await _tx.WriteAsync(async runner =>
         {
             if (setActive)
-                await runner.RunAsync(SchemaPersistenceQueries.DeactivateByName, new { name = schema.Name });
+                await runner.RunAsync(SchemaPersistenceQueries.DeactivateByName, new { name = schema.Name }).ConfigureAwait(false);
 
             await runner.RunAsync(SchemaPersistenceQueries.Save, new
             {
@@ -81,8 +81,8 @@ public sealed class Neo4jSchemaManager : ISchemaManager
                 isActive = setActive,
                 createdAtUtc,
                 createdBy = (object?)createdBy
-            });
-        }, ct);
+            }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
 
         _logger.LogDebug("Saved schema {Name} v{Version} (active={Active})", schema.Name, schema.Version, setActive);
     }
@@ -92,8 +92,8 @@ public sealed class Neo4jSchemaManager : ISchemaManager
     {
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(SchemaPersistenceQueries.List, new { nameFilter = (object?)nameFilter });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(SchemaPersistenceQueries.List, new { nameFilter = (object?)nameFilter }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return (IReadOnlyList<SchemaListItem>)records.Select(r => new SchemaListItem
             {
                 Name = r["name"].As<string>(),
@@ -102,7 +102,7 @@ public sealed class Neo4jSchemaManager : ISchemaManager
                 VersionCount = r["versionCount"].As<int>(),
                 IsActive = r["isActive"].As<bool>()
             }).ToList();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -110,10 +110,10 @@ public sealed class Neo4jSchemaManager : ISchemaManager
     {
         return await _tx.ReadAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(SchemaPersistenceQueries.Exists, new { name });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(SchemaPersistenceQueries.Exists, new { name }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["exists"].As<bool>();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -121,10 +121,10 @@ public sealed class Neo4jSchemaManager : ISchemaManager
     {
         return await _tx.WriteAsync(async runner =>
         {
-            var cursor = await runner.RunAsync(SchemaPersistenceQueries.DeleteById, new { id = schemaId });
-            var records = await cursor.ToListAsync();
+            var cursor = await runner.RunAsync(SchemaPersistenceQueries.DeleteById, new { id = schemaId }).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, ct);
+        }, ct).ConfigureAwait(false);
     }
 
     private static EntitySchemaConfig MapToConfig(INode node)

--- a/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
+++ b/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
@@ -30,7 +30,7 @@ internal sealed class InstrumentedEnrichmentService : IEnrichmentService
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.EnrichEntityAsync(entityName, entityType, ct);
+            var result = await _inner.EnrichEntityAsync(entityName, entityType, ct).ConfigureAwait(false);
             _metrics.EnrichmentRequests.Add(1);
             activity?.SetTag("memory.enrichment.enriched", result is not null);
             return result;

--- a/src/AgentMemory.Observability/InstrumentedEntityExtractor.cs
+++ b/src/AgentMemory.Observability/InstrumentedEntityExtractor.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentedEntityExtractor : IEntityExtractor
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.ExtractAsync(messages, cancellationToken);
+            var result = await _inner.ExtractAsync(messages, cancellationToken).ConfigureAwait(false);
             _metrics.EntitiesExtracted.Add(result.Count);
             activity?.SetTag("memory.extraction.entity_count", result.Count);
             return result;

--- a/src/AgentMemory.Observability/InstrumentedFactExtractor.cs
+++ b/src/AgentMemory.Observability/InstrumentedFactExtractor.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentedFactExtractor : IFactExtractor
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.ExtractAsync(messages, cancellationToken);
+            var result = await _inner.ExtractAsync(messages, cancellationToken).ConfigureAwait(false);
             _metrics.FactsExtracted.Add(result.Count);
             activity?.SetTag("memory.extraction.fact_count", result.Count);
             return result;

--- a/src/AgentMemory.Observability/InstrumentedGraphRagContextSource.cs
+++ b/src/AgentMemory.Observability/InstrumentedGraphRagContextSource.cs
@@ -30,7 +30,7 @@ internal sealed class InstrumentedGraphRagContextSource : IGraphRagContextSource
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.GetContextAsync(request, cancellationToken);
+            var result = await _inner.GetContextAsync(request, cancellationToken).ConfigureAwait(false);
             _metrics.GraphRagQueries.Add(1);
             activity?.SetTag("memory.graphrag.result_count", result.Items.Count);
             return result;

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.RecallAsync(request, cancellationToken);
+            var result = await _inner.RecallAsync(request, cancellationToken).ConfigureAwait(false);
             _metrics.RecallRequests.Add(1);
             activity?.SetTag("memory.recall.entity_count", result.Context.RelevantEntities.Items.Count);
             activity?.SetTag("memory.recall.total_items", result.TotalItemsRetrieved);
@@ -66,7 +66,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.RecallAsOfAsync(request, validAsOf, systemAsOf, cancellationToken);
+            var result = await _inner.RecallAsOfAsync(request, validAsOf, systemAsOf, cancellationToken).ConfigureAwait(false);
             _metrics.RecallRequests.Add(1);
             activity?.SetTag("memory.recall.total_items", result.TotalItemsRetrieved);
             return result;
@@ -98,7 +98,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         try
         {
             var result = await _inner.AddMessageAsync(
-                sessionId, conversationId, role, content, metadata, cancellationToken);
+                sessionId, conversationId, role, content, metadata, cancellationToken).ConfigureAwait(false);
             _metrics.MessagesStored.Add(1);
             return result;
         }
@@ -117,7 +117,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
 
         try
         {
-            var result = await _inner.AddMessagesAsync(messages, cancellationToken);
+            var result = await _inner.AddMessagesAsync(messages, cancellationToken).ConfigureAwait(false);
             _metrics.MessagesStored.Add(result.Count);
             activity?.SetTag("memory.messages.count", result.Count);
             return result;
@@ -139,7 +139,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.ExtractAndPersistAsync(request, cancellationToken);
+            var result = await _inner.ExtractAndPersistAsync(request, cancellationToken).ConfigureAwait(false);
             // NOTE: entity/fact/preference counts are owned by the per-extractor decorators
             // (InstrumentedEntityExtractor etc.), which are the single source of truth for these
             // counters. Counting them here as well would double-count. We keep only span tags.
@@ -170,7 +170,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
 
         try
         {
-            await _inner.ClearSessionAsync(sessionId, ownerId, cancellationToken);
+            await _inner.ClearSessionAsync(sessionId, ownerId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -191,7 +191,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         var sw = Stopwatch.StartNew();
         try
         {
-            await _inner.ExtractFromSessionAsync(sessionId, userId, cancellationToken);
+            await _inner.ExtractFromSessionAsync(sessionId, userId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -217,7 +217,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         var sw = Stopwatch.StartNew();
         try
         {
-            await _inner.ExtractFromConversationAsync(conversationId, userId, cancellationToken);
+            await _inner.ExtractFromConversationAsync(conversationId, userId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -241,6 +241,6 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.generate_embeddings_batch");
         activity?.SetTag("memory.node_label", nodeLabel);
         activity?.SetTag("memory.batch_size", batchSize);
-        return await _inner.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken);
+        return await _inner.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/AgentMemory.Observability/InstrumentedPreferenceExtractor.cs
+++ b/src/AgentMemory.Observability/InstrumentedPreferenceExtractor.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentedPreferenceExtractor : IPreferenceExtractor
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.ExtractAsync(messages, cancellationToken);
+            var result = await _inner.ExtractAsync(messages, cancellationToken).ConfigureAwait(false);
             _metrics.PreferencesExtracted.Add(result.Count);
             activity?.SetTag("memory.extraction.preference_count", result.Count);
             return result;

--- a/src/AgentMemory.Observability/InstrumentedRelationshipExtractor.cs
+++ b/src/AgentMemory.Observability/InstrumentedRelationshipExtractor.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentedRelationshipExtractor : IRelationshipExtractor
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.ExtractAsync(messages, cancellationToken);
+            var result = await _inner.ExtractAsync(messages, cancellationToken).ConfigureAwait(false);
             _metrics.RelationshipsExtracted.Add(result.Count);
             activity?.SetTag("memory.extraction.relationship_count", result.Count);
             return result;


### PR DESCRIPTION
## R6 cleanup — fix the ConfigureAwait drift permanently

The convergence test flagged this shape: **~68 library files lacked `ConfigureAwait(false)`** on their awaits, while **28 applied it consistently** — a real inconsistency, with nothing stopping it from re-drifting across the next 68 files.

### Fix
- **`src/.editorconfig`** enabling `CA2007` at `warning` severity. Because `TreatWarningsAsErrors` is on for `src`, this is now **enforced** — every library `await` must `ConfigureAwait(false)` or the build fails. Scoped to `src/` only: tests/samples/tools are app/test code not consumed on arbitrary synchronization contexts, so CA2007 doesn't apply there.
- Applied the fix across all **67 affected files** mechanically via `dotnet format analyzers --diagnostics CA2007` (~620 sites; 110 → 734 `ConfigureAwait(false)`).

### One auto-fixer edge case, fixed by hand
The CA2007 fixer mis-handled 4 `await using var session = factory.OpenSession(…)` declarations — appending `.ConfigureAwait(false)` to the initializer rebinds the variable to `ConfiguredAsyncDisposable`, breaking the subsequent `session.ExecuteWriteAsync(...)`. Fixed to the correct two-line form that ConfigureAwaits **only the disposal** (`Neo4jTransactionRunner` ×2, `Neo4jMemoryStoreProvisioner` ×2).

### Why this is safe
- `ConfigureAwait(false)` is correct, desirable behavior for a library (don't capture the caller's context) — it can only *prevent* context-capture deadlocks, never introduce them. The 110 pre-existing usages show this was already the maintainer's intent; this completes it.
- The change is mechanical and analyzer-driven. The transaction runner — on the hot path of every DB call — is included, so the **live-DB integration suite exercises the changed awaits**.

### Verification
Full solution builds **0 warnings**; **2648 unit + 236 integration green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)