### PR TITLE
1.0 API surface (2/4): interface follow-ups + MergeEntitiesAsync return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`IReasoningMemoryService.ListAllTracesAsync` — owner-scoped, paged, cross-session trace listing.** Returns a `PagedResult<ReasoningTrace>` (newest-first, N+1 `HasNextPage`, `offset`-advanced), optionally owner-scoped (R1). Mirrored on `IReasoningTraceRepository.ListAllAsync`. Added pre-`1.0` because extending a public interface after the freeze breaks every third-party implementer.
-- **`IToolCallRepository.GetStatsAsync(toolName?)` + a `ToolCallStats` record — per-tool usage aggregates.** Groups tool calls by name (total / successful / failed / success-rate / avg-duration) over calls reachable through owner-scoped reasoning traces; never reads the cross-owner global `:Tool` node. Same pre-`1.0` interface-stability rationale.
+- **`IToolCallRepository.GetStatsAsync(toolName?, scope?)` + a `ToolCallStats` record — per-tool usage aggregates.** Groups tool calls by name (total / successful / failed / success-rate / avg-duration) over calls reachable through owner-scoped reasoning traces; never reads the cross-owner global `:Tool` node. Same pre-`1.0` interface-stability rationale.
 - These two additions let the upstream-TCK bridge drop its last two raw-Cypher fallbacks (`list_traces` with no session, `get_tool_stats`) in favor of the first-class services.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`IReasoningMemoryService.ListAllTracesAsync` — owner-scoped, paged, cross-session trace listing.** Returns a `PagedResult<ReasoningTrace>` (newest-first, N+1 `HasNextPage`, `offset`-advanced), optionally owner-scoped (R1). Mirrored on `IReasoningTraceRepository.ListAllAsync`. Added pre-`1.0` because extending a public interface after the freeze breaks every third-party implementer.
+- **`IToolCallRepository.GetStatsAsync(toolName?)` + a `ToolCallStats` record — per-tool usage aggregates.** Groups tool calls by name (total / successful / failed / success-rate / avg-duration) over calls reachable through owner-scoped reasoning traces; never reads the cross-owner global `:Tool` node. Same pre-`1.0` interface-stability rationale.
+- These two additions let the upstream-TCK bridge drop its last two raw-Cypher fallbacks (`list_traces` with no session, `get_tool_stats`) in favor of the first-class services.
+
 ### Changed
 
+- **`IEntityRepository.MergeEntitiesAsync` now returns `Task<bool>`** (was `Task`): `true` when the merge matched and ran, `false` for a guarded / non-existent no-op. Future-proofs the deferred merge-relationship-transfer fix (it can report edges moved without another signature break).
 - **1.0 API-surface lockdown — implementation types internalized.** Concrete implementation classes that are only ever resolved through the public Abstractions interfaces (the memory/reasoning services, Neo4j repositories/services/query holders/infrastructure, MCP tools/resources/prompts, extraction providers, enrichment decorators, GDS analytics services, merge strategies, and stubs) are now `internal`, shrinking the public surface from ~331 to ~203 types ahead of the SemVer-stable `1.0`. Accessibility-only: no behavior, signature, or DI-wiring change — DI resolves the internal types (via their still-public constructors) unchanged. The public contract is the Abstractions interfaces/records/options/enums, each package's `ServiceCollectionExtensions` + options, the Microsoft Agent Framework and Semantic Kernel adapters, and a small set of deliberate seams (`INeo4jTransactionRunner`, `ISchemaBootstrapper`, `IMigrationRunner`, `MemoryActivitySource`, `MemoryMetrics.MeterName`, the stub/clock/id helpers, `ExtractorBase`).
 - **`SchemaConstants` and the schema-parity kit are now internal.** `SchemaConstants` (raw Neo4j backend label/property/edge strings) and the parity types (`SchemaParityVerifier`, `SchemaDescriptor`, `SchemaParityPolicy`, `SchemaParityReport`, `UpstreamSchemaRegistry`, `DotNetSchema`) — previously described as a reusable library component in `AgentMemory.Neo4j.Schema.Parity` — are implementation details for `1.0`. Schema-parity verification remains available through the `agentmemory schema-parity` CLI command; it is no longer a library API.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,7 @@ graph TD
 | **Purpose** | Domain contracts — all models, interfaces, and configuration types shared across the system |
 | **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.5.1 (approved, D-AR2-1) — .NET 9 BCL otherwise |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK, any MCP SDK, any NuGet package **except** Microsoft.Extensions.AI.Abstractions |
-| **Key types** | 47 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, etc.), 38 service interfaces, 11 repository interfaces, 15 configuration types (incl. `MemoryRankingOptions`), 13 enums (incl. `MemoryProfile`, `RankingIntent`, `MemoryHistoryKind`, `MemoryHistoryStatus`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
+| **Key types** | 48 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, etc.), 38 service interfaces, 11 repository interfaces, 15 configuration types (incl. `MemoryRankingOptions`), 13 enums (incl. `MemoryProfile`, `RankingIntent`, `MemoryHistoryKind`, `MemoryHistoryStatus`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
 
 **Namespace structure:**
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,7 +10,7 @@
 
 ## 1. Domain Model Overview
 
-The domain model comprises **47 domain records** (plus 13 enums) organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, ranking, conflict detection, consolidation, and configuration. All domain types are defined in `AgentMemory.Abstractions`. (Counts are enforced by `AbstractionsContractGuardTests`.)
+The domain model comprises **48 domain records** (plus 13 enums) organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, ranking, conflict detection, consolidation, and configuration. All domain types are defined in `AgentMemory.Abstractions`. (Counts are enforced by `AbstractionsContractGuardTests`.)
 
 ### Key Design Decisions
 
@@ -155,6 +155,7 @@ graph TD
 | `ReasoningTrace` | Top-level record of an agent reasoning task | `TraceId`, `SessionId`, `Task`, `Outcome?`, `Success?`, `StartedAtUtc`, `CompletedAtUtc?`, `TaskEmbedding?`, `Metadata` |
 | `ReasoningStep` | One step in a reasoning chain | `StepId`, `TraceId`, `StepNumber`, `Thought?`, `Action?`, `Observation?`, `Embedding?`, `Metadata` |
 | `ToolCall` | A tool invocation within a step | `ToolCallId`, `StepId`, `ToolName`, `Arguments`, `Result?`, `Status`, `DurationMs?`, `Error?`, `Metadata` |
+| `ToolCallStats` | Aggregate per-tool usage stats | `ToolName`, `TotalCalls`, `SuccessfulCalls`, `FailedCalls`, `SuccessRate`, `AvgDurationMs?` |
 | `ToolCallStatus` (enum) | Tool call lifecycle | `Pending`, `Success`, `Error`, `Cancelled`, `Failure`, `Timeout` |
 
 **Repository Interfaces:**
@@ -382,7 +383,7 @@ All repository interfaces are defined in `AgentMemory.Abstractions.Repositories`
 | 6 | `IRelationshipRepository` | Relationship CRUD over `RELATED_TO` edges | `UpsertAsync`, `GetByIdAsync`, `GetByEntityAsync`, `GetBySourceEntityAsync`, `GetByTargetEntityAsync` | `(:Entity)-[:RELATED_TO]->(:Entity)` |
 | 7 | `IReasoningTraceRepository` | Trace persistence + search | `AddAsync`, `UpdateAsync`, `GetByIdAsync`, `ListBySessionAsync`, `SearchByTaskVectorAsync` | `:ReasoningTrace` |
 | 8 | `IReasoningStepRepository` | Step persistence | `AddAsync`, `GetByTraceAsync`, `GetByIdAsync` | `:ReasoningStep` |
-| 9 | `IToolCallRepository` | Tool call persistence | `AddAsync`, `UpdateAsync`, `GetByStepAsync`, `GetByIdAsync` | `:ToolCall` |
+| 9 | `IToolCallRepository` | Tool call persistence | `AddAsync`, `UpdateAsync`, `GetByStepAsync`, `GetByIdAsync`, `GetStatsAsync` | `:ToolCall` |
 | 10 | `ISchemaRepository` | Schema + migration management | `InitializeSchemaAsync`, `IsSchemaInitializedAsync`, `GetSchemaVersionAsync`, `ApplyMigrationAsync` | (meta) |
 | 11 | `IExtractorRepository` | Extractor registry + extraction provenance | `GetByNameAsync`, `CreateExtractedByRelationshipAsync`, `GetProvenanceAsync`, `GetExtractorStatsAsync`, `GetExtractionStatsAsync`, `DeleteProvenanceAsync` | `:Extractor` / `EXTRACTED_BY` |
 

--- a/src/AgentMemory.Abstractions/Domain/Reasoning/ToolCallStats.cs
+++ b/src/AgentMemory.Abstractions/Domain/Reasoning/ToolCallStats.cs
@@ -1,0 +1,18 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>
+/// Aggregate usage statistics for a single tool, computed over recorded <see cref="ToolCall"/>s.
+/// </summary>
+/// <param name="ToolName">The tool these stats are for.</param>
+/// <param name="TotalCalls">Total number of recorded calls to the tool.</param>
+/// <param name="SuccessfulCalls">Calls whose status is <c>success</c>.</param>
+/// <param name="FailedCalls">Calls whose status is <c>error</c>, <c>failure</c>, or <c>timeout</c>.</param>
+/// <param name="SuccessRate">Successful ÷ total (0.0 when there are no calls).</param>
+/// <param name="AvgDurationMs">Mean recorded duration in milliseconds, or <c>null</c> when there are no calls.</param>
+public sealed record ToolCallStats(
+    string ToolName,
+    int TotalCalls,
+    int SuccessfulCalls,
+    int FailedCalls,
+    double SuccessRate,
+    double? AvgDurationMs);

--- a/src/AgentMemory.Abstractions/Domain/Reasoning/ToolCallStats.cs
+++ b/src/AgentMemory.Abstractions/Domain/Reasoning/ToolCallStats.cs
@@ -8,7 +8,9 @@ namespace AgentMemory.Abstractions.Domain;
 /// <param name="SuccessfulCalls">Calls whose status is <c>success</c>.</param>
 /// <param name="FailedCalls">Calls whose status is <c>error</c>, <c>failure</c>, or <c>timeout</c>.</param>
 /// <param name="SuccessRate">Successful ÷ total (0.0 when there are no calls).</param>
-/// <param name="AvgDurationMs">Mean recorded duration in milliseconds, or <c>null</c> when there are no calls.</param>
+/// <param name="AvgDurationMs">Mean duration in milliseconds across <b>all</b> calls, counting a call whose
+/// duration was not recorded as 0 (i.e. total recorded time ÷ total calls, not ÷ calls-with-a-duration);
+/// <c>null</c> only when the tool has no calls at all.</param>
 public sealed record ToolCallStats(
     string ToolName,
     int TotalCalls,

--- a/src/AgentMemory.Abstractions/Repositories/IEntityRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IEntityRepository.cs
@@ -152,8 +152,10 @@ public interface IEntityRepository
     /// search-field refresh, so a scoped caller never bumps another owner's entity. Null scope ⇒ unscoped
     /// (admin/maintenance dedup). Note: arbitrary typed relationships (other than SAME_AS/MENTIONS) are
     /// not yet re-pointed from source to target — see the merge-relationship-transfer follow-up.
+    /// Returns <c>true</c> if the merge matched and ran; <c>false</c> for a guarded / non-existent no-op.
+    /// (The return value future-proofs the relationship-transfer follow-up, which will report edges moved.)
     /// </summary>
-    Task MergeEntitiesAsync(
+    Task<bool> MergeEntitiesAsync(
         string sourceEntityId,
         string targetEntityId,
         MemoryScope? scope = null,

--- a/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IReasoningTraceRepository.cs
@@ -28,6 +28,16 @@ public interface IReasoningTraceRepository
     /// </summary>
     Task<IReadOnlyList<ReasoningTrace>> ListBySessionAsync(string sessionId, int limit = 10, MemoryScope? scope = null, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Lists traces across all sessions, newest first, paged (fetches one extra to set <c>HasNextPage</c>
+    /// without a COUNT round-trip), optionally scoped to an owner (R1) — never another owner's traces.
+    /// </summary>
+    Task<PagedResult<ReasoningTrace>> ListAllAsync(
+        int limit = 50,
+        int offset = 0,
+        MemoryScope? scope = null,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Searches traces by task embedding similarity, optionally scoped to an owner (R1).</summary>
     Task<IReadOnlyList<(ReasoningTrace Trace, double Score)>> SearchByTaskVectorAsync(
         float[] taskEmbedding,

--- a/src/AgentMemory.Abstractions/Repositories/IToolCallRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IToolCallRepository.cs
@@ -1,4 +1,5 @@
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 
 namespace AgentMemory.Abstractions.Repositories;
 
@@ -25,4 +26,17 @@ public interface IToolCallRepository
 
     /// <summary>Creates a TRIGGERED_BY relationship from a tool call to the message that triggered it.</summary>
     Task CreateTriggeredByRelationshipAsync(string toolCallId, string messageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Aggregates tool-usage statistics grouped by tool name, over tool calls reachable through reasoning
+    /// traces within the given owner scope (R1). Tool calls carry no owner of their own, so the scope is
+    /// applied at the owning <c>ReasoningTrace</c> tier — the aggregate never spans owners. When
+    /// <paramref name="toolName"/> is set, returns at most the single matching tool's stats; otherwise one
+    /// entry per tool, ordered by name. Deliberately does not read the global aggregate <c>:Tool</c> node
+    /// (which accumulates across all owners). <paramref name="scope"/> null ⇒ unscoped (all owners).
+    /// </summary>
+    Task<IReadOnlyList<ToolCallStats>> GetStatsAsync(
+        string? toolName = null,
+        MemoryScope? scope = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IReasoningMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/IReasoningMemoryService.cs
@@ -98,9 +98,9 @@ public interface IReasoningMemoryService
     /// result carries a <c>HasNextPage</c> flag (N+1 pagination); advance with <paramref name="offset"/>.
     /// </summary>
     Task<PagedResult<ReasoningTrace>> ListAllTracesAsync(
-        MemoryScope? scope = null,
         int limit = 50,
         int offset = 0,
+        MemoryScope? scope = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/AgentMemory.Abstractions/Services/IReasoningMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/IReasoningMemoryService.cs
@@ -92,6 +92,18 @@ public interface IReasoningMemoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists reasoning traces across all sessions, newest first, optionally scoped to an owner (R1) and
+    /// paged. A cross-session trace list is not keyed by a private handle, so when <paramref name="scope"/>
+    /// is set this returns only the owner's own (and, if <c>IncludeShared</c>, shared/global) traces. The
+    /// result carries a <c>HasNextPage</c> flag (N+1 pagination); advance with <paramref name="offset"/>.
+    /// </summary>
+    Task<PagedResult<ReasoningTrace>> ListAllTracesAsync(
+        MemoryScope? scope = null,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Searches for similar traces by task embedding.
     /// </summary>
     Task<IReadOnlyList<ReasoningTrace>> SearchSimilarTracesAsync(

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -254,6 +254,16 @@ internal sealed class ReasoningMemoryService : IReasoningMemoryService
         return _traceRepo.ListBySessionAsync(sessionId, limit, scope, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public Task<PagedResult<ReasoningTrace>> ListAllTracesAsync(
+        MemoryScope? scope = null,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        return _traceRepo.ListAllAsync(limit, offset, scope, cancellationToken);
+    }
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<ReasoningTrace>> SearchSimilarTracesAsync(
         float[] taskEmbedding,

--- a/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
+++ b/src/AgentMemory.Core/Services/ReasoningMemoryService.cs
@@ -256,9 +256,9 @@ internal sealed class ReasoningMemoryService : IReasoningMemoryService
 
     /// <inheritdoc />
     public Task<PagedResult<ReasoningTrace>> ListAllTracesAsync(
-        MemoryScope? scope = null,
         int limit = 50,
         int offset = 0,
+        MemoryScope? scope = null,
         CancellationToken cancellationToken = default)
     {
         return _traceRepo.ListAllAsync(limit, offset, scope, cancellationToken);

--- a/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
@@ -60,6 +60,26 @@ internal static class ReasoningQueries
     }
 
     /// <summary>
+    /// Lists traces across ALL sessions, newest first, paged via SKIP/LIMIT. Callers fetch one extra row
+    /// ($limit is size+1) to detect a next page. Optionally owner-scoped (R1) — a cross-session list is not
+    /// keyed by a private handle, so when scoped it returns only the owner's own (and, if includeShared,
+    /// shared/global) traces.
+    /// </summary>
+    public static string ListAllTraces(bool hasOwnerFilter, bool includeShared)
+    {
+        var owner = !hasOwnerFilter ? string.Empty
+            : includeShared ? " AND (t.owner_id = $ownerId OR t.owner_id IS NULL)"
+                            : " AND t.owner_id = $ownerId";
+        return @"
+            MATCH (t:ReasoningTrace)
+            WHERE true" + owner + @"
+            RETURN t
+            ORDER BY t.started_at DESC
+            SKIP $offset
+            LIMIT $limit";
+    }
+
+    /// <summary>
     /// Delete ReasoningTrace nodes for a session (and their child ReasoningStep nodes), confined to a
     /// single R1 owner bucket so a session-keyed destructive write can never cross owners (the twin of the
     /// #56 <see cref="PruneSessionTraces"/> hardening — ReasoningTrace carries <c>owner_id</c>, and

--- a/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ReasoningQueries.cs
@@ -70,11 +70,13 @@ internal static class ReasoningQueries
         var owner = !hasOwnerFilter ? string.Empty
             : includeShared ? " AND (t.owner_id = $ownerId OR t.owner_id IS NULL)"
                             : " AND t.owner_id = $ownerId";
+        // Tie-break on id so SKIP/LIMIT paging is stable when traces share a started_at — without it,
+        // equal-timestamp rows can reorder between page fetches, causing duplicates or missed rows.
         return @"
             MATCH (t:ReasoningTrace)
             WHERE true" + owner + @"
             RETURN t
-            ORDER BY t.started_at DESC
+            ORDER BY t.started_at DESC, t.id DESC
             SKIP $offset
             LIMIT $limit";
     }

--- a/src/AgentMemory.Neo4j/Queries/ToolCallQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/ToolCallQueries.cs
@@ -5,6 +5,28 @@ namespace AgentMemory.Neo4j.Queries;
 /// </summary>
 internal static class ToolCallQueries
 {
+    /// <summary>
+    /// Aggregates tool-usage stats grouped by tool name over ToolCall nodes reached through
+    /// ReasoningTrace→ReasoningStep→ToolCall, optionally owner-scoped at the trace tier (R1) and optionally
+    /// filtered to one tool. Success/failure classification matches UpsertToolInstance (status is stored
+    /// lowercase: success vs error/failure/timeout). Deliberately does not read the global :Tool node.
+    /// </summary>
+    public static string GetStats(bool hasOwnerFilter, bool includeShared)
+    {
+        var owner = !hasOwnerFilter ? string.Empty
+            : includeShared ? " AND (t.owner_id = $ownerId OR t.owner_id IS NULL)"
+                            : " AND t.owner_id = $ownerId";
+        return @"
+            MATCH (t:ReasoningTrace)-[:HAS_STEP]->(:ReasoningStep)-[:USES_TOOL]->(tc:ToolCall)
+            WHERE ($toolName IS NULL OR tc.tool_name = $toolName)" + owner + @"
+            WITH tc.tool_name AS name, count(tc) AS total_calls,
+                 sum(CASE WHEN tc.status = 'success' THEN 1 ELSE 0 END) AS successful_calls,
+                 sum(CASE WHEN tc.status IN ['error', 'failure', 'timeout'] THEN 1 ELSE 0 END) AS failed_calls,
+                 sum(coalesce(tc.duration_ms, 0)) AS total_duration_ms
+            RETURN name, total_calls, successful_calls, failed_calls, total_duration_ms
+            ORDER BY name";
+    }
+
     /// <summary>Create a new ToolCall node and link it to its parent ReasoningStep.</summary>
     public const string Add = @"
             MATCH (s:ReasoningStep {id: $stepId})

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -369,7 +369,7 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task MergeEntitiesAsync(string sourceEntityId, string targetEntityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+    public async Task<bool> MergeEntitiesAsync(string sourceEntityId, string targetEntityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
@@ -394,6 +394,8 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
         // makes such a call a true no-op, not merely a merge-less one.
         if (merged)
             await RefreshEntitySearchFieldsAsync(targetEntityId, cancellationToken).ConfigureAwait(false);
+
+        return merged;
     }
 
     public async Task RefreshEntitySearchFieldsAsync(string entityId, CancellationToken cancellationToken = default)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -107,6 +107,30 @@ internal sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<PagedResult<ReasoningTrace>> ListAllAsync(int limit = 50, int offset = 0, MemoryScope? scope = null, CancellationToken cancellationToken = default)
+    {
+        bool hasOwner = scope?.HasOwnerFilter == true;
+        bool includeShared = scope?.IncludeShared ?? true;
+        _logger.LogDebug("Listing all reasoning traces, limit={Limit}, offset={Offset}, owner={Owner}", limit, offset, scope?.OwnerId);
+
+        var cypher = ReasoningQueries.ListAllTraces(hasOwner, includeShared);
+        // Fetch one extra row (N+1) to set HasNextPage without a separate COUNT round-trip.
+        var parameters = new Dictionary<string, object> { ["offset"] = offset, ["limit"] = limit + 1 };
+        if (hasOwner) parameters["ownerId"] = scope!.OwnerId!;
+
+        return await _tx.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            var traces = records.Take(limit).Select(r =>
+            {
+                var node = r["t"].As<INode>();
+                return MapToTrace(node, ReadEmbedding(node));
+            }).ToList();
+            return new PagedResult<ReasoningTrace>(traces, records.Count > limit);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<(ReasoningTrace Trace, double Score)>> SearchByTaskVectorAsync(
         float[] taskEmbedding,
         bool? successFilter = null,

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jReasoningTraceRepository.cs
@@ -109,13 +109,16 @@ internal sealed class Neo4jReasoningTraceRepository : IReasoningTraceRepository
 
     public async Task<PagedResult<ReasoningTrace>> ListAllAsync(int limit = 50, int offset = 0, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
+        // Predictable failures for invalid paging input, and no wraparound on the N+1 fetch below.
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
         _logger.LogDebug("Listing all reasoning traces, limit={Limit}, offset={Offset}, owner={Owner}", limit, offset, scope?.OwnerId);
 
         var cypher = ReasoningQueries.ListAllTraces(hasOwner, includeShared);
         // Fetch one extra row (N+1) to set HasNextPage without a separate COUNT round-trip.
-        var parameters = new Dictionary<string, object> { ["offset"] = offset, ["limit"] = limit + 1 };
+        var parameters = new Dictionary<string, object> { ["offset"] = offset, ["limit"] = checked(limit + 1) };
         if (hasOwner) parameters["ownerId"] = scope!.OwnerId!;
 
         return await _tx.ReadAsync(async runner =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Neo4j.Infrastructure;
 using AgentMemory.Neo4j.Queries;
@@ -124,6 +125,40 @@ internal sealed class Neo4jToolCallRepository : IToolCallRepository
             await runner.RunAsync(
                 ToolCallQueries.CreateTriggeredByRelationship,
                 new { toolCallId, messageId }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ToolCallStats>> GetStatsAsync(
+        string? toolName = null,
+        MemoryScope? scope = null,
+        CancellationToken cancellationToken = default)
+    {
+        bool hasOwner = scope?.HasOwnerFilter == true;
+        bool includeShared = scope?.IncludeShared ?? true;
+        _logger.LogDebug("Aggregating tool stats, tool={Tool}, owner={Owner}", toolName, scope?.OwnerId);
+
+        var cypher = ToolCallQueries.GetStats(hasOwner, includeShared);
+        var parameters = new Dictionary<string, object?> { ["toolName"] = toolName };
+        if (hasOwner) parameters["ownerId"] = scope!.OwnerId!;
+
+        return await _tx.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            return records.Select(r =>
+            {
+                var totalCalls = checked((int)r["total_calls"].As<long>());
+                var successful = checked((int)r["successful_calls"].As<long>());
+                var failed = checked((int)r["failed_calls"].As<long>());
+                var totalDurationMs = r["total_duration_ms"].As<long?>() ?? 0;
+                return new ToolCallStats(
+                    r["name"].As<string>(),
+                    totalCalls,
+                    successful,
+                    failed,
+                    totalCalls > 0 ? (double)successful / totalCalls : 0.0,
+                    totalCalls > 0 ? (double)totalDurationMs / totalCalls : null);
+            }).ToList();
         }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/EntityRepositoryIntegrationTests.cs
@@ -200,8 +200,9 @@ public class EntityRepositoryIntegrationTests : IAsyncLifetime
         var bobBefore = await _repo.GetByIdAsync(bobId);
 
         // bob's scope must not be able to merge alice's entity into bob's.
-        await _repo.MergeEntitiesAsync(aliceId, bobId, MemoryScope.For("bob"));
+        var merged = await _repo.MergeEntitiesAsync(aliceId, bobId, MemoryScope.For("bob"));
 
+        merged.Should().BeFalse("a guarded cross-owner merge matches nothing and is a no-op");
         (await _repo.GetByIdAsync(aliceId)).Should().NotBeNull("the cross-owner merge must no-op");
         var bobAfter = await _repo.GetByIdAsync(bobId);
         bobAfter!.Aliases.Should().NotContain("AliceCo", "bob's entity must not absorb alice's name");
@@ -209,6 +210,19 @@ public class EntityRepositoryIntegrationTests : IAsyncLifetime
         // which would otherwise bump bob's updated_at — a scoped call silently writing another owner's node.
         bobAfter.UpdatedAtUtc.Should().Be(bobBefore!.UpdatedAtUtc,
             "a no-op merge must not touch bob's entity at all (no post-merge refresh)");
+    }
+
+    [Fact]
+    public async Task MergeEntitiesAsync_SameOwner_ReturnsTrue_AndAbsorbsSourceName()
+    {
+        var targetId = await SeedOwnedEntityAsync("Alice Johnson", "alice");
+        var sourceId = await SeedOwnedEntityAsync("A. Johnson", "alice");
+
+        var merged = await _repo.MergeEntitiesAsync(sourceId, targetId, MemoryScope.For("alice"));
+
+        merged.Should().BeTrue("both endpoints are alice's own entities, so the merge matches and runs");
+        (await _repo.GetByIdAsync(targetId))!.Aliases.Should().Contain("A. Johnson",
+            "the surviving target absorbs the source's name as an alias");
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Neo4j.Repositories;
 using AgentMemory.Tests.Integration.Fixtures;
 using Neo4j.Driver;
@@ -316,5 +317,60 @@ public class ReasoningTraceRepositoryIntegrationTests : IAsyncLifetime
         });
 
         count.Should().Be(1);
+    }
+
+    // ---- ListAllAsync (cross-session, paged, owner-scoped) ----
+
+    private ReasoningTrace NewTrace(string session, string task, DateTimeOffset started, string? owner = null) => new()
+    {
+        TraceId = $"trace-{Guid.NewGuid():N}",
+        SessionId = session,
+        Task = task,
+        OwnerId = owner,
+        StartedAtUtc = started,
+    };
+
+    [Fact]
+    public async Task ListAllAsync_ReturnsTracesAcrossSessions_NewestFirst()
+    {
+        await _repo.AddAsync(NewTrace("s1", "task A", new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+        await _repo.AddAsync(NewTrace("s2", "task B", new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero)));
+        await _repo.AddAsync(NewTrace("s3", "task C", new DateTimeOffset(2025, 3, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        var page = await _repo.ListAllAsync(limit: 10);
+
+        page.Items.Should().HaveCount(3);
+        page.Items.Select(t => t.Task).Should().ContainInOrder("task C", "task B", "task A");
+        page.HasNextPage.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListAllAsync_Paging_SetsHasNextPage_AndAdvancesByOffset()
+    {
+        for (var i = 0; i < 3; i++)
+            await _repo.AddAsync(NewTrace($"s{i}", $"task {i}", new DateTimeOffset(2025, 1, 1 + i, 0, 0, 0, TimeSpan.Zero)));
+
+        var page1 = await _repo.ListAllAsync(limit: 2, offset: 0);
+        page1.Items.Should().HaveCount(2);
+        page1.HasNextPage.Should().BeTrue("a 4th row was fetched beyond the page of 2");
+
+        var page2 = await _repo.ListAllAsync(limit: 2, offset: 2);
+        page2.Items.Should().HaveCount(1);
+        page2.HasNextPage.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListAllAsync_OwnerScoped_ExcludesOtherOwners()
+    {
+        var now = new DateTimeOffset(2025, 4, 1, 0, 0, 0, TimeSpan.Zero);
+        await _repo.AddAsync(NewTrace("s", "alice task", now, owner: "alice"));
+        await _repo.AddAsync(NewTrace("s", "bob task", now, owner: "bob"));
+        await _repo.AddAsync(NewTrace("s", "shared task", now, owner: null));
+
+        var page = await _repo.ListAllAsync(limit: 10, scope: MemoryScope.For("alice"));
+        var tasks = page.Items.Select(t => t.Task).ToList();
+
+        tasks.Should().Contain("alice task").And.Contain("shared task");
+        tasks.Should().NotContain("bob task", "bob's traces are outside alice's scope");
     }
 }

--- a/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ReasoningTraceRepositoryIntegrationTests.cs
@@ -352,7 +352,7 @@ public class ReasoningTraceRepositoryIntegrationTests : IAsyncLifetime
 
         var page1 = await _repo.ListAllAsync(limit: 2, offset: 0);
         page1.Items.Should().HaveCount(2);
-        page1.HasNextPage.Should().BeTrue("a 4th row was fetched beyond the page of 2");
+        page1.HasNextPage.Should().BeTrue("a 3rd row was fetched (N+1) beyond the page of 2");
 
         var page2 = await _repo.ListAllAsync(limit: 2, offset: 2);
         page2.Items.Should().HaveCount(1);

--- a/tests/AgentMemory.Tests.Integration/Repositories/ToolCallStatsIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ToolCallStatsIntegrationTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Neo4j.Repositories;
+using AgentMemory.Tests.Integration.Fixtures;
+
+namespace AgentMemory.Tests.Integration.Repositories;
+
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public class ToolCallStatsIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private readonly Neo4jReasoningTraceRepository _traceRepo;
+    private readonly Neo4jReasoningStepRepository _stepRepo;
+    private readonly Neo4jToolCallRepository _toolRepo;
+
+    public ToolCallStatsIntegrationTests(Neo4jIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _traceRepo = new Neo4jReasoningTraceRepository(fixture.TransactionRunner, NullLogger<Neo4jReasoningTraceRepository>.Instance);
+        _stepRepo = new Neo4jReasoningStepRepository(fixture.TransactionRunner, NullLogger<Neo4jReasoningStepRepository>.Instance);
+        _toolRepo = new Neo4jToolCallRepository(fixture.TransactionRunner, NullLogger<Neo4jToolCallRepository>.Instance);
+    }
+
+    public Task InitializeAsync() => _fixture.CleanDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // Seeds a trace (owned as given) + one step, returns the step id so tool calls can hang off it.
+    private async Task<string> SeedStepAsync(string? owner)
+    {
+        var traceId = $"trace-{Guid.NewGuid():N}";
+        await _traceRepo.AddAsync(new ReasoningTrace
+        {
+            TraceId = traceId,
+            SessionId = "s",
+            Task = "t",
+            OwnerId = owner,
+            StartedAtUtc = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+        var stepId = $"step-{Guid.NewGuid():N}";
+        await _stepRepo.AddAsync(new ReasoningStep { StepId = stepId, TraceId = traceId, StepNumber = 1 });
+        return stepId;
+    }
+
+    private Task AddCallAsync(string stepId, string tool, ToolCallStatus status, long? durationMs) =>
+        _toolRepo.AddAsync(new ToolCall
+        {
+            ToolCallId = $"tc-{Guid.NewGuid():N}",
+            StepId = stepId,
+            ToolName = tool,
+            ArgumentsJson = "{}",
+            Status = status,
+            DurationMs = durationMs,
+        });
+
+    [Fact]
+    public async Task GetStatsAsync_AggregatesByTool_WithSuccessRateAndAvgDuration()
+    {
+        var step = await SeedStepAsync(owner: null);
+        await AddCallAsync(step, "search", ToolCallStatus.Success, 100);
+        await AddCallAsync(step, "search", ToolCallStatus.Success, 300);
+        await AddCallAsync(step, "search", ToolCallStatus.Error, 200);
+        await AddCallAsync(step, "fetch", ToolCallStatus.Timeout, 50);
+
+        var stats = await _toolRepo.GetStatsAsync();
+
+        stats.Should().HaveCount(2);
+        var search = stats.Single(s => s.ToolName == "search");
+        search.TotalCalls.Should().Be(3);
+        search.SuccessfulCalls.Should().Be(2);
+        search.FailedCalls.Should().Be(1);
+        search.SuccessRate.Should().BeApproximately(2.0 / 3.0, 1e-9);
+        search.AvgDurationMs.Should().BeApproximately(200.0, 1e-9); // (100+300+200)/3
+
+        var fetch = stats.Single(s => s.ToolName == "fetch");
+        fetch.TotalCalls.Should().Be(1);
+        fetch.FailedCalls.Should().Be(1, "timeout classifies as failed");
+        fetch.SuccessRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_FilterByToolName_ReturnsOnlyThatTool()
+    {
+        var step = await SeedStepAsync(owner: null);
+        await AddCallAsync(step, "search", ToolCallStatus.Success, 10);
+        await AddCallAsync(step, "fetch", ToolCallStatus.Success, 10);
+
+        var stats = await _toolRepo.GetStatsAsync("search");
+
+        stats.Should().ContainSingle().Which.ToolName.Should().Be("search");
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_EmptyStore_ReturnsEmpty()
+    {
+        var stats = await _toolRepo.GetStatsAsync();
+        stats.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_OwnerScoped_ExcludesOtherOwnersToolCalls()
+    {
+        var aliceStep = await SeedStepAsync(owner: "alice");
+        var bobStep = await SeedStepAsync(owner: "bob");
+        await AddCallAsync(aliceStep, "search", ToolCallStatus.Success, 10);
+        await AddCallAsync(bobStep, "search", ToolCallStatus.Success, 10);
+
+        var stats = await _toolRepo.GetStatsAsync("search", MemoryScope.For("alice"));
+
+        stats.Should().ContainSingle();
+        stats[0].TotalCalls.Should().Be(1, "bob's tool call is out of alice's scope (owner lives on the trace)");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
@@ -18,7 +18,7 @@ public sealed class AbstractionsContractGuardTests
     // Counts mirrored in docs/architecture.md §3.1 and docs/design.md §5/§6.
     private const int DocumentedServiceInterfaces = 38; // R1b store + IC8 owner contexts, +IConsolidationService (PR#113), +IConflictDetectionService, +IMemoryRankingContext/+IWritable (D3)
     private const int DocumentedRepositoryInterfaces = 11;
-    private const int DocumentedDomainRecords = 47;
+    private const int DocumentedDomainRecords = 48; // +ToolCallStats (PR2 — IToolCallRepository.GetStatsAsync)
     private const int DocumentedEnums = 13; // +MemoryProfile (D1/D2 ranking tier), +RankingIntent (D3 query intent)
 
     private static IEnumerable<Type> PublicTypes() =>

--- a/tools/AgentMemory.TckBridge/Program.cs
+++ b/tools/AgentMemory.TckBridge/Program.cs
@@ -605,7 +605,6 @@ app.MapPost("/get_trace_with_steps", async (
 app.MapPost("/list_traces", async (
     ListTracesRequest req,
     IReasoningMemoryService reasoning,
-    INeo4jSessionFactory sessionFactory,
     CancellationToken ct) =>
 {
     var limit = req.Limit ?? 100;
@@ -616,59 +615,27 @@ app.MapPost("/list_traces", async (
     }
     else
     {
-        // Judgment call (openQuestions): neither IReasoningMemoryService.ListTracesAsync nor
-        // IReasoningTraceRepository can list traces across every session — both require a session_id — yet
-        // SPEC-4.6.1 (list_traces with no session_id) requires exactly "all traces, any session". Read-only
-        // raw Cypher against the same ReasoningTrace schema Neo4jReasoningTraceRepository maintains, mirroring
-        // BridgeAdmin's own "no high-level service for X, so run raw Cypher" precedent — filtered to the
-        // shared/global bucket (owner_id IS NULL) to match this bridge's owner-agnostic design (see
-        // /clear_session's comment), so this fallback can never surface another owner's private trace.
-        await using var session = sessionFactory.OpenSession(AccessMode.Read);
-        var cursor = await session.RunAsync(
-            "MATCH (t:ReasoningTrace) WHERE t.owner_id IS NULL RETURN t ORDER BY t.started_at DESC LIMIT $limit",
-            new { limit }).ConfigureAwait(false);
-        var records = await cursor.ToListAsync(ct).ConfigureAwait(false);
-        traces = records.Select(r => MapTraceNode(r["t"].As<INode>())).ToList();
+        // SPEC-4.6.1: list_traces with no session_id returns all traces across sessions. Served by the
+        // first-class IReasoningMemoryService.ListAllTracesAsync (which replaced the earlier raw-Cypher
+        // fallback), scoped to this bridge's shared sentinel bucket so it can never surface another owner's
+        // private trace.
+        var page = await reasoning.ListAllTracesAsync(scope: sharedScope, limit: limit, cancellationToken: ct).ConfigureAwait(false);
+        traces = page.Items;
     }
     return Results.Ok(traces.Select(t => ToTraceDto(t, Array.Empty<TckReasoningStep>())).ToList());
 });
 
 app.MapPost("/get_tool_stats", async (
     GetToolStatsRequest req,
-    INeo4jSessionFactory sessionFactory,
+    IToolCallRepository toolCallRepo,
     CancellationToken ct) =>
 {
-    // No IToolCallRepository/service exposes tool-usage aggregates, so this is read-only raw Cypher
-    // (mirroring BridgeAdmin's "no high-level service for X" precedent). We deliberately do NOT read the
-    // global (:Tool) aggregate node — it accumulates across ALL owners and carries no owner_id, so on a
-    // multi-owner store it would leak cross-owner usage stats. Instead we aggregate ToolCall nodes reached
-    // only through shared-bucket traces (owner_id IS NULL), keeping the bridge owner-agnostic and consistent
-    // with /list_traces. Success/failure classification matches ToolCallQueries.UpsertToolInstance
-    // (failed = error/failure/timeout).
-    await using var session = sessionFactory.OpenSession(AccessMode.Read);
-    var cursor = await session.RunAsync(
-        "MATCH (t:ReasoningTrace)-[:HAS_STEP]->(:ReasoningStep)-[:USES_TOOL]->(tc:ToolCall) " +
-        "WHERE t.owner_id IS NULL AND ($toolName IS NULL OR tc.tool_name = $toolName) " +
-        "WITH tc.tool_name AS name, count(tc) AS total_calls, " +
-        "sum(CASE WHEN tc.status = 'success' THEN 1 ELSE 0 END) AS successful_calls, " +
-        "sum(CASE WHEN tc.status IN ['error', 'failure', 'timeout'] THEN 1 ELSE 0 END) AS failed_calls, " +
-        "sum(coalesce(tc.duration_ms, 0)) AS total_duration_ms " +
-        "RETURN name, total_calls, successful_calls, failed_calls, total_duration_ms ORDER BY name",
-        new { toolName = (object?)req.ToolName }).ConfigureAwait(false);
-    var records = await cursor.ToListAsync(ct).ConfigureAwait(false);
-    var stats = records.Select(r =>
-    {
-        var totalCalls = checked((int)r["total_calls"].As<long>());
-        var totalDurationMs = r["total_duration_ms"].As<long?>() ?? 0;
-        return new TckToolStats(
-            r["name"].As<string>(),
-            totalCalls,
-            checked((int)r["successful_calls"].As<long>()),
-            checked((int)r["failed_calls"].As<long>()),
-            totalCalls > 0 ? (double)r["successful_calls"].As<long>() / totalCalls : 0.0,
-            totalCalls > 0 ? (double)totalDurationMs / totalCalls : null);
-    }).ToList();
-    return Results.Ok(stats);
+    // Served by the first-class IToolCallRepository.GetStatsAsync (which replaced the earlier raw-Cypher
+    // fallback), scoped to this bridge's shared sentinel bucket. The repository query deliberately avoids the
+    // global (:Tool) aggregate node (which spans all owners) and classifies success/failure the same way.
+    var stats = await toolCallRepo.GetStatsAsync(req.ToolName, sharedScope, ct).ConfigureAwait(false);
+    return Results.Ok(stats.Select(s => new TckToolStats(
+        s.ToolName, s.TotalCalls, s.SuccessfulCalls, s.FailedCalls, s.SuccessRate, s.AvgDurationMs)).ToList());
 });
 
 // get_similar_traces (Gold tier): find reasoning traces whose task is semantically similar to a query task.
@@ -752,41 +719,6 @@ static JsonElement? ParseJsonOrNull(string? json)
     using var doc = JsonDocument.Parse(json);
     return doc.RootElement.Clone();
 }
-
-// Duplicates AgentMemory.Neo4j.Infrastructure.Neo4jDateTimeHelper's tiny conversion logic: that helper is
-// `internal` to AgentMemory.Neo4j (no InternalsVisibleTo for this bridge project), and is only needed here
-// for the /list_traces "no session_id" raw-Cypher fallback (see MapTraceNode below).
-static DateTimeOffset ReadTraceDateTimeOffset(object? value) => value switch
-{
-    ZonedDateTime zdt => zdt.ToDateTimeOffset(),
-    string s => DateTimeOffset.Parse(s, null, System.Globalization.DateTimeStyles.RoundtripKind),
-    // This is only reached for started_at (a required trace property); completed_at's legitimate null is
-    // handled by ReadTraceNullableDateTimeOffset before it gets here. A null started_at is corrupt data /
-    // a schema mismatch — fail loudly rather than fabricating a plausible, nondeterministic "now".
-    null => throw new InvalidOperationException("ReasoningTrace.started_at is null — a trace must have a start time"),
-    _ => throw new InvalidOperationException($"Unexpected datetime type: {value.GetType()}")
-};
-
-static DateTimeOffset? ReadTraceNullableDateTimeOffset(object? value) =>
-    value is null ? null : ReadTraceDateTimeOffset(value);
-
-// Maps a raw :ReasoningTrace node (from the /list_traces "all sessions" fallback query) the same way
-// Neo4jReasoningTraceRepository.MapToTrace does, minus TaskEmbedding/Metadata/OwnerId (not needed on the
-// TckReasoningTrace wire DTO, which only ever sets Steps to an empty list for /list_traces).
-static ReasoningTrace MapTraceNode(INode node) => new()
-{
-    TraceId = node["id"].As<string>(),
-    SessionId = node["session_id"].As<string>(),
-    Task = node["task"].As<string>(),
-    Outcome = node.Properties.TryGetValue("outcome", out var outcome) ? outcome.As<string>() : null,
-    Success = node.Properties.TryGetValue("success", out var success) && success is not null
-        ? success.As<bool?>()
-        : null,
-    StartedAtUtc = ReadTraceDateTimeOffset(node["started_at"]),
-    CompletedAtUtc = node.Properties.TryGetValue("completed_at", out var completedAt)
-        ? ReadTraceNullableDateTimeOffset(completedAt)
-        : null,
-};
 
 // Mirrors the single-string embedding call shape used by AgentMemory.Core.Services.EmbeddingOrchestrator
 // (GenerateAsync with a one-element input, then unwrap the sole result's vector) so the bridge's embedding


### PR DESCRIPTION
## Summary

Second of the pre-1.0 API-surface PRs (after #75's internalization sweep). Adds the two reasoning-tier reader methods the audit recommended landing **before** the SemVer freeze — extending a public interface after `1.0` breaks every third-party implementer — and gives `MergeEntitiesAsync` a return value. As a bonus, these let the upstream-TCK bridge drop its **last two raw-Cypher fallbacks**.

## Interface additions

- **`IReasoningMemoryService.ListAllTracesAsync(scope?, limit, offset)` → `PagedResult<ReasoningTrace>`** (newest-first, N+1 `HasNextPage`, owner-scoped R1), mirrored on `IReasoningTraceRepository.ListAllAsync`. There was no first-class cross-session trace listing (only per-session `ListTracesAsync`), which forced the bridge's raw-Cypher `list_traces` fallback.
- **`IToolCallRepository.GetStatsAsync(toolName?, scope?)` → `IReadOnlyList<ToolCallStats>`** (new domain record: `TotalCalls`/`SuccessfulCalls`/`FailedCalls`/`SuccessRate`/`AvgDurationMs?`). Aggregates tool calls reached through **owner-scoped** reasoning traces; deliberately never reads the cross-owner global `:Tool` node. Replaces the bridge's raw-Cypher `get_tool_stats` fallback.

## Signature change

- **`IEntityRepository.MergeEntitiesAsync`: `Task` → `Task<bool>`** — `true` when the merge matched and ran, `false` for a guarded / non-existent no-op. Future-proofs the deferred merge-relationship-transfer fix (it can report edges moved without another signature break). The Neo4j impl already computed this bool internally since Gold; it now returns it.

## Bridge

`list_traces` (no session) and `get_tool_stats` now call the new services instead of raw Cypher; removed the now-dead `MapTraceNode` / trace-datetime helpers. (`INeo4jSessionFactory` remains for `/setup`'s vector-index readiness poll.)

## Tests

- **+4** `GetStatsAsync` integration (aggregation w/ success-rate + avg-duration, tool-name filter, empty store, owner scoping) — new `ToolCallStatsIntegrationTests`.
- **+3** `ListAllAsync` integration (cross-session newest-first, paging/`HasNextPage` + offset, owner scoping).
- **+1** positive `MergeEntitiesAsync` (returns `true`, absorbs source name); strengthened the foreign-owner test to assert `false`.
- Domain-record guard count 47 → 48 (`+ToolCallStats`); `docs/architecture.md` + `docs/design.md` catalogs updated.

## Verified

| Check | Result |
|---|---|
| Release build | 0 warnings / 0 errors |
| Full unit suite | 2705 / 2705 |
| Full integration suite (Testcontainers) | 261 / 261 |
| TCK Bronze+Silver+Gold (live Neo4j 5.26) | 178 / 178 |

## Next in the 1.0 series

PR3 correctness/honesty (the `ContextCompressor`/`BackgroundEnrichmentQueue`/Diffbot DI-wiring bugs, `AddMessageAsync` fabrication, `UpdateAsync?`, facade owner-scoping) · PR4 naming/enum/`ct` freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsi9nT4PG1BBrvLBq3XZma
