### PR TITLE
1.0 API surface (3/4): correctness & contract-honesty pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP `memory_get_observations` could not resolve at runtime.** `IContextCompressor` was injected into the MCP observation tool but registered by no `AddX`. It is now bound in `AddAgentMemoryCore`, and `ContextCompressor`'s `IChatClient` dependency is optional — with no LLM registered it degrades to a verbatim passthrough, so the binding is always safe to resolve (it does not break LLM-less consumers under `ValidateOnBuild`).
+- **The Agent Framework chat-message store no longer fabricates a fake success on a failed write.** `Neo4jChatMessageStore.AddMessageAsync` previously caught any persist error and returned a plausible-looking `Message`, silently hiding data loss and letting the extraction step run over messages that were never stored. It now surfaces the failure (the facade's `PersistAfterRunAsync` catches and logs it at the run boundary).
+- **`Neo4jMicrosoftMemoryFacade.GetContextForRunAsync` now owner-scopes recall.** The read path never set `RecallRequest.UserId` while the write path took a `userId`; a new optional `userId` parameter threads owner scope into recall so a multi-tenant host does not recall across owners.
+- **`IToolCallRepository.UpdateAsync` no longer throws on a concurrently-removed tool call.** A session clear / trace prune between a read and the update yields no row; it now returns `null` (see Changed) instead of a sequence-empty exception.
+- **`GdsAnalyticsOptions.DefaultTopN` is validated (> 0) on start**, and `MemoryPageRankService.RankEntitiesAsync` rejects a non-positive `topN` — a non-positive value previously flowed unchecked into a Neo4j `LIMIT`.
+
 ### Added
 
 - **`IReasoningMemoryService.ListAllTracesAsync` — owner-scoped, paged, cross-session trace listing.** Returns a `PagedResult<ReasoningTrace>` (newest-first, N+1 `HasNextPage`, `offset`-advanced), optionally owner-scoped (R1). Mirrored on `IReasoningTraceRepository.ListAllAsync`. Added pre-`1.0` because extending a public interface after the freeze breaks every third-party implementer.
@@ -14,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`IToolCallRepository.UpdateAsync` now returns `Task<ToolCall?>`** (was `Task<ToolCall>`): `null` when no tool call with that id exists (concurrent clear/prune), matching `IReasoningTraceRepository.UpdateAsync`.
+- **`AgentTraceRecorder.StartTraceAsync` parameter order is now `(sessionId, task, …)`** (was `(task, sessionId, …)`), matching `IReasoningMemoryService.StartTraceAsync` — the two strings were easy to transpose.
+- **`Message.ToolCallIds` is now a non-nullable `IReadOnlyList<string>` defaulting to empty** (was a nullable, undefaulted collection), matching the record's other collection members.
+- **`LlmExtractionOptions.ModelId` is now `string?` defaulting to `null`** (was an empty-string sentinel); behavior is unchanged (the guard already treated null and empty identically as "use the `IChatClient` default").
 - **`IEntityRepository.MergeEntitiesAsync` now returns `Task<bool>`** (was `Task`): `true` when the merge matched and ran, `false` for a guarded / non-existent no-op. Future-proofs the deferred merge-relationship-transfer fix (it can report edges moved without another signature break).
 - **1.0 API-surface lockdown — implementation types internalized.** Concrete implementation classes that are only ever resolved through the public Abstractions interfaces (the memory/reasoning services, Neo4j repositories/services/query holders/infrastructure, MCP tools/resources/prompts, extraction providers, enrichment decorators, GDS analytics services, merge strategies, and stubs) are now `internal`, shrinking the public surface from ~331 to ~203 types ahead of the SemVer-stable `1.0`. Accessibility-only: no behavior, signature, or DI-wiring change — DI resolves the internal types (via their still-public constructors) unchanged. The public contract is the Abstractions interfaces/records/options/enums, each package's `ServiceCollectionExtensions` + options, the Microsoft Agent Framework and Semantic Kernel adapters, and a small set of deliberate seams (`INeo4jTransactionRunner`, `ISchemaBootstrapper`, `IMigrationRunner`, `MemoryActivitySource`, `MemoryMetrics.MeterName`, the stub/clock/id helpers, `ExtractorBase`).
 - **`SchemaConstants` and the schema-parity kit are now internal.** `SchemaConstants` (raw Neo4j backend label/property/edge strings) and the parity types (`SchemaParityVerifier`, `SchemaDescriptor`, `SchemaParityPolicy`, `SchemaParityReport`, `UpstreamSchemaRegistry`, `DotNetSchema`) — previously described as a reusable library component in `AgentMemory.Neo4j.Schema.Parity` — are implementation details for `1.0`. Schema-parity verification remains available through the `agentmemory schema-parity` CLI command; it is no longer a library API.

--- a/src/AgentMemory.Abstractions/Domain/ShortTerm/Message.cs
+++ b/src/AgentMemory.Abstractions/Domain/ShortTerm/Message.cs
@@ -41,9 +41,10 @@ public sealed record Message
     public float[]? Embedding { get; init; }
 
     /// <summary>
-    /// Optional tool call identifiers if this message involved tool usage.
+    /// Tool call identifiers if this message involved tool usage; empty when none (never null), matching the
+    /// other collection members on this record.
     /// </summary>
-    public IReadOnlyList<string>? ToolCallIds { get; init; }
+    public IReadOnlyList<string> ToolCallIds { get; init; } = [];
 
     /// <summary>
     /// Additional metadata for the message.

--- a/src/AgentMemory.Abstractions/Repositories/IToolCallRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IToolCallRepository.cs
@@ -15,8 +15,13 @@ public interface IToolCallRepository
     /// <summary>Adds a tool call.</summary>
     Task<ToolCall> AddAsync(ToolCall toolCall, CancellationToken cancellationToken = default);
 
-    /// <summary>Updates a tool call.</summary>
-    Task<ToolCall> UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Updates a tool call. Returns <c>null</c> if no tool call with the given id exists — e.g. it was
+    /// concurrently removed (a session clear / trace prune) between a read and this write — so callers get a
+    /// clean "not found" rather than a sequence-empty exception (the same contract as
+    /// <see cref="IReasoningTraceRepository.UpdateAsync"/>).
+    /// </summary>
+    Task<ToolCall?> UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken = default);
 
     /// <summary>Gets tool calls for a step.</summary>
     Task<IReadOnlyList<ToolCall>> GetByStepAsync(string stepId, CancellationToken cancellationToken = default);

--- a/src/AgentMemory.AgentFramework/AgentTraceRecorder.cs
+++ b/src/AgentMemory.AgentFramework/AgentTraceRecorder.cs
@@ -49,13 +49,16 @@ public sealed class AgentTraceRecorder
     }
 
     /// <summary>Starts a new reasoning trace for an agent run.</summary>
-    /// <param name="task">Human-readable description of the task the agent is performing.</param>
     /// <param name="sessionId">Session identifier that scopes this trace to a conversation.</param>
+    /// <param name="task">Human-readable description of the task the agent is performing.</param>
+    /// <param name="ownerId">Optional owner id that scopes the trace to a user (R1).</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>The created <see cref="ReasoningTrace"/> with its assigned <c>TraceId</c>.</returns>
+    // Parameter order is (sessionId, task) to match IReasoningMemoryService.StartTraceAsync — the two strings
+    // are easy to transpose, and a mismatch here would silently tag traces with the task as the session.
     public async Task<ReasoningTrace> StartTraceAsync(
-        string task,
         string sessionId,
+        string task,
         string? ownerId = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
@@ -50,16 +50,11 @@ public sealed class Neo4jChatMessageStore
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to add message for session {SessionId}.", sessionId);
-            return new Message
-            {
-                MessageId = _idGenerator.GenerateId(),
-                SessionId = sessionId,
-                ConversationId = conversationId,
-                Role = MafTypeMapper.ToInternalRole(chatMessage.Role),
-                Content = chatMessage.Text ?? string.Empty,
-                TimestampUtc = _clock.UtcNow
-            };
+            // Do NOT fabricate a success Message on failure — that silently hides data loss from the caller
+            // and would let PersistAfterRun's extraction step run over messages that were never stored.
+            // Surface the failure; the facade's PersistAfterRunAsync catches and logs it at the run boundary.
+            _logger.LogError(ex, "Failed to add message for session {SessionId}.", sessionId);
+            throw;
         }
     }
 

--- a/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
@@ -52,8 +52,9 @@ public sealed class Neo4jChatMessageStore
         {
             // Do NOT fabricate a success Message on failure — that silently hides data loss from the caller
             // and would let PersistAfterRun's extraction step run over messages that were never stored.
-            // Surface the failure; the facade's PersistAfterRunAsync catches and logs it at the run boundary.
-            _logger.LogError(ex, "Failed to add message for session {SessionId}.", sessionId);
+            // Surface the failure by rethrowing; the caller decides how to log it (the facade's
+            // PersistAfterRunAsync logs it at the run boundary). Debug-level here to avoid a duplicate entry.
+            _logger.LogDebug(ex, "Failed to add message for session {SessionId}; rethrowing.", sessionId);
             throw;
         }
     }

--- a/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
@@ -40,6 +40,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
         IReadOnlyList<ChatMessage> messages,
         string sessionId,
         string conversationId,
+        string? userId = null,
         CancellationToken ct = default)
     {
         try
@@ -53,8 +54,10 @@ public sealed class Neo4jMicrosoftMemoryFacade
             if (string.IsNullOrWhiteSpace(queryText))
                 return await _messageStore.GetMessagesAsync(sessionId, ct: ct).ConfigureAwait(false);
 
+            // Owner-scope the recall (R1): the write path (PersistAfterRunAsync / StoreMessageAsync) takes a
+            // userId, so the read path must too — otherwise a multi-tenant host would recall across owners.
             var recall = await _memoryService
-                .RecallAsync(new RecallRequest { SessionId = sessionId, Query = queryText }, ct)
+                .RecallAsync(new RecallRequest { SessionId = sessionId, Query = queryText, UserId = userId }, ct)
                 .ConfigureAwait(false);
 
             // RecentMessages is newest-first (recall orders DESC); reverse it to chronological

--- a/src/AgentMemory.Analytics/MemoryPageRankService.cs
+++ b/src/AgentMemory.Analytics/MemoryPageRankService.cs
@@ -29,6 +29,9 @@ internal sealed class MemoryPageRankService : IMemoryPageRankService
     public async Task<IReadOnlyList<EntityRank>> RankEntitiesAsync(
         int? topN = null, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
+        if (topN is not null)
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topN.Value, nameof(topN));
+
         if (!await _gds.IsAvailableAsync(cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("PageRank skipped — Neo4j GDS plugin not installed; returning no ranks.");

--- a/src/AgentMemory.Analytics/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Analytics/ServiceCollectionExtensions.cs
@@ -15,10 +15,14 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddGdsMemoryAnalytics(
         this IServiceCollection services, Action<GdsAnalyticsOptions>? configure = null)
     {
+        var optionsBuilder = services.AddOptions<GdsAnalyticsOptions>();
         if (configure is not null)
-            services.Configure(configure);
-        else
-            services.AddOptions<GdsAnalyticsOptions>();
+            optionsBuilder.Configure(configure);
+        // A non-positive DefaultTopN flows straight into a Neo4j LIMIT and errors at query time; fail fast at
+        // startup instead (per-call topN is guarded separately in MemoryPageRankService.RankEntitiesAsync).
+        optionsBuilder
+            .Validate(o => o.DefaultTopN > 0, "GdsAnalyticsOptions.DefaultTopN must be greater than 0.")
+            .ValidateOnStart();
 
         services.TryAddScoped<IGdsAvailability, GdsAvailability>();
         services.TryAddScoped<IMemoryPageRankService, MemoryPageRankService>();

--- a/src/AgentMemory.Core/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Core/ServiceCollectionExtensions.cs
@@ -93,6 +93,12 @@ public static class ServiceCollectionExtensions
             truncationStrategies: sp.GetServices<ITruncationStrategy>()));
         services.TryAddScoped<IMemoryService, MemoryService>();
 
+        // Context compressor (reflection/observation summarization). It uses an IChatClient when one is
+        // registered and degrades to a verbatim passthrough when not, so this binding is always safe to
+        // resolve. Without it, IContextCompressor consumers — e.g. the MCP memory-observations tool — fail
+        // to resolve at runtime (it was previously injected but registered by no AddX).
+        services.TryAddScoped<IContextCompressor, ContextCompressor>();
+
         // Role interfaces (ISP): bind each to the same scoped IMemoryService instance so consumers
         // can depend on a narrow contract (recall / ingestion / maintenance) without a second object.
         services.TryAddScoped<IMemoryRecall>(sp => sp.GetRequiredService<IMemoryService>());

--- a/src/AgentMemory.Core/Services/ContextCompressor.cs
+++ b/src/AgentMemory.Core/Services/ContextCompressor.cs
@@ -14,20 +14,22 @@ internal sealed class ContextCompressor : IContextCompressor
 {
     private const int CharsPerToken = 4;
 
-    private readonly IChatClient _chatClient;
+    private readonly IChatClient? _chatClient;
     private readonly ILogger<ContextCompressor> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContextCompressor"/> class.
     /// </summary>
-    /// <param name="chatClient">The chat client used to generate observation summaries and reflections.</param>
     /// <param name="logger">The logger used to record compression diagnostics.</param>
+    /// <param name="chatClient">The chat client used to generate observation summaries and reflections.
+    /// Optional: when no <see cref="IChatClient"/> is registered, compression degrades to a passthrough
+    /// (messages are kept verbatim), so the compressor can be resolved in deployments without an LLM.</param>
     public ContextCompressor(
-        IChatClient chatClient,
-        ILogger<ContextCompressor> logger)
+        ILogger<ContextCompressor> logger,
+        IChatClient? chatClient = null)
     {
-        _chatClient = chatClient;
         _logger = logger;
+        _chatClient = chatClient;
     }
 
     /// <inheritdoc/>
@@ -54,6 +56,23 @@ internal sealed class ContextCompressor : IContextCompressor
 
         if (originalTokenCount <= options.TokenThreshold)
         {
+            return new CompressedContext
+            {
+                RecentMessages = messages,
+                WasCompressed = false,
+                OriginalTokenCount = originalTokenCount,
+                CompressedTokenCount = originalTokenCount
+            };
+        }
+
+        // No LLM available: keep everything verbatim rather than failing. Compression (observation/reflection
+        // summarization) is inherently LLM-backed, so without an IChatClient the honest behavior is a
+        // passthrough — the caller still gets a usable (uncompressed) context.
+        if (_chatClient is null)
+        {
+            _logger.LogDebug(
+                "Context compression skipped: {Tokens} tokens exceeds threshold {Threshold}, but no IChatClient is registered.",
+                originalTokenCount, options.TokenThreshold);
             return new CompressedContext
             {
                 RecentMessages = messages,
@@ -140,7 +159,8 @@ internal sealed class ContextCompressor : IContextCompressor
                 new(ChatRole.User, conversationText)
             };
 
-            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
+            // Non-null here: these summarization helpers run only after CompressAsync's null-IChatClient guard.
+            var response = await _chatClient!.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Text?.Trim() ?? string.Empty;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -171,7 +191,8 @@ internal sealed class ContextCompressor : IContextCompressor
                 new(ChatRole.User, $"Observations:\n{observationText}")
             };
 
-            var response = await _chatClient.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
+            // Non-null here: these summarization helpers run only after CompressAsync's null-IChatClient guard.
+            var response = await _chatClient!.GetResponseAsync(chatMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Text?.Trim() ?? string.Empty;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/AgentMemory.Extraction.Llm/LlmExtractionOptions.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmExtractionOptions.cs
@@ -16,9 +16,9 @@ public sealed class LlmExtractionOptions
     public int MaxRetries { get; set; } = 2;
 
     /// <summary>
-    /// Model identifier to use. Empty string means use the IChatClient default.
+    /// Model identifier to use. <c>null</c> (the default) means use the <c>IChatClient</c> default.
     /// </summary>
-    public string ModelId { get; set; } = "";
+    public string? ModelId { get; set; }
 
     /// <summary>
     /// POLE+O entity types recognised by the entity extractor.

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
@@ -292,7 +292,7 @@ internal sealed class Neo4jMessageRepository : IMessageRepository
             Embedding      = embedding,
             ToolCallIds    = node.Properties.TryGetValue("tool_call_ids", out var tc)
                                 ? tc.As<IList<object>>().Select(v => v.ToString()!).ToList()
-                                : null,
+                                : [],
             Metadata       = DeserializeMetadata(node.Properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
         };
 

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jToolCallRepository.cs
@@ -43,7 +43,7 @@ internal sealed class Neo4jToolCallRepository : IToolCallRepository
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<ToolCall> UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken = default)
+    public async Task<ToolCall?> UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Updating tool call {Id}", toolCall.ToolCallId);
 
@@ -51,8 +51,11 @@ internal sealed class Neo4jToolCallRepository : IToolCallRepository
         {
             var parameters = BuildToolCallParameters(toolCall);
             var cursor = await runner.RunAsync(ToolCallQueries.Update, parameters).ConfigureAwait(false);
-            var record = await cursor.SingleAsync().ConfigureAwait(false);
-            return MapToToolCall(record["tc"].As<INode>());
+            // The Update Cypher is MATCH ... RETURN, so a concurrently-cleared grandchild (a session clear /
+            // trace prune between a read and this write) yields no row. Return null instead of throwing a
+            // sequence-empty exception — the same clean not-found contract as IReasoningTraceRepository.UpdateAsync.
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            return records.Count > 0 ? MapToToolCall(records[0]["tc"].As<INode>()) : null;
         }, cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/AgentMemory.Tests.Integration/Repositories/ToolCallStatsIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/ToolCallStatsIntegrationTests.cs
@@ -100,6 +100,23 @@ public class ToolCallStatsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpdateAsync_NonexistentToolCall_ReturnsNull_DoesNotThrow()
+    {
+        // The Update Cypher is MATCH ... RETURN; a concurrently-removed grandchild (session clear / trace
+        // prune between a read and this write) must return null, not throw a sequence-empty exception.
+        var result = await _toolRepo.UpdateAsync(new ToolCall
+        {
+            ToolCallId = $"tc-{Guid.NewGuid():N}",
+            StepId = $"step-{Guid.NewGuid():N}",
+            ToolName = "ghost",
+            ArgumentsJson = "{}",
+            Status = ToolCallStatus.Success,
+        });
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetStatsAsync_OwnerScoped_ExcludesOtherOwnersToolCalls()
     {
         var aliceStep = await SeedStepAsync(owner: "alice");

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/AgentTraceRecorderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/AgentTraceRecorderTests.cs
@@ -92,7 +92,7 @@ public sealed class AgentTraceRecorderTests
     {
         var sut = CreateSut(persist: false);
 
-        var trace = await sut.StartTraceAsync("task", "session-1", ownerId: "alice");
+        var trace = await sut.StartTraceAsync("session-1", "task", ownerId: "alice");
         var step = await sut.RecordStepAsync(trace.TraceId, "action", "did x");
         var call = await sut.RecordToolCallAsync(step.StepId, "tool", "{}");
         await sut.CompleteTraceAsync(trace.TraceId, "done");
@@ -121,7 +121,7 @@ public sealed class AgentTraceRecorderTests
     {
         var sut = CreateSut();
 
-        var trace = await sut.StartTraceAsync("summarize document", "session-1");
+        var trace = await sut.StartTraceAsync("session-1", "summarize document");
 
         trace.Task.Should().Be("summarize document");
         trace.SessionId.Should().Be("session-1");
@@ -135,7 +135,7 @@ public sealed class AgentTraceRecorderTests
     public async Task RecordStep_AddsStepToTrace()
     {
         var sut = CreateSut();
-        await sut.StartTraceAsync("task", "session-1");
+        await sut.StartTraceAsync("session-1", "task");
 
         var step = await sut.RecordStepAsync("trace-1", "thought", "I should search for Alice");
 
@@ -167,7 +167,7 @@ public sealed class AgentTraceRecorderTests
     public async Task CompleteTrace_SetsOutcomeAndDuration()
     {
         var sut = CreateSut();
-        await sut.StartTraceAsync("task", "session-1");
+        await sut.StartTraceAsync("session-1", "task");
 
         await sut.CompleteTraceAsync("trace-1", "Task completed successfully");
 
@@ -198,8 +198,8 @@ public sealed class AgentTraceRecorderTests
             });
 
         var sut = CreateSut();
-        var t1 = await sut.StartTraceAsync("task one", "session-1");
-        var t2 = await sut.StartTraceAsync("task two", "session-1");
+        var t1 = await sut.StartTraceAsync("session-1", "task one");
+        var t2 = await sut.StartTraceAsync("session-1", "task two");
 
         t1.TraceId.Should().NotBe(t2.TraceId);
     }
@@ -208,7 +208,7 @@ public sealed class AgentTraceRecorderTests
     public async Task RecordStep_IncrementsStepNumber()
     {
         var sut = CreateSut();
-        await sut.StartTraceAsync("task", "session-1");
+        await sut.StartTraceAsync("session-1", "task");
 
         await sut.RecordStepAsync("trace-1", "thought", "step one");
         await sut.RecordStepAsync("trace-1", "action", "step two");

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
@@ -69,17 +69,18 @@ public sealed class Neo4jChatMessageStoreTests
     }
 
     [Fact]
-    public async Task AddMessageAsync_ServiceThrows_ReturnsFallbackMessage()
+    public async Task AddMessageAsync_ServiceThrows_PropagatesInsteadOfFabricatingSuccess()
     {
+        // A persist failure must surface, not be hidden behind a fabricated "success" Message (which would
+        // also let the facade's extraction step run over messages that were never stored). The facade's
+        // PersistAfterRunAsync catches this at the run boundary.
         _memoryService.AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("DB error"));
 
-        var result = await _sut.AddMessageAsync(new ChatMessage(ChatRole.User, "Hello"), "s1", "c1");
+        var act = async () => await _sut.AddMessageAsync(new ChatMessage(ChatRole.User, "Hello"), "s1", "c1");
 
-        result.Should().NotBeNull();
-        result.Content.Should().Be("Hello");
-        result.Role.Should().Be("user");
+        await act.Should().ThrowAsync<Exception>().WithMessage("DB error");
     }
 
     // ── GetMessagesAsync ───────────────────────────────────────────────────

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
@@ -189,9 +189,32 @@ public sealed class Neo4jMicrosoftMemoryFacadeTests
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         var messages = new List<ChatMessage> { new(ChatRole.User, "find relevant history") };
-        var act = async () => await _sut.GetContextForRunAsync(messages, "s1", "c1", cts.Token);
+        var act = async () => await _sut.GetContextForRunAsync(messages, "s1", "c1", ct: cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetContextForRunAsync_PassesUserId_ToRecallForOwnerScoping()
+    {
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RecallResult
+            {
+                Context = new MemoryContext
+                {
+                    SessionId = "s1",
+                    AssembledAtUtc = _now,
+                    RecentMessages = new MemoryContextSection<Message> { Items = [] },
+                    RelevantMessages = new MemoryContextSection<Message> { Items = [] }
+                }
+            });
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "find relevant history") };
+        await _sut.GetContextForRunAsync(messages, "s1", "c1", userId: "alice");
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r => r.UserId == "alice" && r.SessionId == "s1"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Analytics/GdsAnalyticsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Analytics/GdsAnalyticsTests.cs
@@ -143,4 +143,22 @@ public sealed class GdsAnalyticsTests
         scope.ServiceProvider.GetRequiredService<IMemoryPageRankService>().Should().NotBeNull();
         scope.ServiceProvider.GetRequiredService<IMemoryCommunityService>().Should().NotBeNull();
     }
+
+    // ── RankEntitiesAsync: topN input guard (runs before the GDS-availability probe) ──
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public async Task RankEntitiesAsync_NonPositiveTopN_Throws(int topN)
+    {
+        var sut = new MemoryPageRankService(
+            Substitute.For<INeo4jTransactionRunner>(),
+            Substitute.For<IGdsAvailability>(),
+            Options.Create(new GdsAnalyticsOptions()),
+            NullLogger<MemoryPageRankService>.Instance);
+
+        var act = async () => await sut.RankEntitiesAsync(topN: topN);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Options/ConfigurationValidationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Options/ConfigurationValidationTests.cs
@@ -323,9 +323,9 @@ public sealed class ConfigurationValidationTests
     }
 
     [Fact]
-    public void LlmExtractionOptions_Default_ModelIdIsEmpty()
+    public void LlmExtractionOptions_Default_ModelIdIsNull()
     {
-        new LlmExtractionOptions().ModelId.Should().BeEmpty();
+        new LlmExtractionOptions().ModelId.Should().BeNull();
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
@@ -71,7 +71,7 @@ public sealed class ContextCompressorTests
         var result = await sut.CompressAsync(messages, _defaultOptions);
 
         result.WasCompressed.Should().BeFalse();
-        result.RecentMessages.Should().BeEquivalentTo(messages);
+        result.RecentMessages.Should().Equal(messages, "passthrough keeps the messages verbatim and in order");
         result.Observations.Should().BeEmpty();
         result.Reflections.Should().BeEmpty();
     }

--- a/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ContextCompressorTests.cs
@@ -29,7 +29,7 @@ public sealed class ContextCompressorTests
             .GetResponseAsync(Arg.Any<IList<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
             .Returns(ci => new ChatResponse([new ChatMessage(ChatRole.Assistant, "Summary of conversation.")]));
 
-        _sut = new ContextCompressor(_chatClient, NullLogger<ContextCompressor>.Instance);
+        _sut = new ContextCompressor(NullLogger<ContextCompressor>.Instance, _chatClient);
     }
 
     [Fact]
@@ -56,6 +56,24 @@ public sealed class ContextCompressorTests
         var result = await _sut.CompressAsync(messages, _defaultOptions);
 
         result.WasCompressed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompressAsync_OverThreshold_NoChatClient_DegradesToPassthrough()
+    {
+        // Without an IChatClient there is no way to summarize; the compressor must keep messages verbatim
+        // rather than throw, so it can be resolved in deployments that never registered an LLM.
+        var sut = new ContextCompressor(NullLogger<ContextCompressor>.Instance, chatClient: null);
+        var messages = Enumerable.Range(1, 6)
+            .Select(i => CreateMessage($"m{i}", new string('x', 100)))
+            .ToArray();
+
+        var result = await sut.CompressAsync(messages, _defaultOptions);
+
+        result.WasCompressed.Should().BeFalse();
+        result.RecentMessages.Should().BeEquivalentTo(messages);
+        result.Observations.Should().BeEmpty();
+        result.Reflections.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Third of the pre-1.0 API-surface PRs. Fixes the genuine **runtime/honesty bugs** the audit surfaced, plus the small breaking-shape cleanups that must land before the freeze. Unlike PR1/PR2 (surface shape), this one fixes behavior.

## Bug fixes

- **MCP `memory_get_observations` couldn't resolve at runtime.** `IContextCompressor` was injected into the observation tool but registered by no `AddX`. Now bound in `AddAgentMemoryCore`, and `ContextCompressor`'s `IChatClient` dependency is **optional** — with no LLM it degrades to a verbatim passthrough, so the binding is always safe under `ValidateOnBuild` (which is exactly what caught it: the TCK bridge, which has no `IChatClient`, failed to start when the binding was unconditional).
- **`Neo4jChatMessageStore.AddMessageAsync` no longer fabricates a fake success on a failed write.** It previously caught any persist error and returned a plausible `Message`, silently hiding data loss *and* letting the extraction step run over messages that were never stored. It now surfaces the failure (the facade's `PersistAfterRunAsync` catches and logs it at the run boundary).
- **`Neo4jMicrosoftMemoryFacade.GetContextForRunAsync` now owner-scopes recall.** The read path never set `RecallRequest.UserId` while the write path took a `userId`; a new optional `userId` param threads owner scope in — strengthens R1 isolation for multi-tenant hosts.
- **`IToolCallRepository.UpdateAsync` no longer throws sequence-empty** when the tool call was concurrently removed (session clear / trace prune) — returns `null` (see Changed).
- **`GdsAnalyticsOptions.DefaultTopN` validated (> 0) on start**; `RankEntitiesAsync` rejects a non-positive `topN` — previously flowed unchecked into a Neo4j `LIMIT`.

## Breaking-shape cleanups (pre-1.0)

- `AgentTraceRecorder.StartTraceAsync` param order → `(sessionId, task, …)` to match `IReasoningMemoryService` (the two strings were easy to transpose → silent mis-tag).
- `Message.ToolCallIds` → non-nullable `IReadOnlyList<string>` defaulting to empty.
- `LlmExtractionOptions.ModelId` → `string?` default `null` (behavior unchanged).
- `IToolCallRepository.UpdateAsync` → `Task<ToolCall?>`.

## Deferred to PR4 (surface/naming — not correctness)

`MemoryTool*` + `CreateTools` deletion; Diffbot behind `IEnrichmentService` (needs keyed DI + decorator); `RecallAsOf` overload collapse; `SearchByVectorAsync` `metadataFilters` → `IReadOnlyDictionary`; `BackgroundEnrichmentQueue` wiring.

## Verified

| Check | Result |
|---|---|
| Release build | 0 warnings / 0 errors |
| Full unit suite | 2707 / 2707 |
| Full integration suite (Testcontainers) | 261 / 261 |
| TCK Bronze+Silver+Gold (live Neo4j 5.26) | 178 / 178 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsi9nT4PG1BBrvLBq3XZma
