### PR TITLE
1.0 API surface (1/4): internalize implementation types behind the public interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **1.0 API-surface lockdown — implementation types internalized.** Concrete implementation classes that are only ever resolved through the public Abstractions interfaces (the memory/reasoning services, Neo4j repositories/services/query holders/infrastructure, MCP tools/resources/prompts, extraction providers, enrichment decorators, GDS analytics services, merge strategies, and stubs) are now `internal`, shrinking the public surface from ~331 to ~203 types ahead of the SemVer-stable `1.0`. Accessibility-only: no behavior, signature, or DI-wiring change — DI resolves the internal types (via their still-public constructors) unchanged. The public contract is the Abstractions interfaces/records/options/enums, each package's `ServiceCollectionExtensions` + options, the Microsoft Agent Framework and Semantic Kernel adapters, and a small set of deliberate seams (`INeo4jTransactionRunner`, `ISchemaBootstrapper`, `IMigrationRunner`, `MemoryActivitySource`, `MemoryMetrics.MeterName`, the stub/clock/id helpers, `ExtractorBase`).
+- **`SchemaConstants` and the schema-parity kit are now internal.** `SchemaConstants` (raw Neo4j backend label/property/edge strings) and the parity types (`SchemaParityVerifier`, `SchemaDescriptor`, `SchemaParityPolicy`, `SchemaParityReport`, `UpstreamSchemaRegistry`, `DotNetSchema`) — previously described as a reusable library component in `AgentMemory.Neo4j.Schema.Parity` — are implementation details for `1.0`. Schema-parity verification remains available through the `agentmemory schema-parity` CLI command; it is no longer a library API.
+
 ## [0.1.0-preview.4] - 2026-06-21
 
 This release is dominated by a sustained correctness-hardening effort: **six rounds** of adversarial

--- a/src/AgentMemory.Abstractions/AgentMemory.Abstractions.csproj
+++ b/src/AgentMemory.Abstractions/AgentMemory.Abstractions.csproj
@@ -15,4 +15,10 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- SchemaConstants (internal Neo4j backend label/property/edge strings) is consumed by the Neo4j
+         provider package. Targeted grant only. -->
+    <InternalsVisibleTo Include="AgentMemory.Neo4j" />
+  </ItemGroup>
+
 </Project>

--- a/src/AgentMemory.Abstractions/Schema/SchemaConstants.cs
+++ b/src/AgentMemory.Abstractions/Schema/SchemaConstants.cs
@@ -4,7 +4,7 @@ namespace AgentMemory.Abstractions.Schema;
 /// Canonical Neo4j schema constants matching the Python agent-memory reference implementation.
 /// All relationship types and property names MUST match Python exactly for cross-implementation compatibility.
 /// </summary>
-public static class SchemaConstants
+internal static class SchemaConstants
 {
     /// <summary>Neo4j relationship type names used throughout the memory graph.</summary>
     public static class RelationshipTypes

--- a/src/AgentMemory.Analytics/GdsAvailability.cs
+++ b/src/AgentMemory.Analytics/GdsAvailability.cs
@@ -5,7 +5,7 @@ using Neo4j.Driver;
 namespace AgentMemory.Analytics;
 
 /// <inheritdoc/>
-public sealed class GdsAvailability : IGdsAvailability
+internal sealed class GdsAvailability : IGdsAvailability
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<GdsAvailability> _logger;

--- a/src/AgentMemory.Analytics/MemoryCommunityService.cs
+++ b/src/AgentMemory.Analytics/MemoryCommunityService.cs
@@ -6,7 +6,7 @@ using Neo4j.Driver;
 namespace AgentMemory.Analytics;
 
 /// <inheritdoc/>
-public sealed class MemoryCommunityService : IMemoryCommunityService
+internal sealed class MemoryCommunityService : IMemoryCommunityService
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly IGdsAvailability _gds;

--- a/src/AgentMemory.Analytics/MemoryPageRankService.cs
+++ b/src/AgentMemory.Analytics/MemoryPageRankService.cs
@@ -7,7 +7,7 @@ using Neo4j.Driver;
 namespace AgentMemory.Analytics;
 
 /// <inheritdoc/>
-public sealed class MemoryPageRankService : IMemoryPageRankService
+internal sealed class MemoryPageRankService : IMemoryPageRankService
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly IGdsAvailability _gds;

--- a/src/AgentMemory.Core/AgentMemory.Core.csproj
+++ b/src/AgentMemory.Core/AgentMemory.Core.csproj
@@ -24,6 +24,13 @@
   <ItemGroup>
     <InternalsVisibleTo Include="AgentMemory.Tests.Unit" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <!-- Shared internal helpers (ConversationTextBuilder, SchemaLoader, MemoryContextFormatter,
+         MemoryQueryFacade) are consumed by these first-party provider/integration packages. Targeted
+         grants (not a blanket first-party list) keep the internal friend surface minimal. -->
+    <InternalsVisibleTo Include="AgentMemory.Neo4j" />
+    <InternalsVisibleTo Include="AgentMemory.Extraction.Llm" />
+    <InternalsVisibleTo Include="AgentMemory.SemanticKernel" />
+    <InternalsVisibleTo Include="AgentMemory.AgentFramework" />
   </ItemGroup>
 
 </Project>

--- a/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
+++ b/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
@@ -18,7 +18,7 @@ internal record EnrichmentItem(string EntityId, int RetryCount = 0);
 /// Uses <see cref="System.Threading.Channels.Channel{T}"/> with DropOldest overflow,
 /// a fixed pool of worker tasks (no IHostedService), and configurable retry logic.
 /// </summary>
-public sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDisposable, IAsyncDisposable
+internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, IDisposable, IAsyncDisposable
 {
     private readonly Channel<EnrichmentItem> _channel;
     private readonly IReadOnlyList<IEnrichmentService> _enrichmentServices;

--- a/src/AgentMemory.Core/Extraction/ConversationTextBuilder.cs
+++ b/src/AgentMemory.Core/Extraction/ConversationTextBuilder.cs
@@ -6,7 +6,7 @@ namespace AgentMemory.Core.Extraction;
 /// Provides helpers for rendering a sequence of conversation messages into a single
 /// plain-text transcript suitable for extraction and processing.
 /// </summary>
-public static class ConversationTextBuilder
+internal static class ConversationTextBuilder
 {
     /// <summary>
     /// Builds a newline-separated transcript from the supplied messages, formatting each

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/CascadeMergeStrategy.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/CascadeMergeStrategy.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// Tries each extractor's results in order and returns the first non-empty list.
 /// If all lists are empty, returns an empty list.
 /// </summary>
-public sealed class CascadeMergeStrategy<T> : IMergeStrategy<T> where T : class
+internal sealed class CascadeMergeStrategy<T> : IMergeStrategy<T> where T : class
 {
     /// <inheritdoc/>
     public MergeStrategyType StrategyType => MergeStrategyType.Cascade;

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/ConfidenceMergeStrategy.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/ConfidenceMergeStrategy.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// When duplicate items are found across extractors, keeps the one with the highest confidence.
 /// All unique items are preserved. Effectively a union with confidence-based winner selection.
 /// </summary>
-public sealed class ConfidenceMergeStrategy<T> : IMergeStrategy<T> where T : class
+internal sealed class ConfidenceMergeStrategy<T> : IMergeStrategy<T> where T : class
 {
     private readonly Func<T, string> _keySelector;
     private readonly Func<T, double> _confidenceSelector;

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/FirstSuccessMergeStrategy.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/FirstSuccessMergeStrategy.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// In the multi-extractor pipeline, failed extractors return empty lists,
 /// so this effectively uses the first extractor that didn't throw.
 /// </summary>
-public sealed class FirstSuccessMergeStrategy<T> : IMergeStrategy<T> where T : class
+internal sealed class FirstSuccessMergeStrategy<T> : IMergeStrategy<T> where T : class
 {
     /// <inheritdoc/>
     public MergeStrategyType StrategyType => MergeStrategyType.FirstSuccess;

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/IntersectionMergeStrategy.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/IntersectionMergeStrategy.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// Only keeps items found by 2 or more extractors (matched by normalized key).
 /// When duplicates exist, keeps the one with the highest confidence.
 /// </summary>
-public sealed class IntersectionMergeStrategy<T> : IMergeStrategy<T> where T : class
+internal sealed class IntersectionMergeStrategy<T> : IMergeStrategy<T> where T : class
 {
     private readonly Func<T, string> _keySelector;
     private readonly Func<T, double> _confidenceSelector;

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/MergeStrategyFactory.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/MergeStrategyFactory.cs
@@ -6,7 +6,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// <summary>
 /// Factory that creates the correct merge strategy for a given <see cref="MergeStrategyType"/>.
 /// </summary>
-public static class MergeStrategyFactory
+internal static class MergeStrategyFactory
 {
     /// <summary>
     /// Creates a merge strategy for <see cref="ExtractedEntity"/> items.

--- a/src/AgentMemory.Core/Extraction/MergeStrategies/UnionMergeStrategy.cs
+++ b/src/AgentMemory.Core/Extraction/MergeStrategies/UnionMergeStrategy.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Core.Extraction.MergeStrategies;
 /// For entities: case-insensitive name. For facts: (subject, predicate, object) triple.
 /// When duplicates exist, keeps the one with the highest confidence.
 /// </summary>
-public sealed class UnionMergeStrategy<T> : IMergeStrategy<T> where T : class
+internal sealed class UnionMergeStrategy<T> : IMergeStrategy<T> where T : class
 {
     private readonly Func<T, string> _keySelector;
     private readonly Func<T, double> _confidenceSelector;

--- a/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
+++ b/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
@@ -14,7 +14,7 @@ namespace AgentMemory.Core.Extraction.Streaming;
 /// Splits long documents into overlapping chunks and extracts entities from each chunk,
 /// streaming results as they become available.
 /// </summary>
-public sealed class StreamingExtractor : IStreamingExtractor
+internal sealed class StreamingExtractor : IStreamingExtractor
 {
     private static readonly Regex TokenPattern = new(@"\S+", RegexOptions.Compiled);
 

--- a/src/AgentMemory.Core/Resolution/CompositeEntityResolver.cs
+++ b/src/AgentMemory.Core/Resolution/CompositeEntityResolver.cs
@@ -21,7 +21,7 @@ namespace AgentMemory.Core.Resolution;
 /// entity — this is intentional "shared knowledge grows collaboratively" behavior, not a cross-owner
 /// leak (a future opt-in option could make shared knowledge read-only per owner if a deployment needs it).
 /// </remarks>
-public sealed class CompositeEntityResolver : IEntityResolver
+internal sealed class CompositeEntityResolver : IEntityResolver
 {
     private readonly IEntityRepository _entityRepository;
     private readonly IEmbeddingOrchestrator _embeddingOrchestrator;

--- a/src/AgentMemory.Core/Schema/SchemaLoader.cs
+++ b/src/AgentMemory.Core/Schema/SchemaLoader.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Core.Schema;
 /// and provides built-in POLE+O and legacy schema factories.
 /// YAML is not supported to avoid third-party dependencies; use JSON.
 /// </summary>
-public static class SchemaLoader
+internal static class SchemaLoader
 {
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {

--- a/src/AgentMemory.Core/Services/ContextCompressor.cs
+++ b/src/AgentMemory.Core/Services/ContextCompressor.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// Compresses conversation context using a 3-tier strategy:
 /// tier 1 (reflections) → tier 2 (observations) → tier 3 (recent messages verbatim).
 /// </summary>
-public sealed class ContextCompressor : IContextCompressor
+internal sealed class ContextCompressor : IContextCompressor
 {
     private const int CharsPerToken = 4;
 

--- a/src/AgentMemory.Core/Services/DefaultMemoryOwnerContext.cs
+++ b/src/AgentMemory.Core/Services/DefaultMemoryOwnerContext.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Core.Services;
 /// under concurrency: each request/agent-run flow sees its own value (set e.g. by the MAF provider for
 /// that turn), and concurrent flows cannot bleed into one another (IC8, mirrors the store context).
 /// </summary>
-public sealed class DefaultMemoryOwnerContext : IWritableMemoryOwnerContext
+internal sealed class DefaultMemoryOwnerContext : IWritableMemoryOwnerContext
 {
     private readonly AsyncLocal<string?> _userId = new();
 

--- a/src/AgentMemory.Core/Services/DefaultMemoryRankingContext.cs
+++ b/src/AgentMemory.Core/Services/DefaultMemoryRankingContext.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Core.Services;
 /// each recall flow sees its own per-request ranking override (set by the assembler from the recall's
 /// <c>Intent</c>), and concurrent recalls cannot bleed into one another (mirrors the owner/store contexts).
 /// </summary>
-public sealed class DefaultMemoryRankingContext : IWritableMemoryRankingContext
+internal sealed class DefaultMemoryRankingContext : IWritableMemoryRankingContext
 {
     private readonly AsyncLocal<MemoryRankingOptions?> _current = new();
 

--- a/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
+++ b/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// failures are logged and degraded to empty vectors so callers always receive an array aligned
 /// with their input.
 /// </summary>
-public sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
+internal sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
 {
     private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
     private readonly ILogger<EmbeddingOrchestrator> _logger;

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Service for long-term (structured knowledge) memory operations.
 /// </summary>
-public sealed class LongTermMemoryService : ILongTermMemoryService
+internal sealed class LongTermMemoryService : ILongTermMemoryService
 {
     private readonly IEntityRepository _entityRepo;
     private readonly IFactRepository _factRepo;

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Assembles memory context from multiple memory layers for a recall request.
 /// </summary>
-public sealed class MemoryContextAssembler : IMemoryContextAssembler
+internal sealed class MemoryContextAssembler : IMemoryContextAssembler
 {
     private readonly IShortTermMemoryService _shortTerm;
     private readonly ILongTermMemoryService _longTerm;

--- a/src/AgentMemory.Core/Services/MemoryContextFormatter.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextFormatter.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Core.Services;
 /// logic lives in Core so framework adapters (e.g. the Semantic Kernel plugin) remain thin and do
 /// not carry formatting code of their own.
 /// </summary>
-public static class MemoryContextFormatter
+internal static class MemoryContextFormatter
 {
     /// <summary>
     /// Formats the recalled context as Markdown, or returns an empty string when nothing was retrieved.

--- a/src/AgentMemory.Core/Services/MemoryDecayService.cs
+++ b/src/AgentMemory.Core/Services/MemoryDecayService.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Core.Services;
 /// Score formula: baseConfidence × e^(−λ × daysSinceLastAccess) + accessBoost × accessCount
 /// where λ = ln(2) / halfLifeDays.
 /// </summary>
-public sealed class MemoryDecayService : IMemoryDecayService
+internal sealed class MemoryDecayService : IMemoryDecayService
 {
     private readonly IEntityRepository _entityRepo;
     private readonly IFactRepository _factRepo;

--- a/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
+++ b/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
@@ -12,7 +12,7 @@ namespace AgentMemory.Core.Services;
 /// merge, filter, validate, resolve) followed by <see cref="IPersistenceStage"/> (embed, upsert,
 /// wire provenance).  Implements the public <see cref="IMemoryExtractionPipeline"/> interface.
 /// </summary>
-public sealed class MemoryExtractionPipeline : IMemoryExtractionPipeline
+internal sealed class MemoryExtractionPipeline : IMemoryExtractionPipeline
 {
     private readonly IExtractionStage _extractionStage;
     private readonly IPersistenceStage _persistenceStage;

--- a/src/AgentMemory.Core/Services/MemoryQueryFacade.cs
+++ b/src/AgentMemory.Core/Services/MemoryQueryFacade.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Core.Services;
 /// store-preference/fact commands previously duplicated inside the framework adapters. Cancellation
 /// is propagated; all other failures are logged and returned as a failed <see cref="MemoryQueryResult"/>.
 /// </summary>
-public sealed class MemoryQueryFacade : IMemoryQueryFacade
+internal sealed class MemoryQueryFacade : IMemoryQueryFacade
 {
     private readonly ILongTermMemoryService _longTerm;
     private readonly IReasoningMemoryService _reasoning;

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Facade service for all memory operations.
 /// </summary>
-public sealed class MemoryService : IMemoryService
+internal sealed class MemoryService : IMemoryService
 {
     private readonly IShortTermMemoryService _shortTerm;
     private readonly IMemoryContextAssembler _assembler;

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Service for reasoning trace memory operations.
 /// </summary>
-public sealed class ReasoningMemoryService : IReasoningMemoryService
+internal sealed class ReasoningMemoryService : IReasoningMemoryService
 {
     private readonly IReasoningTraceRepository _traceRepo;
     private readonly IReasoningStepRepository _stepRepo;

--- a/src/AgentMemory.Core/Services/SessionIdGenerator.cs
+++ b/src/AgentMemory.Core/Services/SessionIdGenerator.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Generates session IDs based on the configured <see cref="SessionStrategy"/>.
 /// </summary>
-public sealed class SessionIdGenerator : ISessionIdGenerator
+internal sealed class SessionIdGenerator : ISessionIdGenerator
 {
     private readonly ShortTermMemoryOptions _options;
 

--- a/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ShortTermMemoryService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Core.Services;
 /// <summary>
 /// Service for short-term (conversational) memory operations.
 /// </summary>
-public sealed class ShortTermMemoryService : IShortTermMemoryService
+internal sealed class ShortTermMemoryService : IShortTermMemoryService
 {
     private readonly IConversationRepository _conversationRepo;
     private readonly IMessageRepository _messageRepo;

--- a/src/AgentMemory.Core/Stubs/StubEntityExtractor.cs
+++ b/src/AgentMemory.Core/Stubs/StubEntityExtractor.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Stubs;
 /// <summary>
 /// Phase 1 stub: returns no entities. Replace in Phase 2 with an AI-backed extractor.
 /// </summary>
-public sealed class StubEntityExtractor : IEntityExtractor
+internal sealed class StubEntityExtractor : IEntityExtractor
 {
     private readonly ILogger<StubEntityExtractor> _logger;
 

--- a/src/AgentMemory.Core/Stubs/StubEntityResolver.cs
+++ b/src/AgentMemory.Core/Stubs/StubEntityResolver.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Core.Stubs;
 /// <summary>
 /// Phase 1 stub: returns the input entity unchanged with no deduplication. Replace in Phase 2.
 /// </summary>
-public sealed class StubEntityResolver : IEntityResolver
+internal sealed class StubEntityResolver : IEntityResolver
 {
     private readonly ILogger<StubEntityResolver> _logger;
     private readonly IClock _clock;

--- a/src/AgentMemory.Core/Stubs/StubExtractionPipeline.cs
+++ b/src/AgentMemory.Core/Stubs/StubExtractionPipeline.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Core.Stubs;
 /// registered (the default) this performs full extraction; the legacy type name is retained for
 /// source compatibility.
 /// </summary>
-public sealed class StubExtractionPipeline : IMemoryExtractionPipeline
+internal sealed class StubExtractionPipeline : IMemoryExtractionPipeline
 {
     private readonly IEntityExtractor _entityExtractor;
     private readonly IFactExtractor _factExtractor;

--- a/src/AgentMemory.Core/Stubs/StubFactExtractor.cs
+++ b/src/AgentMemory.Core/Stubs/StubFactExtractor.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Stubs;
 /// <summary>
 /// Phase 1 stub: returns no facts. Replace in Phase 2 with an AI-backed extractor.
 /// </summary>
-public sealed class StubFactExtractor : IFactExtractor
+internal sealed class StubFactExtractor : IFactExtractor
 {
     private readonly ILogger<StubFactExtractor> _logger;
 

--- a/src/AgentMemory.Core/Stubs/StubPreferenceExtractor.cs
+++ b/src/AgentMemory.Core/Stubs/StubPreferenceExtractor.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Stubs;
 /// <summary>
 /// Phase 1 stub: returns no preferences. Replace in Phase 2 with an AI-backed extractor.
 /// </summary>
-public sealed class StubPreferenceExtractor : IPreferenceExtractor
+internal sealed class StubPreferenceExtractor : IPreferenceExtractor
 {
     private readonly ILogger<StubPreferenceExtractor> _logger;
 

--- a/src/AgentMemory.Core/Stubs/StubRelationshipExtractor.cs
+++ b/src/AgentMemory.Core/Stubs/StubRelationshipExtractor.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Stubs;
 /// <summary>
 /// Phase 1 stub: returns no relationships. Replace in Phase 2 with an AI-backed extractor.
 /// </summary>
-public sealed class StubRelationshipExtractor : IRelationshipExtractor
+internal sealed class StubRelationshipExtractor : IRelationshipExtractor
 {
     private readonly ILogger<StubRelationshipExtractor> _logger;
 

--- a/src/AgentMemory.Core/Validation/EntityValidator.cs
+++ b/src/AgentMemory.Core/Validation/EntityValidator.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Core.Validation;
 /// Static utility for validating extracted entities before persistence.
 /// Ports the 221-stopword validation logic from the Python reference implementation.
 /// </summary>
-public static class EntityValidator
+internal static class EntityValidator
 {
     // ~221 common English stopwords — case-insensitive comparison applied at call site
     private static readonly HashSet<string> Stopwords = new(StringComparer.OrdinalIgnoreCase)

--- a/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Enrichment;
 /// <summary>
 /// Caching decorator for <see cref="IEnrichmentService"/> using in-memory cache.
 /// </summary>
-public sealed class CachedEnrichmentService : IEnrichmentService
+internal sealed class CachedEnrichmentService : IEnrichmentService
 {
     private readonly IEnrichmentService _inner;
     private readonly IMemoryCache _cache;

--- a/src/AgentMemory.Enrichment/Caching/CachedGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/Caching/CachedGeocodingService.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Enrichment;
 /// <summary>
 /// Caching decorator for <see cref="IGeocodingService"/> using in-memory cache.
 /// </summary>
-public sealed class CachedGeocodingService : IGeocodingService
+internal sealed class CachedGeocodingService : IGeocodingService
 {
     private readonly IGeocodingService _inner;
     private readonly IMemoryCache _cache;

--- a/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
@@ -14,7 +14,7 @@ namespace AgentMemory.Enrichment;
 /// Enrichment service backed by the Diffbot Knowledge Graph API.
 /// Supports PERSON, ORGANIZATION, LOCATION, OBJECT, and EVENT entity types.
 /// </summary>
-public sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
+internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
 {
     internal const string ClientName = "Diffbot";
 

--- a/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Enrichment;
 /// <summary>
 /// Enrichment service backed by the Wikipedia REST API (Wikimedia).
 /// </summary>
-public sealed class WikimediaEnrichmentService : IEnrichmentService
+internal sealed class WikimediaEnrichmentService : IEnrichmentService
 {
     internal const string ClientName = "Wikipedia";
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/AgentMemory.Enrichment/Geocoding/NominatimGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/Geocoding/NominatimGeocodingService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Enrichment;
 /// <summary>
 /// Geocoding service backed by the Nominatim OpenStreetMap API.
 /// </summary>
-public sealed class NominatimGeocodingService : IGeocodingService
+internal sealed class NominatimGeocodingService : IGeocodingService
 {
     internal const string ClientName = "Nominatim";
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/AgentMemory.Enrichment/RateLimiting/RateLimitedGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/RateLimiting/RateLimitedGeocodingService.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Enrichment;
 /// Rate-limiting decorator for <see cref="IGeocodingService"/>.
 /// Ensures at most N requests per second are forwarded to the inner service.
 /// </summary>
-public sealed class RateLimitedGeocodingService : IGeocodingService, IDisposable
+internal sealed class RateLimitedGeocodingService : IGeocodingService, IDisposable
 {
     private readonly IGeocodingService _inner;
     private readonly int _rateLimitPerSecond;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Extraction.AzureLanguage;
 /// <summary>
 /// Extracts named entities from conversation messages using Azure AI Text Analytics.
 /// </summary>
-public sealed class AzureLanguageEntityExtractor : ExtractorBase<ExtractedEntity>, IEntityExtractor
+internal sealed class AzureLanguageEntityExtractor : ExtractorBase<ExtractedEntity>, IEntityExtractor
 {
     private readonly ITextAnalyticsClientWrapper _client;
     private readonly AzureLanguageOptions _options;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.AzureLanguage;
 /// Extracts facts from conversation messages using Azure AI Text Analytics
 /// (key phrases and linked entity recognition).
 /// </summary>
-public sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>, IFactExtractor
+internal sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>, IFactExtractor
 {
     private readonly ITextAnalyticsClientWrapper _client;
     private readonly AzureLanguageOptions _options;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.AzureLanguage;
 /// Extracts user preferences from conversation messages using Azure AI Text Analytics
 /// (sentiment analysis combined with key phrase extraction).
 /// </summary>
-public sealed class AzureLanguagePreferenceExtractor : ExtractorBase<ExtractedPreference>, IPreferenceExtractor
+internal sealed class AzureLanguagePreferenceExtractor : ExtractorBase<ExtractedPreference>, IPreferenceExtractor
 {
     private readonly ITextAnalyticsClientWrapper _client;
     private readonly AzureLanguageOptions _options;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.AzureLanguage;
 /// Extracts relationships between co-occurring entities in conversation messages
 /// using Azure AI Text Analytics.
 /// </summary>
-public sealed class AzureLanguageRelationshipExtractor : ExtractorBase<ExtractedRelationship>, IRelationshipExtractor
+internal sealed class AzureLanguageRelationshipExtractor : ExtractorBase<ExtractedRelationship>, IRelationshipExtractor
 {
     private readonly ITextAnalyticsClientWrapper _client;
     private readonly AzureLanguageOptions _options;

--- a/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.Llm;
 /// <summary>
 /// Extracts named entities from conversation messages using an LLM.
 /// </summary>
-public sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEntityExtractor
+internal sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEntityExtractor
 {
     /// <summary>The canonical POLE+O entity types, used when no custom set is configured.</summary>
     internal static readonly IReadOnlyList<string> DefaultEntityTypes =

--- a/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.Llm;
 /// <summary>
 /// Extracts Subject-Predicate-Object facts from conversation messages using an LLM.
 /// </summary>
-public sealed class LlmFactExtractor : ExtractorBase<ExtractedFact>, IFactExtractor
+internal sealed class LlmFactExtractor : ExtractorBase<ExtractedFact>, IFactExtractor
 {
     public const string DefaultSystemPrompt =
         """

--- a/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.Llm;
 /// <summary>
 /// Extracts user preferences from conversation messages using an LLM.
 /// </summary>
-public sealed class LlmPreferenceExtractor : ExtractorBase<ExtractedPreference>, IPreferenceExtractor
+internal sealed class LlmPreferenceExtractor : ExtractorBase<ExtractedPreference>, IPreferenceExtractor
 {
     public const string DefaultSystemPrompt =
         """

--- a/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Extraction.Llm;
 /// <summary>
 /// Extracts relationships between entities from conversation messages using an LLM.
 /// </summary>
-public sealed class LlmRelationshipExtractor : ExtractorBase<ExtractedRelationship>, IRelationshipExtractor
+internal sealed class LlmRelationshipExtractor : ExtractorBase<ExtractedRelationship>, IRelationshipExtractor
 {
     public const string DefaultSystemPrompt =
         """

--- a/src/AgentMemory.McpServer/Prompts/MemoryConversationPrompt.cs
+++ b/src/AgentMemory.McpServer/Prompts/MemoryConversationPrompt.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.McpServer.Prompts;
 /// MCP prompt that initializes a memory-aware conversation session.
 /// </summary>
 [McpServerPromptType]
-public sealed class MemoryConversationPrompt
+internal sealed class MemoryConversationPrompt
 {
     /// <summary>
     /// Returns system instructions for starting a memory-aware conversation.

--- a/src/AgentMemory.McpServer/Prompts/MemoryReasoningPrompt.cs
+++ b/src/AgentMemory.McpServer/Prompts/MemoryReasoningPrompt.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.McpServer.Prompts;
 /// MCP prompt that guides the agent through structured reasoning with trace recording.
 /// </summary>
 [McpServerPromptType]
-public sealed class MemoryReasoningPrompt
+internal sealed class MemoryReasoningPrompt
 {
     /// <summary>
     /// Returns instructions for recording a structured reasoning trace for a complex task.

--- a/src/AgentMemory.McpServer/Prompts/MemoryReviewPrompt.cs
+++ b/src/AgentMemory.McpServer/Prompts/MemoryReviewPrompt.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.McpServer.Prompts;
 /// MCP prompt that guides the agent through reviewing and auditing stored memories.
 /// </summary>
 [McpServerPromptType]
-public sealed class MemoryReviewPrompt
+internal sealed class MemoryReviewPrompt
 {
     /// <summary>
     /// Returns instructions for reviewing all stored knowledge and flagging contradictions.

--- a/src/AgentMemory.McpServer/Resources/ContextResource.cs
+++ b/src/AgentMemory.McpServer/Resources/ContextResource.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.McpServer.Resources;
 /// MCP resource that returns assembled memory context for a session.
 /// </summary>
 [McpServerResourceType]
-public sealed class ContextResource
+internal sealed class ContextResource
 {
     [McpServerResource(UriTemplate = "memory://context/{session_id}", Name = "memory_context", MimeType = "application/json"),
      Description("Returns assembled memory context for a given session, including recent messages, relevant entities, facts, and preferences.")]

--- a/src/AgentMemory.McpServer/Resources/ConversationListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/ConversationListResource.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.McpServer.Resources;
 /// MCP resource that lists recent conversations.
 /// </summary>
 [McpServerResourceType]
-public sealed class ConversationListResource
+internal sealed class ConversationListResource
 {
     [McpServerResource(UriTemplate = "memory://conversations", Name = "memory_conversations", MimeType = "application/json"),
      Description("Returns recent conversations with message counts.")]

--- a/src/AgentMemory.McpServer/Resources/EntityListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/EntityListResource.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.McpServer.Resources;
 /// MCP resource that lists entities in the knowledge graph.
 /// </summary>
 [McpServerResourceType]
-public sealed class EntityListResource
+internal sealed class EntityListResource
 {
     [McpServerResource(UriTemplate = "memory://entities", Name = "memory_entities", MimeType = "application/json"),
      Description("Returns a paginated list of entities in the knowledge graph.")]

--- a/src/AgentMemory.McpServer/Resources/MemoryStatusResource.cs
+++ b/src/AgentMemory.McpServer/Resources/MemoryStatusResource.cs
@@ -13,7 +13,7 @@ namespace AgentMemory.McpServer.Resources;
 /// these counts are additionally physically isolated per store.
 /// </summary>
 [McpServerResourceType]
-public sealed class MemoryStatusResource
+internal sealed class MemoryStatusResource
 {
     [McpServerResource(UriTemplate = "memory://status", Name = "memory_status", MimeType = "application/json"),
      Description("Returns current memory statistics: entity count, fact count, preference count, conversation count, message count.")]

--- a/src/AgentMemory.McpServer/Resources/PreferenceListResource.cs
+++ b/src/AgentMemory.McpServer/Resources/PreferenceListResource.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.McpServer.Resources;
 /// MCP resource that lists preferences grouped by category.
 /// </summary>
 [McpServerResourceType]
-public sealed class PreferenceListResource
+internal sealed class PreferenceListResource
 {
     [McpServerResource(UriTemplate = "memory://preferences", Name = "memory_preferences", MimeType = "application/json"),
      Description("Returns preferences grouped by category.")]

--- a/src/AgentMemory.McpServer/Resources/SchemaInfoResource.cs
+++ b/src/AgentMemory.McpServer/Resources/SchemaInfoResource.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.McpServer.Resources;
 /// MCP resource that exposes the current graph schema.
 /// </summary>
 [McpServerResourceType]
-public sealed class SchemaInfoResource
+internal sealed class SchemaInfoResource
 {
     [McpServerResource(UriTemplate = "memory://schema", Name = "memory_schema", MimeType = "application/json"),
      Description("Returns the current graph schema including node labels, relationship types, and property keys.")]

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Advanced memory tools: record tool calls, export graph, find duplicates, extract and persist.
 /// </summary>
 [McpServerToolType]
-public sealed class AdvancedMemoryTools
+internal sealed class AdvancedMemoryTools
 {
     [McpServerTool(Name = "memory_record_tool_call"), Description("Records a tool call for a reasoning trace step. Associates a tool invocation with an existing reasoning step.")]
     public static async Task<string> MemoryRecordToolCall(

--- a/src/AgentMemory.McpServer/Tools/ConversationTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ConversationTools.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Conversation tools: get conversation history, list sessions.
 /// </summary>
 [McpServerToolType]
-public sealed class ConversationTools
+internal sealed class ConversationTools
 {
     [McpServerTool(Name = "memory_get_conversation"), Description("Get the message history for a specific conversation.")]
     public static async Task<string> MemoryGetConversation(

--- a/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/CoreMemoryTools.cs
@@ -13,7 +13,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Core memory tools: search, context, store, add entity/preference/fact.
 /// </summary>
 [McpServerToolType]
-public sealed class CoreMemoryTools
+internal sealed class CoreMemoryTools
 {
     [McpServerTool(Name = "memory_search"), Description("Search agent memory for relevant context matching a query. Returns assembled memory context with recent messages, entities, facts, and preferences.")]
     public static async Task<string> MemorySearch(

--- a/src/AgentMemory.McpServer/Tools/EntityTools.cs
+++ b/src/AgentMemory.McpServer/Tools/EntityTools.cs
@@ -12,7 +12,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Entity tools: get entity, provenance, create relationship.
 /// </summary>
 [McpServerToolType]
-public sealed class EntityTools
+internal sealed class EntityTools
 {
     [McpServerTool(Name = "memory_get_entity_provenance"), Description("Get the provenance of an entity for auditability: the source messages it was extracted from (with span/confidence) and the extractors that produced it (with confidence and timing).")]
     public static async Task<string> MemoryGetEntityProvenance(

--- a/src/AgentMemory.McpServer/Tools/GraphQueryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/GraphQueryTools.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Graph query tool: execute arbitrary Cypher queries.
 /// </summary>
 [McpServerToolType]
-public sealed class GraphQueryTools
+internal sealed class GraphQueryTools
 {
     [McpServerTool(Name = "graph_query"), Description("Execute a Cypher query against the Neo4j knowledge graph. Only available when explicitly enabled in server configuration.")]
     public static async Task<string> GraphQuery(

--- a/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
+++ b/src/AgentMemory.McpServer/Tools/MaintenanceTools.cs
@@ -12,7 +12,7 @@ namespace AgentMemory.McpServer.Tools;
 /// call never touches another owner's data; a null/blank <c>userId</c> is an unscoped (admin) operation.
 /// </summary>
 [McpServerToolType]
-public sealed class MaintenanceTools
+internal sealed class MaintenanceTools
 {
     [McpServerTool(Name = "memory_invalidate"), Description("Soft-invalidate a long-term memory node (fact, entity, or preference) by id. It drops from live recall but is kept and remains visible to as-of recall for times before invalidation (non-destructive, reversible). Owner-scoped when userId is set.")]
     public static async Task<string> MemoryInvalidate(

--- a/src/AgentMemory.McpServer/Tools/ObservationTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ObservationTools.cs
@@ -13,7 +13,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Token-budget-aware observation retrieval tool for MCP.
 /// </summary>
 [McpServerToolType]
-public sealed class ObservationTools
+internal sealed class ObservationTools
 {
     [McpServerTool(Name = "memory_get_observations"), Description("Get compressed observations from memory within a token budget. Retrieves recent context and compresses it to fit the specified token limit.")]
     public static async Task<string> MemoryGetObservations(

--- a/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.McpServer.Tools;
 /// Reasoning trace tools: start, record step, complete.
 /// </summary>
 [McpServerToolType]
-public sealed class ReasoningTools
+internal sealed class ReasoningTools
 {
     [McpServerTool(Name = "memory_start_trace"), Description("Start a new reasoning trace to track an agent's multi-step problem solving process.")]
     public static async Task<string> MemoryStartTrace(

--- a/src/AgentMemory.Neo4j/Infrastructure/CypherBuilder.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/CypherBuilder.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// Each method returns a new immutable instance, making instances safe to share across threads.
 /// Parameters always use <c>$paramName</c> syntax — never interpolated values.
 /// </remarks>
-public sealed class CypherBuilder
+internal sealed class CypherBuilder
 {
     private readonly IReadOnlyList<string> _lines;
     private readonly bool _whereStarted;

--- a/src/AgentMemory.Neo4j/Infrastructure/IMemoryStoreProvisioner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/IMemoryStoreProvisioner.cs
@@ -4,7 +4,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// Ensures the physical store (Neo4j database) for an application exists and is schema-bootstrapped
 /// (R1b). A no-op under the default <see cref="MemoryStorageStrategy.SharedDatabase"/> strategy.
 /// </summary>
-public interface IMemoryStoreProvisioner
+internal interface IMemoryStoreProvisioner
 {
     /// <summary>
     /// Ensures the store for <paramref name="applicationId"/> is ready.

--- a/src/AgentMemory.Neo4j/Infrastructure/INeo4jDriverFactory.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/INeo4jDriverFactory.cs
@@ -2,7 +2,7 @@ using Neo4j.Driver;
 
 namespace AgentMemory.Neo4j.Infrastructure;
 
-public interface INeo4jDriverFactory : IAsyncDisposable
+internal interface INeo4jDriverFactory : IAsyncDisposable
 {
     IDriver GetDriver();
 }

--- a/src/AgentMemory.Neo4j/Infrastructure/INeo4jSessionFactory.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/INeo4jSessionFactory.cs
@@ -2,7 +2,7 @@ using Neo4j.Driver;
 
 namespace AgentMemory.Neo4j.Infrastructure;
 
-public interface INeo4jSessionFactory
+internal interface INeo4jSessionFactory
 {
     /// <summary>
     /// Opens a session against the store database resolved from the ambient

--- a/src/AgentMemory.Neo4j/Infrastructure/MemoryStoreOptions.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/MemoryStoreOptions.cs
@@ -59,7 +59,7 @@ public sealed class MemoryStoreOptions
 /// Concurrent requests therefore cannot corrupt each other's store routing (R1b). Setting it flows to
 /// every awaited call downstream on the same logical async context — including the session factory.
 /// </summary>
-public sealed class DefaultMemoryStoreContext : IWritableMemoryStoreContext
+internal sealed class DefaultMemoryStoreContext : IWritableMemoryStoreContext
 {
     private readonly AsyncLocal<string?> _applicationId = new();
 

--- a/src/AgentMemory.Neo4j/Infrastructure/MigrationRunner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/MigrationRunner.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// Runs Cypher migration scripts in version order, tracking applied migrations
 /// in a (:Migration {version, appliedAtUtc}) node.
 /// </summary>
-public sealed class MigrationRunner : IMigrationRunner
+internal sealed class MigrationRunner : IMigrationRunner
 {
     private const string MigrationFolder = "Schema/Migrations";
 

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jDriverFactory.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jDriverFactory.cs
@@ -4,7 +4,7 @@ using Neo4j.Driver;
 
 namespace AgentMemory.Neo4j.Infrastructure;
 
-public sealed class Neo4jDriverFactory : INeo4jDriverFactory
+internal sealed class Neo4jDriverFactory : INeo4jDriverFactory
 {
     private readonly IDriver _driver;
     private readonly ILogger<Neo4jDriverFactory> _logger;

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jMemoryStoreProvisioner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jMemoryStoreProvisioner.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// <see cref="MemoryStorageStrategy.DatabasePerApplication"/>). Requires Neo4j Enterprise or AuraDB —
 /// Community Edition supports only a single user database and raises an actionable error.
 /// </summary>
-public sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
+internal sealed class Neo4jMemoryStoreProvisioner : IMemoryStoreProvisioner
 {
     private const string SystemDatabase = "system";
 

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jSessionFactory.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jSessionFactory.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// resolution collapses to the configured <see cref="Neo4jOptions.Database"/> — identical to the
 /// original single-store behavior.
 /// </summary>
-public sealed class Neo4jSessionFactory : INeo4jSessionFactory
+internal sealed class Neo4jSessionFactory : INeo4jSessionFactory
 {
     private readonly INeo4jDriverFactory _driverFactory;
     private readonly MemoryStoreOptions _storeOptions;

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
@@ -13,7 +13,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// point throws <see cref="OperationCanceledException"/> if the token is already cancelled
 /// <em>before</em> a session is opened or work is started.
 /// </remarks>
-public sealed class Neo4jTransactionRunner : INeo4jTransactionRunner
+internal sealed class Neo4jTransactionRunner : INeo4jTransactionRunner
 {
     private readonly INeo4jSessionFactory _sessionFactory;
     private readonly ILogger<Neo4jTransactionRunner> _logger;

--- a/src/AgentMemory.Neo4j/Infrastructure/SchemaBootstrapper.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/SchemaBootstrapper.cs
@@ -6,7 +6,7 @@ using Neo4j.Driver;
 
 namespace AgentMemory.Neo4j.Infrastructure;
 
-public sealed class SchemaBootstrapper : ISchemaBootstrapper
+internal sealed class SchemaBootstrapper : ISchemaBootstrapper
 {
     private readonly INeo4jTransactionRunner _txRunner;
     private readonly ILogger<SchemaBootstrapper> _logger;

--- a/src/AgentMemory.Neo4j/Infrastructure/SchemaConformance.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/SchemaConformance.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Neo4j.Infrastructure;
 /// distinct from <c>schema-parity</c> (static check that the .NET schema is compatible with the upstream
 /// Python snapshot).
 /// </summary>
-public static class SchemaConformance
+internal static class SchemaConformance
 {
     /// <summary>
     /// The names of every constraint and index the bootstrap creates for the given embedding

--- a/src/AgentMemory.Neo4j/Queries/ConflictQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ConflictQueries.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// query idempotent (a superseded loser drops out, so a re-run finds nothing) and guarantees the
 /// resolution winner is a live fact.
 /// </summary>
-public static class ConflictQueries
+internal static class ConflictQueries
 {
     /// <summary>
     /// Finds fact contradictions among <b>live</b> facts: same subject + predicate + owner with ≥2

--- a/src/AgentMemory.Neo4j/Queries/ConsolidationQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ConsolidationQueries.cs
@@ -4,7 +4,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Cypher for batch memory-hygiene (consolidation, PR #113). Count* variants are the dry-run
 /// projections of their mutating counterparts, so a dry run reports exactly what an apply run does.
 /// </summary>
-public static class ConsolidationQueries
+internal static class ConsolidationQueries
 {
     // ── Archive expired conversations ───────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/ConversationQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ConversationQueries.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Centralized Cypher queries for Conversation operations.
 /// </summary>
-public static class ConversationQueries
+internal static class ConversationQueries
 {
     /// <summary>Upsert a Conversation node by id.</summary>
     public const string Upsert = @"

--- a/src/AgentMemory.Neo4j/Queries/CypherQueryRegistry.cs
+++ b/src/AgentMemory.Neo4j/Queries/CypherQueryRegistry.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Discovers all centralized Cypher query constants via reflection for EXPLAIN validation.
 /// </summary>
-public static class CypherQueryRegistry
+internal static class CypherQueryRegistry
 {
     /// <summary>
     /// Returns all (name, cypherText) pairs from all *Queries classes in this assembly.
@@ -14,7 +14,7 @@ public static class CypherQueryRegistry
     {
         var queryTypes = typeof(CypherQueryRegistry).Assembly
             .GetTypes()
-            .Where(t => t.IsPublic && t.IsAbstract && t.IsSealed // static classes
+            .Where(t => !t.IsNested && t.IsAbstract && t.IsSealed // top-level static classes (public or internal)
                         && t.Name.EndsWith("Queries")
                         && t.Namespace == "AgentMemory.Neo4j.Queries");
 

--- a/src/AgentMemory.Neo4j/Queries/DecayQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/DecayQueries.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Cypher queries for memory decay, access tracking, and pruning.
 /// </summary>
-public static class DecayQueries
+internal static class DecayQueries
 {
     /// <summary>
     /// Updates <c>last_accessed_at</c> to now, increments <c>access_count</c>, and records a

--- a/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Each constant or method corresponds to exactly one repository method in
 /// <see cref="AgentMemory.Neo4j.Repositories.Neo4jEntityRepository"/>.
 /// </summary>
-public static class EntityQueries
+internal static class EntityQueries
 {
     // ── UpsertAsync ────────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/ExtractorQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ExtractorQueries.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Centralized Cypher queries for Extractor operations.
 /// </summary>
-public static class ExtractorQueries
+internal static class ExtractorQueries
 {
     /// <summary>Upsert an Extractor node by name.</summary>
     public const string Upsert = @"

--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Each constant corresponds to exactly one repository method in
 /// <see cref="AgentMemory.Neo4j.Repositories.Neo4jFactRepository"/>.
 /// </summary>
-public static class FactQueries
+internal static class FactQueries
 {
     // ── UpsertAsync ────────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/HistoryQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/HistoryQueries.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Cypher for normalized memory-history reads over long-term memory nodes.
 /// </summary>
-public static class HistoryQueries
+internal static class HistoryQueries
 {
     public static string List(MemoryHistoryKind? kind)
     {

--- a/src/AgentMemory.Neo4j/Queries/MessageQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/MessageQueries.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Each constant corresponds to exactly one repository method in
 /// <see cref="AgentMemory.Neo4j.Repositories.Neo4jMessageRepository"/>.
 /// </summary>
-public static class MessageQueries
+internal static class MessageQueries
 {
     // ── AddAsync ───────────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/MetadataFilterBuilder.cs
+++ b/src/AgentMemory.Neo4j/Queries/MetadataFilterBuilder.cs
@@ -7,7 +7,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Supported operators: <c>$eq</c>, <c>$ne</c>, <c>$contains</c>, <c>$in</c>, <c>$exists</c>.
 /// Values are always bound as parameters to prevent Cypher injection.
 /// </remarks>
-public static class MetadataFilterBuilder
+internal static class MetadataFilterBuilder
 {
     /// <summary>
     /// Builds a WHERE clause fragment and a parameter dictionary from <paramref name="filters"/>.

--- a/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Centralized Cypher queries for Preference operations.
 /// </summary>
-public static class PreferenceQueries
+internal static class PreferenceQueries
 {
     /// <summary>Upsert a Preference node by id.</summary>
     public const string Upsert = @"

--- a/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Centralized Cypher queries for ReasoningTrace and ReasoningStep operations.
 /// </summary>
-public static class ReasoningQueries
+internal static class ReasoningQueries
 {
     // ── ReasoningTrace ──────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/RelationshipQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/RelationshipQueries.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Each constant corresponds to exactly one repository method in
 /// <see cref="AgentMemory.Neo4j.Repositories.Neo4jRelationshipRepository"/>.
 /// </summary>
-public static class RelationshipQueries
+internal static class RelationshipQueries
 {
     // ── UpsertAsync ────────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/SchemaPersistenceQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/SchemaPersistenceQueries.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// activating the saved one. Schema nodes are global (NOT owner-scoped): they describe the ontology shared
 /// across all users, like <c>:Extractor</c> and <c>:Tool</c>.</para>
 /// </summary>
-public static class SchemaPersistenceQueries
+internal static class SchemaPersistenceQueries
 {
     /// <summary>
     /// Upsert a schema revision by (name, version). <c>id</c>/<c>created_at</c>/<c>created_by</c> are set

--- a/src/AgentMemory.Neo4j/Queries/SchemaQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/SchemaQueries.cs
@@ -4,7 +4,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// Centralized Cypher statements for schema bootstrapping (constraints, indexes)
 /// and migration tracking.
 /// </summary>
-public static class SchemaQueries
+internal static class SchemaQueries
 {
     // ── Constraints ─────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/SharedFragments.cs
+++ b/src/AgentMemory.Neo4j/Queries/SharedFragments.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Reusable Cypher fragments shared across multiple domain query classes.
 /// </summary>
-public static class SharedFragments
+internal static class SharedFragments
 {
     // ── Embedding operations ───────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/TemporalQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/TemporalQueries.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// ("what was true in the world at that time"). A single-clock caller passes both equal. The by-id AsOf
 /// constants remain single-clock (<c>$asOf</c>) — a direct handle lookup has no need for two clocks.
 /// </summary>
-public static class TemporalQueries
+internal static class TemporalQueries
 {
     /// <summary>The owner/shared AsOf-search AND-clause for node alias <c>node</c>, or empty when unscoped (R1).</summary>
     private static string OwnerAnd(bool hasOwnerFilter, bool includeShared) =>

--- a/src/AgentMemory.Neo4j/Queries/ToolCallQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ToolCallQueries.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Queries;
 /// <summary>
 /// Centralized Cypher queries for ToolCall operations.
 /// </summary>
-public static class ToolCallQueries
+internal static class ToolCallQueries
 {
     /// <summary>Create a new ToolCall node and link it to its parent ReasoningStep.</summary>
     public const string Add = @"

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
@@ -8,7 +8,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jConversationRepository : IConversationRepository
+internal sealed class Neo4jConversationRepository : IConversationRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jConversationRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -11,7 +11,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jEntityRepository : IEntityRepository
+internal sealed class Neo4jEntityRepository : IEntityRepository
 {
     private const int OwnerOverFetchFactor = Neo4jFactRepository.OwnerOverFetchFactor;
     private const int OwnerOverFetchFloor = Neo4jFactRepository.OwnerOverFetchFloor;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
@@ -12,7 +12,7 @@ namespace AgentMemory.Neo4j.Repositories;
 /// <summary>
 /// Neo4j implementation of <see cref="IExtractorRepository"/>.
 /// </summary>
-public sealed class Neo4jExtractorRepository : IExtractorRepository
+internal sealed class Neo4jExtractorRepository : IExtractorRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jExtractorRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -11,7 +11,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jFactRepository : IFactRepository
+internal sealed class Neo4jFactRepository : IFactRepository
 {
     // Owner-scoped vector search over-fetches candidates (topK > limit) so an owner filter is not
     // starved by higher-scoring foreign rows; the post-WHERE then LIMITs to the requested count (R1).

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
@@ -8,7 +8,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jMessageRepository : IMessageRepository
+internal sealed class Neo4jMessageRepository : IMessageRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jMessageRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
@@ -11,7 +11,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jPreferenceRepository : IPreferenceRepository
+internal sealed class Neo4jPreferenceRepository : IPreferenceRepository
 {
     private const int OwnerOverFetchFactor = Neo4jFactRepository.OwnerOverFetchFactor;
     private const int OwnerOverFetchFloor = Neo4jFactRepository.OwnerOverFetchFloor;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningStepRepository.cs
@@ -8,7 +8,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
+internal sealed class Neo4jReasoningStepRepository : IReasoningStepRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jReasoningStepRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -10,7 +10,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
+internal sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jReasoningTraceRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jRelationshipRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jRelationshipRepository.cs
@@ -9,7 +9,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jRelationshipRepository : IRelationshipRepository
+internal sealed class Neo4jRelationshipRepository : IRelationshipRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jRelationshipRepository> _logger;

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
@@ -8,7 +8,7 @@ using static AgentMemory.Neo4j.Repositories.Neo4jRecordMapper;
 
 namespace AgentMemory.Neo4j.Repositories;
 
-public sealed class Neo4jToolCallRepository : IToolCallRepository
+internal sealed class Neo4jToolCallRepository : IToolCallRepository
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jToolCallRepository> _logger;

--- a/src/AgentMemory.Neo4j/Retrieval/IRetriever.cs
+++ b/src/AgentMemory.Neo4j/Retrieval/IRetriever.cs
@@ -3,7 +3,7 @@ namespace AgentMemory.Neo4j.Retrieval;
 /// <summary>
 /// Interface for retrieving search results from Neo4j.
 /// </summary>
-public interface IRetriever
+internal interface IRetriever
 {
     /// <summary>
     /// Search Neo4j and return matching results.

--- a/src/AgentMemory.Neo4j/Retrieval/RetrieverResult.cs
+++ b/src/AgentMemory.Neo4j/Retrieval/RetrieverResult.cs
@@ -5,10 +5,10 @@ namespace AgentMemory.Neo4j.Retrieval;
 /// </summary>
 /// <param name="Content">The text content of the result.</param>
 /// <param name="Metadata">Additional metadata fields (score, etc.).</param>
-public record RetrieverResultItem(string Content, Dictionary<string, object?>? Metadata = null);
+internal record RetrieverResultItem(string Content, Dictionary<string, object?>? Metadata = null);
 
 /// <summary>
 /// The result of a retriever search operation.
 /// </summary>
 /// <param name="Items">The list of result items.</param>
-public record RetrieverResult(IReadOnlyList<RetrieverResultItem> Items);
+internal record RetrieverResult(IReadOnlyList<RetrieverResultItem> Items);

--- a/src/AgentMemory.Neo4j/Schema/Parity/DotNetSchema.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/DotNetSchema.cs
@@ -9,7 +9,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// of truth for "what the .NET port's schema actually is" — used by both the parity test and the CLI
 /// self-verification, so they can never disagree.
 /// </summary>
-public static class DotNetSchema
+internal static class DotNetSchema
 {
     /// <summary>Builds a descriptor of the current .NET schema.</summary>
     public static SchemaDescriptor Describe() => new(

--- a/src/AgentMemory.Neo4j/Schema/Parity/SchemaDescriptor.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/SchemaDescriptor.cs
@@ -6,7 +6,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// <see cref="AgentMemory.Abstractions.Schema.SchemaConstants"/>) and a captured upstream snapshot are
 /// projected into this shape so they can be compared by <see cref="SchemaParityVerifier"/>.
 /// </summary>
-public sealed record SchemaDescriptor(
+internal sealed record SchemaDescriptor(
     string Version,
     IReadOnlySet<string> NodeLabels,
     IReadOnlySet<string> RelationshipTypes,

--- a/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityPolicy.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityPolicy.cs
@@ -6,7 +6,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// these allowlists (a dropped label, a renamed property, a brand-new undocumented divergence, or an
 /// upstream version that caught up to a .NET superset) is reported as a compatibility break.
 /// </summary>
-public sealed record SchemaParityPolicy(
+internal sealed record SchemaParityPolicy(
     string UpstreamVersion,
     IReadOnlySet<string> UpstreamOnlyLabels,
     IReadOnlySet<string> NetOnlyLabels,

--- a/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityReport.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityReport.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// empty; the <see cref="DocumentedDivergences"/> list records the intentional deltas that were present
 /// (informational, never a failure).
 /// </summary>
-public sealed record SchemaParityReport(
+internal sealed record SchemaParityReport(
     string UpstreamVersion,
     IReadOnlyList<string> MissingLabels,
     IReadOnlyList<string> MissingRelationshipTypes,

--- a/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityVerifier.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/SchemaParityVerifier.cs
@@ -6,7 +6,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// <see cref="SchemaParityReport"/>. Reusable across the unit/regression test and the
 /// <c>agentmemory schema-parity</c> CLI self-verification, so both judge compatibility identically.
 /// </summary>
-public static class SchemaParityVerifier
+internal static class SchemaParityVerifier
 {
     /// <summary>
     /// Verifies the live .NET schema against the embedded upstream snapshot for

--- a/src/AgentMemory.Neo4j/Schema/Parity/UpstreamSchemaRegistry.cs
+++ b/src/AgentMemory.Neo4j/Schema/Parity/UpstreamSchemaRegistry.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Neo4j.Schema.Parity;
 /// <see cref="SchemaParityPolicy"/>). Parsing the rich capture down to a <see cref="SchemaDescriptor"/>
 /// (labels / relationship types / property names) lives here so the verifier stays format-agnostic.
 /// </summary>
-public sealed class UpstreamSchemaRegistry
+internal sealed class UpstreamSchemaRegistry
 {
     private const string ResourcePrefix = "AgentMemory.Neo4j.Schema.Parity.Snapshots.";
     private const string ResourceSuffix = ".json";

--- a/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.Neo4j.Services;
 /// Neo4j-backed <see cref="IConflictDetectionService"/>. Detect-only: runs read Cypher grouping facts
 /// by subject + predicate within an owner scope and reports groups with multiple distinct objects.
 /// </summary>
-public sealed class Neo4jConflictDetectionService : IConflictDetectionService
+internal sealed class Neo4jConflictDetectionService : IConflictDetectionService
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly IClock _clock;

--- a/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
@@ -11,7 +11,7 @@ namespace AgentMemory.Neo4j.Services;
 /// Cypher; dry runs use the <c>Count*</c> projection of each mutating query, so the reported counts
 /// match what an apply run does. Applied runs write a <c>:ConsolidationRun</c> audit node.
 /// </summary>
-public sealed class Neo4jConsolidationService : IConsolidationService
+internal sealed class Neo4jConsolidationService : IConsolidationService
 {
     // A "duplicate group" is 2+ nodes sharing the same key; we keep one and report/remove the rest.
     private const int DuplicateGroupMinSize = 2;

--- a/src/AgentMemory.Neo4j/Services/Neo4jGraphQueryService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jGraphQueryService.cs
@@ -5,7 +5,7 @@ using Neo4j.Driver;
 
 namespace AgentMemory.Neo4j.Services;
 
-public sealed class Neo4jGraphQueryService : IGraphQueryService
+internal sealed class Neo4jGraphQueryService : IGraphQueryService
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly ILogger<Neo4jGraphQueryService> _logger;

--- a/src/AgentMemory.Neo4j/Services/Neo4jGraphRagContextSource.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jGraphRagContextSource.cs
@@ -15,7 +15,7 @@ namespace AgentMemory.Neo4j.Services;
 /// Implements <see cref="IGraphRagContextSource"/> by delegating to a Neo4j-backed
 /// <see cref="IRetriever"/>. Supports vector, fulltext, hybrid, and graph-enriched modes.
 /// </summary>
-public sealed class Neo4jGraphRagContextSource : IGraphRagContextSource
+internal sealed class Neo4jGraphRagContextSource : IGraphRagContextSource
 {
     private readonly IRetriever _retriever;
     private readonly GraphRagOptions _options;

--- a/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
@@ -17,7 +17,7 @@ namespace AgentMemory.Neo4j.Services;
 /// when non-destructive is disabled. When a <see cref="MemoryScope"/> with an owner is supplied (R1) the prune is
 /// owner-scoped (own nodes only — never another owner's, never shared/global); a null scope prunes globally (admin).
 /// </summary>
-public sealed class Neo4jMemoryDecayService : IMemoryDecayService
+internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
 {
     /// <summary>Labels whose decay/pruning is supported. Guards the label-interpolating Cypher against injection.</summary>
     private static readonly IReadOnlyList<string> PrunableLabels = new[] { "Entity", "Fact", "Preference" };

--- a/src/AgentMemory.Neo4j/Services/Neo4jMemoryHistoryService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jMemoryHistoryService.cs
@@ -12,7 +12,7 @@ namespace AgentMemory.Neo4j.Services;
 /// existing lifecycle fields (<c>invalidated_at</c>, <c>valid_until</c>, <c>:SUPERSEDED_BY</c>, provenance)
 /// plus read-audit/access fields into a normalized API/CLI surface.
 /// </summary>
-public sealed class Neo4jMemoryHistoryService(INeo4jTransactionRunner tx) : IMemoryHistoryService
+internal sealed class Neo4jMemoryHistoryService(INeo4jTransactionRunner tx) : IMemoryHistoryService
 {
     public async Task<IReadOnlyList<MemoryHistoryRecord>> GetHistoryAsync(
         MemoryHistoryQuery query,

--- a/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
@@ -15,7 +15,7 @@ namespace AgentMemory.Neo4j.Services;
 /// <see cref="SchemaLoader"/>); <c>name</c>/<c>version</c>/<c>description</c> are mirrored as top-level
 /// properties for indexed lookup. Schema nodes are global, not owner-scoped.
 /// </summary>
-public sealed class Neo4jSchemaManager : ISchemaManager
+internal sealed class Neo4jSchemaManager : ISchemaManager
 {
     private readonly INeo4jTransactionRunner _tx;
     private readonly IIdGenerator _idGenerator;

--- a/src/AgentMemory.Observability/MemoryMetrics.cs
+++ b/src/AgentMemory.Observability/MemoryMetrics.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Observability;
 /// <summary>
 /// Centralized <see cref="Meter"/> with counters and histograms for memory operations.
 /// </summary>
-public sealed class MemoryMetrics : IDisposable
+internal sealed class MemoryMetrics : IDisposable
 {
     /// <summary>
     /// The meter name used when registering with OpenTelemetry.

--- a/src/AgentMemory.Observability/MemoryMetrics.cs
+++ b/src/AgentMemory.Observability/MemoryMetrics.cs
@@ -17,7 +17,7 @@ public sealed class MemoryMetrics : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="MemoryMetrics"/> class.
     /// </summary>
-    internal MemoryMetrics()
+    public MemoryMetrics()
     {
         _meter = new Meter(MeterName, "1.0.0");
 

--- a/src/AgentMemory.Observability/MemoryMetrics.cs
+++ b/src/AgentMemory.Observability/MemoryMetrics.cs
@@ -5,7 +5,7 @@ namespace AgentMemory.Observability;
 /// <summary>
 /// Centralized <see cref="Meter"/> with counters and histograms for memory operations.
 /// </summary>
-internal sealed class MemoryMetrics : IDisposable
+public sealed class MemoryMetrics : IDisposable
 {
     /// <summary>
     /// The meter name used when registering with OpenTelemetry.
@@ -17,7 +17,7 @@ internal sealed class MemoryMetrics : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="MemoryMetrics"/> class.
     /// </summary>
-    public MemoryMetrics()
+    internal MemoryMetrics()
     {
         _meter = new Meter(MeterName, "1.0.0");
 
@@ -120,64 +120,64 @@ internal sealed class MemoryMetrics : IDisposable
     // Counters
 
     /// <summary>Number of messages stored in short-term memory.</summary>
-    public Counter<long> MessagesStored { get; }
+    internal Counter<long> MessagesStored { get; }
 
     /// <summary>Number of entities extracted from messages.</summary>
-    public Counter<long> EntitiesExtracted { get; }
+    internal Counter<long> EntitiesExtracted { get; }
 
     /// <summary>Number of facts extracted from messages.</summary>
-    public Counter<long> FactsExtracted { get; }
+    internal Counter<long> FactsExtracted { get; }
 
     /// <summary>Number of preferences extracted from messages.</summary>
-    public Counter<long> PreferencesExtracted { get; }
+    internal Counter<long> PreferencesExtracted { get; }
 
     /// <summary>Number of recall operations performed.</summary>
-    public Counter<long> RecallRequests { get; }
+    internal Counter<long> RecallRequests { get; }
 
     /// <summary>Number of extraction operations that failed.</summary>
-    public Counter<long> ExtractionErrors { get; }
+    internal Counter<long> ExtractionErrors { get; }
 
     /// <summary>Number of GraphRAG context queries performed.</summary>
-    public Counter<long> GraphRagQueries { get; }
+    internal Counter<long> GraphRagQueries { get; }
 
     // Histograms
 
     /// <summary>Duration of recall operations in milliseconds.</summary>
-    public Histogram<double> RecallDurationMs { get; }
+    internal Histogram<double> RecallDurationMs { get; }
 
     /// <summary>Duration of extraction operations in milliseconds.</summary>
-    public Histogram<double> ExtractionDurationMs { get; }
+    internal Histogram<double> ExtractionDurationMs { get; }
 
     /// <summary>Duration of persist operations in milliseconds.</summary>
-    public Histogram<double> PersistDurationMs { get; }
+    internal Histogram<double> PersistDurationMs { get; }
 
     /// <summary>Duration of GraphRAG queries in milliseconds.</summary>
-    public Histogram<double> GraphRagDurationMs { get; }
+    internal Histogram<double> GraphRagDurationMs { get; }
 
     /// <summary>Duration of context assembly operations in milliseconds.</summary>
-    public Histogram<double> ContextAssemblyDurationMs { get; }
+    internal Histogram<double> ContextAssemblyDurationMs { get; }
 
     /// <summary>Duration of entity extraction operations in milliseconds.</summary>
-    public Histogram<double> EntityExtractionDurationMs { get; }
+    internal Histogram<double> EntityExtractionDurationMs { get; }
 
     /// <summary>Duration of fact extraction operations in milliseconds.</summary>
-    public Histogram<double> FactExtractionDurationMs { get; }
+    internal Histogram<double> FactExtractionDurationMs { get; }
 
     /// <summary>Duration of preference extraction operations in milliseconds.</summary>
-    public Histogram<double> PreferenceExtractionDurationMs { get; }
+    internal Histogram<double> PreferenceExtractionDurationMs { get; }
 
     /// <summary>Duration of relationship extraction operations in milliseconds.</summary>
-    public Histogram<double> RelationshipExtractionDurationMs { get; }
+    internal Histogram<double> RelationshipExtractionDurationMs { get; }
 
     /// <summary>Number of relationships extracted from messages.</summary>
-    public Counter<long> RelationshipsExtracted { get; }
+    internal Counter<long> RelationshipsExtracted { get; }
 
     /// <summary>Number of enrichment requests performed.</summary>
-    public Counter<long> EnrichmentRequests { get; }
+    internal Counter<long> EnrichmentRequests { get; }
 
     /// <summary>Number of enrichment operations that failed.</summary>
-    public Counter<long> EnrichmentErrors { get; }
+    internal Counter<long> EnrichmentErrors { get; }
 
     /// <summary>Duration of enrichment operations in milliseconds.</summary>
-    public Histogram<double> EnrichmentDurationMs { get; }
+    internal Histogram<double> EnrichmentDurationMs { get; }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,16 +2,19 @@
   <!-- Chain to the repo-root Directory.Build.props (framework, packaging metadata, warnings-as-errors). -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <!-- 1.0 API-surface lockdown: the concrete implementation types across these packages are being made
+  <!-- 1.0 API-surface lockdown: the concrete implementation types across these packages are made
        'internal' (they are only ever resolved through the public Abstractions interfaces). These
-       InternalsVisibleTo grants keep them reachable from the first-party test/bench/cli/tool projects and,
-       pragmatically, from sibling first-party packages that construct a concrete directly. External
-       consumers are unaffected — IVT does not widen the public surface. Scoped to src/ so only the shipped
-       libraries grant friend access. -->
+       InternalsVisibleTo grants keep them reachable from the first-party test/bench/cli/tool projects.
+       The only shipped-sibling grants are the two justified by genuine cross-package use of shared
+       internal helpers, and they live in the individual grantor .csproj files (Core -> a few provider
+       packages for its text/format helpers; Abstractions -> Neo4j for SchemaConstants) rather than being
+       applied blanket here. Note: without strong-naming, IVT friend names are technically spoofable by an
+       assembly that adopts a friend's name; strong-naming (a project-wide change) is a possible future
+       hardening. IVT does not widen the public API surface seen by normal consumers. Scoped to src/. -->
   <ItemGroup>
     <!-- Castle DynamicProxy (used by NSubstitute) needs friend access to mock internal interfaces. -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <!-- Test / benchmark / tool consumers -->
+    <!-- Test / benchmark / tool consumers. -->
     <InternalsVisibleTo Include="AgentMemory.Tests.Unit" />
     <InternalsVisibleTo Include="AgentMemory.Tests.Unit.SemanticKernel" />
     <InternalsVisibleTo Include="AgentMemory.Tests.Integration" />
@@ -19,18 +22,5 @@
     <InternalsVisibleTo Include="AgentMemory.Benchmarks" />
     <InternalsVisibleTo Include="AgentMemory.Cli" />
     <InternalsVisibleTo Include="AgentMemory.TckBridge" />
-    <!-- First-party sibling packages -->
-    <InternalsVisibleTo Include="AgentMemory" />
-    <InternalsVisibleTo Include="AgentMemory.Abstractions" />
-    <InternalsVisibleTo Include="AgentMemory.Core" />
-    <InternalsVisibleTo Include="AgentMemory.Neo4j" />
-    <InternalsVisibleTo Include="AgentMemory.AgentFramework" />
-    <InternalsVisibleTo Include="AgentMemory.SemanticKernel" />
-    <InternalsVisibleTo Include="AgentMemory.McpServer" />
-    <InternalsVisibleTo Include="AgentMemory.Analytics" />
-    <InternalsVisibleTo Include="AgentMemory.Enrichment" />
-    <InternalsVisibleTo Include="AgentMemory.Observability" />
-    <InternalsVisibleTo Include="AgentMemory.Extraction.Llm" />
-    <InternalsVisibleTo Include="AgentMemory.Extraction.AzureLanguage" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+  <!-- Chain to the repo-root Directory.Build.props (framework, packaging metadata, warnings-as-errors). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- 1.0 API-surface lockdown: the concrete implementation types across these packages are being made
+       'internal' (they are only ever resolved through the public Abstractions interfaces). These
+       InternalsVisibleTo grants keep them reachable from the first-party test/bench/cli/tool projects and,
+       pragmatically, from sibling first-party packages that construct a concrete directly. External
+       consumers are unaffected — IVT does not widen the public surface. Scoped to src/ so only the shipped
+       libraries grant friend access. -->
+  <ItemGroup>
+    <!-- Castle DynamicProxy (used by NSubstitute) needs friend access to mock internal interfaces. -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <!-- Test / benchmark / tool consumers -->
+    <InternalsVisibleTo Include="AgentMemory.Tests.Unit" />
+    <InternalsVisibleTo Include="AgentMemory.Tests.Unit.SemanticKernel" />
+    <InternalsVisibleTo Include="AgentMemory.Tests.Integration" />
+    <InternalsVisibleTo Include="AgentMemory.Tests.Performance" />
+    <InternalsVisibleTo Include="AgentMemory.Benchmarks" />
+    <InternalsVisibleTo Include="AgentMemory.Cli" />
+    <InternalsVisibleTo Include="AgentMemory.TckBridge" />
+    <!-- First-party sibling packages -->
+    <InternalsVisibleTo Include="AgentMemory" />
+    <InternalsVisibleTo Include="AgentMemory.Abstractions" />
+    <InternalsVisibleTo Include="AgentMemory.Core" />
+    <InternalsVisibleTo Include="AgentMemory.Neo4j" />
+    <InternalsVisibleTo Include="AgentMemory.AgentFramework" />
+    <InternalsVisibleTo Include="AgentMemory.SemanticKernel" />
+    <InternalsVisibleTo Include="AgentMemory.McpServer" />
+    <InternalsVisibleTo Include="AgentMemory.Analytics" />
+    <InternalsVisibleTo Include="AgentMemory.Enrichment" />
+    <InternalsVisibleTo Include="AgentMemory.Observability" />
+    <InternalsVisibleTo Include="AgentMemory.Extraction.Llm" />
+    <InternalsVisibleTo Include="AgentMemory.Extraction.AzureLanguage" />
+  </ItemGroup>
+</Project>

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQueryRegistryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQueryRegistryTests.cs
@@ -71,7 +71,7 @@ public sealed class CypherQueryRegistryTests
         // but independently to catch drift.
         var expectedCount = typeof(CypherQueryRegistry).Assembly
             .GetTypes()
-            .Where(t => t.IsPublic && t.IsAbstract && t.IsSealed
+            .Where(t => !t.IsNested && t.IsAbstract && t.IsSealed // top-level static classes (public or internal)
                         && t.Name.EndsWith("Queries")
                         && t.Namespace == "AgentMemory.Neo4j.Queries")
             .SelectMany(t => t.GetFields(BindingFlags.Public | BindingFlags.Static))

--- a/tools/AgentMemory.TckBridge/BridgeAdmin.cs
+++ b/tools/AgentMemory.TckBridge/BridgeAdmin.cs
@@ -10,7 +10,7 @@ namespace AgentMemory.TckBridge;
 /// (<see cref="AgentMemory.Neo4j.Infrastructure.ISchemaBootstrapper"/> sibling —
 /// mirrors <c>Neo4jIntegrationFixture.CleanDatabaseAsync</c>).
 /// </summary>
-public sealed class BridgeAdmin
+internal sealed class BridgeAdmin
 {
     private readonly INeo4jSessionFactory _sessionFactory;
 


### PR DESCRIPTION
## Summary

First of the pre-1.0 **API-surface-lockdown** PRs, from the 12-package audit. The audit's headline: the public *contract design* is sound, but the surface is too **large** — ~115+ concrete implementation types were `public` though only ever resolved through the Abstractions interfaces, and would freeze under SemVer at 1.0 for zero consumer benefit. This PR makes them `internal`. **Accessibility-only: no signature, behavior, or DI-wiring changes.**

## Surface reduction (reflected public-type counts)

| Package | Before | After |
|---|--:|--:|
| AgentMemory.Core | 38 | **6** |
| AgentMemory.Neo4j | 65 | **8** |
| AgentMemory.McpServer | 19 | **2** |
| AgentMemory.Enrichment | 10 | **4** |
| AgentMemory.Analytics | 10 | **7** |
| AgentMemory.Extraction.AzureLanguage | 6 | **2** |
| AgentMemory.Extraction.Llm | 6 | **2** |
| AgentMemory.Observability | 3 | **2** |
| AgentMemory.Abstractions | 158 | 153 |
| AgentMemory.AgentFramework | 13 | 13 |
| AgentMemory.SemanticKernel | 3 | 3 |
| **Total** | **~331** | **~203** |

Every removed type was pure implementation. Abstractions (the actual contract) is essentially unchanged; the MAF + Semantic Kernel adapters stay public because samples program against them directly.

## What stayed public (the intended 1.0 contract)

All Abstractions interfaces/records/options/enums; each package's `ServiceCollectionExtensions` + options; the MAF & SK integration adapters; and the deliberate seams `INeo4jTransactionRunner`, `ISchemaBootstrapper`, `IMigrationRunner`, `StubEmbeddingGenerator`, `SystemClock`, `GuidIdGenerator`, `PatternBasedPreferenceDetector`, `ExtractorBase`, `MemoryActivitySource`, `GraphRagOptions`. (The compiler flagged `ISchemaBootstrapper`/`IMigrationRunner` as used by samples/CLI — a real ops surface — so the audit's suggestion to internalize them was walked back.)

## Mechanics

- New `src/Directory.Build.props` grants `InternalsVisibleTo` to test/bench/CLI/bridge projects, first-party sibling packages, and **`DynamicProxyGenAssembly2`** (so NSubstitute can still mock the now-internal interfaces). Scoped to `src/` so only shipped libraries grant friend access; IVT does not widen the public surface.
- `SchemaConstants` → `internal` (only Abstractions/Neo4j reference it; no external caller passes the node-label strings). The `MemoryNodeKind` enum + dead-`ToolCallStatusValues` deletion are deferred to the enum/naming PR (signature/deletion changes, not pure accessibility).
- `CypherQueryRegistry` reflection (and its mirror test) now match top-level static classes public **or** internal, instead of filtering on `IsPublic`.
- Bridge's `BridgeAdmin` → `internal` (its `INeo4jSessionFactory` dependency is now internal).

## Verified

| Check | Result |
|---|---|
| Release build | 0 warnings / 0 errors |
| Full unit suite | 2705 / 2705 |
| Full integration suite (Testcontainers) | 253 / 253 |
| TCK Bronze+Silver+Gold (live Neo4j 5.26) | 178 / 178 |

## Next in the 1.0 series

PR2 interface follow-ups (`ListAllTracesAsync`, `GetStatsAsync`) + `MergeEntitiesAsync` return value · PR3 correctness/honesty (DI wiring bugs, `AddMessageAsync`, `UpdateAsync?`) · PR4 naming/enum/`ct` freeze (incl. `MemoryNodeKind`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsi9nT4PG1BBrvLBq3XZma
