### PR TITLE
chore: remaining R6 LOW cleanup — culture, telemetry status, dead option

### DIFF
--- a/src/AgentMemory.Abstractions/Options/MemoryDecayOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/MemoryDecayOptions.cs
@@ -28,17 +28,17 @@ public sealed record MemoryDecayOptions
     /// </summary>
     public double AccessBoostFactor { get; init; } = 0.2;
 
-    /// <summary>
-    /// When <c>true</c>, low-scoring memories are automatically pruned during extraction.
-    /// </summary>
-    public bool EnableAutoPrune { get; init; }
+    // NOTE: a documented-but-dead `EnableAutoPrune` option was removed (R6 cleanup). It promised
+    // "automatically prune during extraction" but was read nowhere — auto-prune-on-extraction would wire
+    // the decay service into the extraction pipeline, which belongs with the (currently held) decay/forget
+    // work, not a settable flag that silently does nothing. Pruning runs only when explicitly invoked.
 
     /// <summary>
     /// When <c>true</c> (the default, D4), decay pruning is <b>non-destructive</b>: low-score nodes are
     /// soft-invalidated (their <c>invalidated_at</c> is stamped) — kept, recoverable, and still visible to
     /// as-of recall — rather than deleted, so forgetting is reversible and auditable. Set <c>false</c> for
-    /// a hard <c>DETACH DELETE</c> purge (storage reclamation / GDPR erasure). Either way, pruning only
-    /// runs when invoked — it is not automatic unless <see cref="EnableAutoPrune"/> is set.
+    /// a hard <c>DETACH DELETE</c> purge (storage reclamation / GDPR erasure). Pruning only runs when
+    /// explicitly invoked; it is never automatic.
     /// </summary>
     public bool NonDestructive { get; init; } = true;
 

--- a/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
@@ -233,8 +234,11 @@ public sealed class CoreMemoryTools
     private static (bool Persisted, string? Reason) PersistenceOutcome(double confidence, double threshold) =>
         confidence >= threshold
             ? (true, (string?)null)
-            : (false, $"Not stored: confidence {confidence:0.###} is below the configured minimum {threshold:0.###} " +
-                      "(LongTermMemoryOptions.MinConfidenceThreshold). Increase confidence or lower the threshold.");
+            // Format the doubles with InvariantCulture: this string lands in a JSON tool response, so a
+            // comma-decimal locale must not change "0.3" to "0,3" (R6 cleanup).
+            : (false, string.Create(CultureInfo.InvariantCulture,
+                      $"Not stored: confidence {confidence:0.###} is below the configured minimum {threshold:0.###} " +
+                      $"(LongTermMemoryOptions.MinConfidenceThreshold). Increase confidence or lower the threshold."));
 
     // Parses an optional JSON-object string into a metadata dictionary. Returns null when blank;
     // throws an actionable ArgumentException (surfaced to the MCP caller) when the JSON is invalid.

--- a/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
+++ b/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
@@ -32,7 +32,20 @@ internal sealed class InstrumentedEnrichmentService : IEnrichmentService
         {
             var result = await _inner.EnrichEntityAsync(entityName, entityType, ct).ConfigureAwait(false);
             _metrics.EnrichmentRequests.Add(1);
-            activity?.SetTag("memory.enrichment.enriched", result is not null);
+
+            // Providers (e.g. Diffbot) return a status-bearing result instead of throwing, so a non-null
+            // Error/RateLimited result is a FAILURE, not an enrichment. Branch on Status — counting it as
+            // success would hide transient outages from telemetry (R6 cleanup; mirrors the
+            // BackgroundEnrichmentQueue / CachedEnrichmentService status-aware fixes).
+            bool failed = result is null
+                || result.Status is EnrichmentStatus.Error or EnrichmentStatus.RateLimited;
+            bool enriched = !failed && result is not null;
+            activity?.SetTag("memory.enrichment.enriched", enriched);
+            if (result?.Status is EnrichmentStatus.Error or EnrichmentStatus.RateLimited)
+            {
+                _metrics.EnrichmentErrors.Add(1);
+                activity?.SetTag("memory.enrichment.status", result.Status.ToString());
+            }
             return result;
         }
         catch (Exception ex)

--- a/tests/AgentMemory.Tests.Unit/McpServer/CoreMemoryToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/CoreMemoryToolsTests.cs
@@ -446,6 +446,32 @@ public sealed class CoreMemoryToolsTests
         doc.RootElement.GetProperty("reason").GetString().Should().NotBeNullOrEmpty();
     }
 
+    [Fact]
+    public async Task MemoryAddFact_BelowThreshold_ReasonUsesInvariantDecimalPoint_UnderCommaCulture()
+    {
+        // R6 cleanup: the reason string lands in a JSON tool response, so the confidence/threshold doubles
+        // must format with a period under a comma-decimal locale (e.g. de-DE), not "0,3".
+        var original = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+            _longTermMemory.AddFactAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>())
+                .Returns(ci => ci.Arg<Fact>());
+
+            var result = await CoreMemoryTools.MemoryAddFact(
+                _longTermMemory, _idGenerator, _clock, _options, Threshold(0.5),
+                "Alice", "maybe_works_at", "Microsoft", confidence: 0.3);
+
+            var reason = JsonDocument.Parse(result).RootElement.GetProperty("reason").GetString();
+            reason.Should().Contain("0.3").And.Contain("0.5");
+            reason.Should().NotContain("0,3").And.NotContain("0,5");
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = original;
+        }
+    }
+
     [Theory]
     [InlineData(0.5)]  // boundary: equal to threshold persists (gate is strict <)
     [InlineData(0.9)]

--- a/tests/AgentMemory.Tests.Unit/Observability/InstrumentedEnrichmentServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/InstrumentedEnrichmentServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using FluentAssertions;
 using AgentMemory.Abstractions.Domain.Enrichment;
 using AgentMemory.Abstractions.Services;
@@ -56,6 +57,56 @@ public sealed class InstrumentedEnrichmentServiceTests
 
         var act = () => _sut.EnrichEntityAsync("Test", "PERSON");
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+
+    // R6 cleanup: providers return a status-bearing result instead of throwing, so a non-null
+    // Error/RateLimited result must count as an enrichment ERROR (not a success) in telemetry.
+
+    private async Task<long> CaptureEnrichmentErrorsAsync(Func<Task> action)
+    {
+        long errors = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MemoryMetrics.MeterName) l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "memory.enrichment.errors") Interlocked.Add(ref errors, value);
+        });
+        listener.Start();
+        await action();
+        listener.Dispose();
+        return Interlocked.Read(ref errors);
+    }
+
+    [Theory]
+    [InlineData(EnrichmentStatus.Error)]
+    [InlineData(EnrichmentStatus.RateLimited)]
+    public async Task EnrichEntityAsync_StatusBearingFailure_CountsAsError(EnrichmentStatus status)
+    {
+        _inner.EnrichEntityAsync("Acme", "ORGANIZATION", Arg.Any<CancellationToken>())
+            .Returns(new EnrichmentResult { EntityName = "Acme", Status = status });
+
+        var errors = await CaptureEnrichmentErrorsAsync(() => _sut.EnrichEntityAsync("Acme", "ORGANIZATION"));
+
+        errors.Should().Be(1, "a non-null Error/RateLimited result is a failure, not a successful enrichment");
+    }
+
+    [Theory]
+    [InlineData(EnrichmentStatus.Success)]
+    [InlineData(EnrichmentStatus.NotFound)]
+    [InlineData(EnrichmentStatus.Skipped)]
+    public async Task EnrichEntityAsync_NonFailureStatus_DoesNotCountAsError(EnrichmentStatus status)
+    {
+        _inner.EnrichEntityAsync("Acme", "ORGANIZATION", Arg.Any<CancellationToken>())
+            .Returns(new EnrichmentResult { EntityName = "Acme", Status = status });
+
+        var errors = await CaptureEnrichmentErrorsAsync(() => _sut.EnrichEntityAsync("Acme", "ORGANIZATION"));
+
+        errors.Should().Be(0);
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
@@ -224,7 +224,7 @@ public sealed class MemoryDecayServiceTests
         options.DecayHalfLifeDays.Should().Be(30);
         options.MinRetentionScore.Should().Be(0.1);
         options.AccessBoostFactor.Should().Be(0.2);
-        options.EnableAutoPrune.Should().BeFalse();
+        options.NonDestructive.Should().BeTrue();
     }
 
     [Fact]
@@ -233,6 +233,6 @@ public sealed class MemoryDecayServiceTests
         var defaults = MemoryDecayOptions.Default;
 
         defaults.DecayHalfLifeDays.Should().Be(30);
-        defaults.EnableAutoPrune.Should().BeFalse();
+        defaults.NonDestructive.Should().BeTrue();
     }
 }

--- a/tools/AgentMemory.Cli/Commands/MemoryCommands.cs
+++ b/tools/AgentMemory.Cli/Commands/MemoryCommands.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
@@ -117,7 +118,9 @@ public sealed class ConflictsCommand(IConflictDetectionService service, TextWrit
             var owner = conflict.OwnerId is null ? "shared" : $"owner={conflict.OwnerId}";
             output.WriteLine($"  [{owner}] {conflict.Subject} / {conflict.Predicate}:");
             foreach (var value in conflict.Values)
-                output.WriteLine($"      = {value.Object}  (fact {value.FactId}, conf {value.Confidence:0.00})");
+                // InvariantCulture so the confidence decimal point is stable across locales (R6 cleanup).
+                output.WriteLine(string.Create(CultureInfo.InvariantCulture,
+                    $"      = {value.Object}  (fact {value.FactId}, conf {value.Confidence:0.00})"));
         }
         if (report.FactConflictCount == 0)
             output.WriteLine("  No contradictions found.");


### PR DESCRIPTION
## R6 cleanup (final) — the four remaining LOW findings, batched

### 1. Culture-invariant number formatting (cosmetic correctness)
- **MCP** `CoreMemoryTools.PersistenceOutcome` built its `"Not stored: confidence {…} is below {…}"` string — which lands in a **JSON tool response** — with `CurrentCulture`, so a comma-decimal locale would emit `"0,3"`.
- **CLI** `ConflictsCommand` formatted `conf {Confidence:0.00}` the same way.

Both now use `string.Create(CultureInfo.InvariantCulture, …)`.

### 2. Telemetry status-vs-null
`InstrumentedEnrichmentService` tagged any **non-null** result as a successful enrichment and only counted errors on a thrown exception. But providers (e.g. Diffbot) **return** a status-bearing `Error`/`RateLimited` result instead of throwing — so transient outages were invisible to metrics. Now branches on `result.Status`: increments `EnrichmentErrors` and tags the activity for `Error`/`RateLimited`. Mirrors the `BackgroundEnrichmentQueue` (#33) and `CachedEnrichmentService` (#59) status-aware fixes — the last non-status-aware consumer.

### 3. Dead option removed
`MemoryDecayOptions.EnableAutoPrune` was documented + settable but **read nowhere**. Auto-prune-on-extraction would wire the decay service into the extraction pipeline — that belongs with the (currently held) decay/forget work, not a flag that silently does nothing. Removed with a `NOTE` comment (round-4 precedent for premise-not-wired options); the `NonDestructive` doc cross-reference updated.

### Tests
- `MeterListener` theories: `Error`/`RateLimited` count as one enrichment error; `Success`/`NotFound`/`Skipped` count as zero.
- A `de-DE` culture test asserting the MCP reason uses a period (`0.3`), not a comma.
- Decay-default tests updated for the removed property.

Full unit suite **2654 green**; solution builds **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)