### PR TITLE
1.0 API surface (6): MemoryNodeKind enum (replace string nodeLabel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The decay/maintenance `string nodeLabel` parameters are now a closed `MemoryNodeKind` enum** (`Entity`/`Fact`/`Preference`). `IMemoryDecayService.CalculateRetentionScoreAsync`/`UpdateAccessTimestampAsync` and `IMemoryMaintenance.GenerateEmbeddingsBatchAsync` take the enum — an unsupported label is now a compile error, not a runtime `ArgumentException`, which also removes the label-injection surface in the decay Cypher. The MCP `memory_generate_embeddings` tool keeps its wire-level `nodeLabel` string and parses it to the enum (returning a clear error for an unknown value).
 - **`DuplicatePair.Status` and `EntityResolutionResult.MatchType` are now enums** (`DuplicateStatus` and `EntityMatchType`) instead of strings, for compile-time safety.
 - **Collapsed the two `RecallAsOfAsync` overloads (and the two `AssembleContextAsOfAsync` overloads) into one** method with an optional `DateTimeOffset? systemAsOf = null` — omit it for single-clock recall (both clocks equal), pass it for bitemporal. Same behavior; fewer overloads.
 - **`IMessageRepository.SearchByVectorAsync`'s `metadataFilters` parameter is now `IReadOnlyDictionary<string, object>?`** (was `Dictionary<string, object>?`) — a source-only change for implementers, not callers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,7 @@ graph TD
 | **Purpose** | Domain contracts — all models, interfaces, and configuration types shared across the system |
 | **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.5.1 (approved, D-AR2-1) — .NET 9 BCL otherwise |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK, any MCP SDK, any NuGet package **except** Microsoft.Extensions.AI.Abstractions |
-| **Key types** | 48 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, etc.), 38 service interfaces, 11 repository interfaces, 15 configuration types (incl. `MemoryRankingOptions`), 15 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
+| **Key types** | 48 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, etc.), 38 service interfaces, 11 repository interfaces, 15 configuration types (incl. `MemoryRankingOptions`), 16 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`, `MemoryNodeKind`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
 
 **Namespace structure:**
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,7 +10,7 @@
 
 ## 1. Domain Model Overview
 
-The domain model comprises **48 domain records** (plus 15 enums) organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, ranking, conflict detection, consolidation, and configuration. All domain types are defined in `AgentMemory.Abstractions`. (Counts are enforced by `AbstractionsContractGuardTests`.)
+The domain model comprises **48 domain records** (plus 16 enums) organized across three memory layers, plus supporting types for context assembly, extraction, GraphRAG integration, ranking, conflict detection, consolidation, and configuration. All domain types are defined in `AgentMemory.Abstractions`. (Counts are enforced by `AbstractionsContractGuardTests`.)
 
 ### Key Design Decisions
 

--- a/src/AgentMemory.Abstractions/Domain/MemoryNodeKind.cs
+++ b/src/AgentMemory.Abstractions/Domain/MemoryNodeKind.cs
@@ -1,0 +1,18 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>
+/// The kind of long-term memory node a decay/maintenance operation targets. The enum name matches the
+/// Neo4j node label exactly (<c>Entity</c>/<c>Fact</c>/<c>Preference</c>). Replaces the earlier free-form
+/// <c>string nodeLabel</c> parameters with a closed set — invalid labels are now a compile error.
+/// </summary>
+public enum MemoryNodeKind
+{
+    /// <summary>An <c>:Entity</c> node.</summary>
+    Entity = 0,
+
+    /// <summary>A <c>:Fact</c> node.</summary>
+    Fact = 1,
+
+    /// <summary>A <c>:Preference</c> node.</summary>
+    Preference = 2
+}

--- a/src/AgentMemory.Abstractions/Services/IMemoryDecayService.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryDecayService.cs
@@ -1,3 +1,4 @@
+using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 
 namespace AgentMemory.Abstractions.Services;
@@ -20,13 +21,13 @@ public interface IMemoryDecayService
     /// Calculates the retention score for a single memory node.
     /// </summary>
     /// <param name="nodeId">The id property of the node.</param>
-    /// <param name="nodeLabel">The Neo4j label (Entity, Fact, or Preference).</param>
+    /// <param name="nodeKind">The kind of memory node (Entity, Fact, or Preference).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Computed retention score in [0, ∞).</returns>
-    Task<double> CalculateRetentionScoreAsync(string nodeId, string nodeLabel, CancellationToken cancellationToken = default);
+    Task<double> CalculateRetentionScoreAsync(string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Bumps <c>last_accessed_at</c> and increments <c>access_count</c> on a memory node.
     /// </summary>
-    Task UpdateAccessTimestampAsync(string nodeId, string nodeLabel, CancellationToken cancellationToken = default);
+    Task UpdateAccessTimestampAsync(string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IMemoryDecayService.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryDecayService.cs
@@ -29,5 +29,8 @@ public interface IMemoryDecayService
     /// <summary>
     /// Bumps <c>last_accessed_at</c> and increments <c>access_count</c> on a memory node.
     /// </summary>
+    /// <param name="nodeId">The id property of the node.</param>
+    /// <param name="nodeKind">The kind of memory node (Entity, Fact, or Preference).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task UpdateAccessTimestampAsync(string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
@@ -20,9 +20,11 @@ public interface IMemoryMaintenance
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Generates and persists embeddings for all nodes of the given label that
+    /// Generates and persists embeddings for all nodes of the given <paramref name="nodeKind"/> that
     /// currently have a null embedding. Processes in batches of <paramref name="batchSize"/>.
     /// </summary>
+    /// <param name="nodeKind">The kind of memory node to backfill (Entity, Fact, or Preference).</param>
+    /// <param name="batchSize">Number of nodes to process per batch.</param>
     /// <returns>
     /// The number of nodes actually updated — i.e. for which a non-empty embedding was generated and
     /// persisted. Nodes whose embedding generation degraded to an empty vector (and were therefore skipped)

--- a/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
@@ -1,3 +1,5 @@
+using AgentMemory.Abstractions.Domain;
+
 namespace AgentMemory.Abstractions.Services;
 
 /// <summary>
@@ -20,7 +22,6 @@ public interface IMemoryMaintenance
     /// <summary>
     /// Generates and persists embeddings for all nodes of the given label that
     /// currently have a null embedding. Processes in batches of <paramref name="batchSize"/>.
-    /// Supported labels: <c>Entity</c>, <c>Fact</c>, <c>Preference</c>.
     /// </summary>
     /// <returns>
     /// The number of nodes actually updated — i.e. for which a non-empty embedding was generated and
@@ -28,7 +29,7 @@ public interface IMemoryMaintenance
     /// are not counted.
     /// </returns>
     Task<int> GenerateEmbeddingsBatchAsync(
-        string nodeLabel,
+        MemoryNodeKind nodeKind,
         int batchSize = 100,
         CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryMaintenance.cs
@@ -25,6 +25,7 @@ public interface IMemoryMaintenance
     /// </summary>
     /// <param name="nodeKind">The kind of memory node to backfill (Entity, Fact, or Preference).</param>
     /// <param name="batchSize">Number of nodes to process per batch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// The number of nodes actually updated — i.e. for which a non-empty embedding was generated and
     /// persisted. Nodes whose embedding generation degraded to an empty vector (and were therefore skipped)

--- a/src/AgentMemory.Core/Services/MemoryDecayService.cs
+++ b/src/AgentMemory.Core/Services/MemoryDecayService.cs
@@ -68,6 +68,8 @@ internal sealed class MemoryDecayService : IMemoryDecayService
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        if (!Enum.IsDefined(nodeKind))
+            throw new ArgumentOutOfRangeException(nameof(nodeKind), nodeKind, "Unknown MemoryNodeKind.");
 
         // This is a pure computation—in the real Neo4j implementation the fields would
         // be fetched from the database. For the Core service we expose the formula so
@@ -101,6 +103,8 @@ internal sealed class MemoryDecayService : IMemoryDecayService
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        if (!Enum.IsDefined(nodeKind))
+            throw new ArgumentOutOfRangeException(nameof(nodeKind), nodeKind, "Unknown MemoryNodeKind.");
 
         // The actual timestamp update is performed in the repository layer
         // (Neo4j Cypher query). This Core implementation is a no-op pass-through

--- a/src/AgentMemory.Core/Services/MemoryDecayService.cs
+++ b/src/AgentMemory.Core/Services/MemoryDecayService.cs
@@ -1,3 +1,4 @@
+using AgentMemory.Abstractions.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Options;
@@ -63,11 +64,10 @@ internal sealed class MemoryDecayService : IMemoryDecayService
     /// <inheritdoc />
     public Task<double> CalculateRetentionScoreAsync(
         string nodeId,
-        string nodeLabel,
+        MemoryNodeKind nodeKind,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeLabel);
 
         // This is a pure computation—in the real Neo4j implementation the fields would
         // be fetched from the database. For the Core service we expose the formula so
@@ -97,16 +97,15 @@ internal sealed class MemoryDecayService : IMemoryDecayService
     /// <inheritdoc />
     public Task UpdateAccessTimestampAsync(
         string nodeId,
-        string nodeLabel,
+        MemoryNodeKind nodeKind,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeLabel);
 
         // The actual timestamp update is performed in the repository layer
         // (Neo4j Cypher query). This Core implementation is a no-op pass-through
         // so the interface compiles; the real work is done by the Neo4j adapter.
-        _logger.LogDebug("Access timestamp update requested for {Label} {NodeId}", nodeLabel, nodeId);
+        _logger.LogDebug("Access timestamp update requested for {NodeKind} {NodeId}", nodeKind, nodeId);
         return Task.CompletedTask;
     }
 }

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -279,21 +279,18 @@ internal sealed class MemoryService : IMemoryService
 
     /// <inheritdoc/>
     public async Task<int> GenerateEmbeddingsBatchAsync(
-        string nodeLabel,
+        MemoryNodeKind nodeKind,
         int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeLabel);
-        _logger.LogDebug("Batch embedding generation for label '{NodeLabel}', batchSize={BatchSize}", nodeLabel, batchSize);
+        _logger.LogDebug("Batch embedding generation for {NodeKind}, batchSize={BatchSize}", nodeKind, batchSize);
 
-        return nodeLabel switch
+        return nodeKind switch
         {
-            "Entity"     => await BackfillEntityEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
-            "Fact"       => await BackfillFactEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
-            "Preference" => await BackfillPreferenceEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
-            _ => throw new ArgumentException(
-                $"Unsupported node label '{nodeLabel}'. Supported values: Entity, Fact, Preference.",
-                nameof(nodeLabel))
+            MemoryNodeKind.Entity     => await BackfillEntityEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
+            MemoryNodeKind.Fact       => await BackfillFactEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
+            MemoryNodeKind.Preference => await BackfillPreferenceEmbeddingsAsync(batchSize, cancellationToken).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(nodeKind), nodeKind, "Unknown MemoryNodeKind.")
         };
     }
 
@@ -393,13 +390,13 @@ internal sealed class MemoryService : IMemoryService
             var tasks = new List<Task>();
 
             foreach (var entity in context.RelevantEntities.Items)
-                tasks.Add(_decayService!.UpdateAccessTimestampAsync(entity.EntityId, "Entity", cancellationToken));
+                tasks.Add(_decayService!.UpdateAccessTimestampAsync(entity.EntityId, MemoryNodeKind.Entity, cancellationToken));
 
             foreach (var fact in context.RelevantFacts.Items)
-                tasks.Add(_decayService!.UpdateAccessTimestampAsync(fact.FactId, "Fact", cancellationToken));
+                tasks.Add(_decayService!.UpdateAccessTimestampAsync(fact.FactId, MemoryNodeKind.Fact, cancellationToken));
 
             foreach (var pref in context.RelevantPreferences.Items)
-                tasks.Add(_decayService!.UpdateAccessTimestampAsync(pref.PreferenceId, "Preference", cancellationToken));
+                tasks.Add(_decayService!.UpdateAccessTimestampAsync(pref.PreferenceId, MemoryNodeKind.Preference, cancellationToken));
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -242,11 +242,19 @@ internal sealed class AdvancedMemoryTools
         [Description("Number of nodes to process per batch (default: 100)")] int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
-        var count = await memoryService.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken).ConfigureAwait(false);
+        if (!Enum.TryParse<MemoryNodeKind>(nodeLabel, ignoreCase: true, out var nodeKind))
+        {
+            return ToolJsonContext.Serialize(new
+            {
+                error = $"Unsupported node label '{nodeLabel}'. Supported values: Entity, Fact, Preference."
+            });
+        }
+
+        var count = await memoryService.GenerateEmbeddingsBatchAsync(nodeKind, batchSize, cancellationToken).ConfigureAwait(false);
 
         return ToolJsonContext.Serialize(new
         {
-            nodeLabel,
+            nodeLabel = nodeKind.ToString(),
             nodesUpdated = count
         });
     }

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -242,7 +242,10 @@ internal sealed class AdvancedMemoryTools
         [Description("Number of nodes to process per batch (default: 100)")] int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
-        if (!Enum.TryParse<MemoryNodeKind>(nodeLabel, ignoreCase: true, out var nodeKind))
+        // Enum.TryParse also succeeds for numeric strings ("999") and out-of-range values, so require the
+        // parsed value to be a defined MemoryNodeKind — otherwise return the clear tool error rather than
+        // letting an undefined value reach (and throw from) the service.
+        if (!Enum.TryParse<MemoryNodeKind>(nodeLabel, ignoreCase: true, out var nodeKind) || !Enum.IsDefined(nodeKind))
         {
             return ToolJsonContext.Serialize(new
             {

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -242,10 +242,12 @@ internal sealed class AdvancedMemoryTools
         [Description("Number of nodes to process per batch (default: 100)")] int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
-        // Enum.TryParse also succeeds for numeric strings ("999") and out-of-range values, so require the
-        // parsed value to be a defined MemoryNodeKind — otherwise return the clear tool error rather than
-        // letting an undefined value reach (and throw from) the service.
-        if (!Enum.TryParse<MemoryNodeKind>(nodeLabel, ignoreCase: true, out var nodeKind) || !Enum.IsDefined(nodeKind))
+        // Enum.TryParse also accepts numeric strings ("1", "999"), so additionally require the input to match
+        // a defined MemoryNodeKind *name* (not its numeric value) — keeps the tool contract exactly the
+        // documented Entity/Fact/Preference and independent of the enum's underlying numbers.
+        if (!Enum.TryParse<MemoryNodeKind>(nodeLabel, ignoreCase: true, out var nodeKind)
+            || !Enum.IsDefined(nodeKind)
+            || !string.Equals(nodeKind.ToString(), nodeLabel, StringComparison.OrdinalIgnoreCase))
         {
             return ToolJsonContext.Serialize(new
             {

--- a/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
@@ -1,3 +1,4 @@
+using AgentMemory.Abstractions.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Options;
@@ -99,11 +100,10 @@ internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
 
     /// <inheritdoc />
     public async Task<double> CalculateRetentionScoreAsync(
-        string nodeId, string nodeLabel, CancellationToken cancellationToken = default)
+        string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeLabel);
-        var label = ValidateLabel(nodeLabel);
+        var label = nodeKind.ToString(); // enum name == Neo4j label (Entity/Fact/Preference)
 
         var cypher = DecayQueries.GetRetentionFields(label);
 
@@ -129,11 +129,10 @@ internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
 
     /// <inheritdoc />
     public async Task UpdateAccessTimestampAsync(
-        string nodeId, string nodeLabel, CancellationToken cancellationToken = default)
+        string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(nodeLabel);
-        var label = ValidateLabel(nodeLabel);
+        var label = nodeKind.ToString(); // enum name == Neo4j label (Entity/Fact/Preference)
 
         var cypher = DecayQueries.UpdateAccessTimestamp(label);
         string now = _clock.UtcNow.ToString("O");
@@ -157,15 +156,4 @@ internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
         double lambda = Math.Log(2) / _options.DecayHalfLifeDays;
         return confidence * Math.Exp(-lambda * daysSince) + _options.AccessBoostFactor * accessCount;
     }
-
-    /// <summary>
-    /// Validates a caller-supplied label against the allowlist. The decay queries interpolate the label
-    /// directly into Cypher (it cannot be a bound parameter), so this guards against injection.
-    /// </summary>
-    private static string ValidateLabel(string label) =>
-        AllowedLabels.Contains(label)
-            ? label
-            : throw new ArgumentException(
-                $"Unsupported memory label '{label}'. Allowed: {string.Join(", ", PrunableLabels)}.",
-                nameof(label));
 }

--- a/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jMemoryDecayService.cs
@@ -20,12 +20,6 @@ namespace AgentMemory.Neo4j.Services;
 /// </summary>
 internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
 {
-    /// <summary>Labels whose decay/pruning is supported. Guards the label-interpolating Cypher against injection.</summary>
-    private static readonly IReadOnlyList<string> PrunableLabels = new[] { "Entity", "Fact", "Preference" };
-
-    private static readonly HashSet<string> AllowedLabels =
-        new(PrunableLabels, StringComparer.Ordinal);
-
     private readonly INeo4jTransactionRunner _tx;
     private readonly IClock _clock;
     private readonly MemoryDecayOptions _options;
@@ -103,6 +97,10 @@ internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
         string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        // The label is interpolated into Cypher, so guard against an out-of-range cast (which would ToString()
+        // to a numeric label and cause a Neo4j syntax error) — fail fast with a clear argument error instead.
+        if (!Enum.IsDefined(nodeKind))
+            throw new ArgumentOutOfRangeException(nameof(nodeKind), nodeKind, "Unknown MemoryNodeKind.");
         var label = nodeKind.ToString(); // enum name == Neo4j label (Entity/Fact/Preference)
 
         var cypher = DecayQueries.GetRetentionFields(label);
@@ -132,6 +130,10 @@ internal sealed class Neo4jMemoryDecayService : IMemoryDecayService
         string nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        // The label is interpolated into Cypher, so guard against an out-of-range cast (which would ToString()
+        // to a numeric label and cause a Neo4j syntax error) — fail fast with a clear argument error instead.
+        if (!Enum.IsDefined(nodeKind))
+            throw new ArgumentOutOfRangeException(nameof(nodeKind), nodeKind, "Unknown MemoryNodeKind.");
         var label = nodeKind.ToString(); // enum name == Neo4j label (Entity/Fact/Preference)
 
         var cypher = DecayQueries.UpdateAccessTimestamp(label);

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -233,15 +233,15 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     }
 
     public async Task<int> GenerateEmbeddingsBatchAsync(
-        string nodeLabel,
+        MemoryNodeKind nodeKind,
         int batchSize = 100,
         CancellationToken cancellationToken = default)
     {
         // Must be async/await: a synchronous method would dispose the activity the moment it returns the
         // still-pending Task, so the span would close with ~0 duration, disconnected from the actual work.
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.generate_embeddings_batch");
-        activity?.SetTag("memory.node_label", nodeLabel);
+        activity?.SetTag("memory.node_kind", nodeKind.ToString());
         activity?.SetTag("memory.batch_size", batchSize);
-        return await _inner.GenerateEmbeddingsBatchAsync(nodeLabel, batchSize, cancellationToken).ConfigureAwait(false);
+        return await _inner.GenerateEmbeddingsBatchAsync(nodeKind, batchSize, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tests/AgentMemory.Tests.Integration/Compatibility/TckMirroredBehaviorTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Compatibility/TckMirroredBehaviorTests.cs
@@ -275,7 +275,7 @@ public sealed class TckMirroredBehaviorTests : IAsyncLifetime
 
         (await longTerm.SupersedeFactAsync(loser.FactId, winner.FactId, Alice))
             .Should().BeTrue();
-        await decay.UpdateAccessTimestampAsync(winner.FactId, "Fact");
+        await decay.UpdateAccessTimestampAsync(winner.FactId, MemoryNodeKind.Fact);
 
         var records = await history.GetHistoryAsync(new MemoryHistoryQuery
         {

--- a/tests/AgentMemory.Tests.Integration/Services/Neo4jMemoryDecayServiceIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Services/Neo4jMemoryDecayServiceIntegrationTests.cs
@@ -109,7 +109,7 @@ public class Neo4jMemoryDecayServiceIntegrationTests : IAsyncLifetime
     {
         var id = await SeedAsync("Entity", confidence: 0.9, daysOld: 10, accessCount: 2, ownerId: "user-A");
 
-        await _service.UpdateAccessTimestampAsync(id, "Entity");
+        await _service.UpdateAccessTimestampAsync(id, MemoryNodeKind.Entity);
 
         await using var session = _fixture.Driver.AsyncSession();
         var cursor = await session.RunAsync(
@@ -137,24 +137,18 @@ public class Neo4jMemoryDecayServiceIntegrationTests : IAsyncLifetime
         var freshId = await SeedAsync("Entity", confidence: 1.0, daysOld: 0, accessCount: 0);
         var halfLifeId = await SeedAsync("Fact", confidence: 1.0, daysOld: 30, accessCount: 0);
 
-        (await _service.CalculateRetentionScoreAsync(freshId, "Entity")).Should().BeApproximately(1.0, 0.05);
-        (await _service.CalculateRetentionScoreAsync(halfLifeId, "Fact")).Should().BeApproximately(0.5, 0.05);
+        (await _service.CalculateRetentionScoreAsync(freshId, MemoryNodeKind.Entity)).Should().BeApproximately(1.0, 0.05);
+        (await _service.CalculateRetentionScoreAsync(halfLifeId, MemoryNodeKind.Fact)).Should().BeApproximately(0.5, 0.05);
     }
 
     [Fact]
     public async Task CalculateRetentionScoreAsync_MissingNode_ReturnsZero()
     {
-        (await _service.CalculateRetentionScoreAsync($"missing-{Guid.NewGuid():N}", "Entity")).Should().Be(0.0);
+        (await _service.CalculateRetentionScoreAsync($"missing-{Guid.NewGuid():N}", MemoryNodeKind.Entity)).Should().Be(0.0);
     }
 
-    [Theory]
-    [InlineData("Message")]
-    [InlineData("Entity); DROP")]
-    public async Task UnsupportedLabel_Throws(string label)
-    {
-        var act = () => _service.CalculateRetentionScoreAsync("any", label);
-        await act.Should().ThrowAsync<ArgumentException>();
-    }
+    // (Former UnsupportedLabel_Throws theory removed: MemoryNodeKind is a closed enum, so an unsupported /
+    // injection label can no longer be passed — it's a compile error, and the label is never caller-supplied.)
 
     [Fact]
     public async Task CalculateRetentionScoreAsync_NullCreatedAt_ReturnsZero()
@@ -167,7 +161,7 @@ public class Neo4jMemoryDecayServiceIntegrationTests : IAsyncLifetime
             "CREATE (n:Entity {id: $id, confidence: 0.9, access_count: 0})", // no created_at
             new { id });
 
-        (await _service.CalculateRetentionScoreAsync(id, "Entity")).Should().Be(0.0);
+        (await _service.CalculateRetentionScoreAsync(id, MemoryNodeKind.Entity)).Should().Be(0.0);
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
@@ -19,7 +19,7 @@ public sealed class AbstractionsContractGuardTests
     private const int DocumentedServiceInterfaces = 38; // R1b store + IC8 owner contexts, +IConsolidationService (PR#113), +IConflictDetectionService, +IMemoryRankingContext/+IWritable (D3)
     private const int DocumentedRepositoryInterfaces = 11;
     private const int DocumentedDomainRecords = 48; // +ToolCallStats (PR2 — IToolCallRepository.GetStatsAsync)
-    private const int DocumentedEnums = 15; // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType (stringly->enum)
+    private const int DocumentedEnums = 16; // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType, +MemoryNodeKind
 
     private static IEnumerable<Type> PublicTypes() =>
         Abstractions.GetTypes().Where(t => t.IsPublic);

--- a/tests/AgentMemory.Tests.Unit/McpServer/RetroactiveToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/RetroactiveToolsTests.cs
@@ -1,3 +1,4 @@
+using AgentMemory.Abstractions.Domain;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -26,7 +27,7 @@ public sealed class RetroactiveToolsTests
             .Returns(Task.CompletedTask);
 
         _memoryService
-            .GenerateEmbeddingsBatchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .GenerateEmbeddingsBatchAsync(Arg.Any<MemoryNodeKind>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(42);
     }
 
@@ -72,7 +73,7 @@ public sealed class RetroactiveToolsTests
         await AdvancedMemoryTools.MemoryGenerateEmbeddings(_memoryService, "Entity");
 
         await _memoryService.Received(1)
-            .GenerateEmbeddingsBatchAsync("Entity", Arg.Any<int>(), Arg.Any<CancellationToken>());
+            .GenerateEmbeddingsBatchAsync(MemoryNodeKind.Entity, Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -81,7 +82,7 @@ public sealed class RetroactiveToolsTests
         await AdvancedMemoryTools.MemoryGenerateEmbeddings(_memoryService, "Fact", batchSize: 50);
 
         await _memoryService.Received(1)
-            .GenerateEmbeddingsBatchAsync("Fact", 50, Arg.Any<CancellationToken>());
+            .GenerateEmbeddingsBatchAsync(MemoryNodeKind.Fact, 50, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/McpServer/RetroactiveToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/RetroactiveToolsTests.cs
@@ -94,4 +94,17 @@ public sealed class RetroactiveToolsTests
         doc.RootElement.GetProperty("nodeLabel").GetString().Should().Be("Preference");
         doc.RootElement.GetProperty("nodesUpdated").GetInt32().Should().Be(42);
     }
+
+    [Theory]
+    [InlineData("1")]        // a numeric string parses to a defined enum value — must still be rejected
+    [InlineData("999")]      // out-of-range
+    [InlineData("Message")]  // unknown label
+    public async Task MemoryGenerateEmbeddings_NonNamedLabel_ReturnsError_AndDoesNotCallService(string label)
+    {
+        var result = await AdvancedMemoryTools.MemoryGenerateEmbeddings(_memoryService, label);
+
+        JsonDocument.Parse(result).RootElement.TryGetProperty("error", out _).Should().BeTrue();
+        await _memoryService.DidNotReceive()
+            .GenerateEmbeddingsBatchAsync(Arg.Any<MemoryNodeKind>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
@@ -307,15 +307,15 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
         // cycle-4: the method must be async/await so the `using` activity stays open across the inner
         // async work. A synchronous body would dispose the span the instant it returned the pending Task,
         // yielding a ~0-duration span. We assert the captured span's duration reflects the inner delay.
-        _inner.GenerateEmbeddingsBatchAsync("Entity", 100, Arg.Any<CancellationToken>())
+        _inner.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Entity, 100, Arg.Any<CancellationToken>())
             .Returns(async _ => { await Task.Delay(60); return 7; });
 
-        var result = await _sut.GenerateEmbeddingsBatchAsync("Entity", 100);
+        var result = await _sut.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Entity, 100);
 
         result.Should().Be(7);
         var activity = _capturedActivities.Should().ContainSingle(
             a => a.OperationName == "memory.generate_embeddings_batch").Subject;
-        activity.GetTagItem("memory.node_label").Should().Be("Entity");
+        activity.GetTagItem("memory.node_kind").Should().Be("Entity");
         activity.Duration.Should().BeGreaterThan(TimeSpan.FromMilliseconds(20),
             "the span must enclose the awaited work, not close at ~0ms before it runs");
     }

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryDecayServiceTests.cs
@@ -1,3 +1,4 @@
+using AgentMemory.Abstractions.Domain;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -157,7 +158,7 @@ public sealed class MemoryDecayServiceTests
     {
         var sut = CreateSut();
 
-        var act = () => sut.UpdateAccessTimestampAsync("node-1", "Entity");
+        var act = () => sut.UpdateAccessTimestampAsync("node-1", MemoryNodeKind.Entity);
 
         await act.Should().NotThrowAsync();
     }
@@ -167,17 +168,7 @@ public sealed class MemoryDecayServiceTests
     {
         var sut = CreateSut();
 
-        var act = () => sut.UpdateAccessTimestampAsync(null!, "Entity");
-
-        await act.Should().ThrowAsync<ArgumentException>();
-    }
-
-    [Fact]
-    public async Task UpdateAccessTimestampAsync_ThrowsForEmptyLabel()
-    {
-        var sut = CreateSut();
-
-        var act = () => sut.UpdateAccessTimestampAsync("node-1", "");
+        var act = () => sut.UpdateAccessTimestampAsync(null!, MemoryNodeKind.Entity);
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
@@ -189,20 +180,11 @@ public sealed class MemoryDecayServiceTests
     {
         var sut = CreateSut();
 
-        var act = () => sut.CalculateRetentionScoreAsync(null!, "Entity");
+        var act = () => sut.CalculateRetentionScoreAsync(null!, MemoryNodeKind.Entity);
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
-    [Fact]
-    public async Task CalculateRetentionScoreAsync_ThrowsForEmptyLabel()
-    {
-        var sut = CreateSut();
-
-        var act = () => sut.CalculateRetentionScoreAsync("node-1", " ");
-
-        await act.Should().ThrowAsync<ArgumentException>();
-    }
 
     // ── MemoryDecayOptions defaults ─────────────────────────────────────
 

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryServiceAccessTrackingTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryServiceAccessTrackingTests.cs
@@ -41,7 +41,7 @@ public sealed class MemoryServiceAccessTrackingTests
         _idGenerator.GenerateId().Returns("generated-msg-id");
 
         _decayService
-            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<MemoryNodeKind>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
     }
 
@@ -80,8 +80,8 @@ public sealed class MemoryServiceAccessTrackingTests
         // Give fire-and-forget time to execute
         await Task.Delay(100);
 
-        await _decayService.Received().UpdateAccessTimestampAsync("ent-1", "Entity", Arg.Any<CancellationToken>());
-        await _decayService.Received().UpdateAccessTimestampAsync("ent-2", "Entity", Arg.Any<CancellationToken>());
+        await _decayService.Received().UpdateAccessTimestampAsync("ent-1", MemoryNodeKind.Entity, Arg.Any<CancellationToken>());
+        await _decayService.Received().UpdateAccessTimestampAsync("ent-2", MemoryNodeKind.Entity, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public sealed class MemoryServiceAccessTrackingTests
         await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "test" });
         await Task.Delay(100);
 
-        await _decayService.Received().UpdateAccessTimestampAsync("fact-1", "Fact", Arg.Any<CancellationToken>());
+        await _decayService.Received().UpdateAccessTimestampAsync("fact-1", MemoryNodeKind.Fact, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class MemoryServiceAccessTrackingTests
         await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "test" });
         await Task.Delay(100);
 
-        await _decayService.Received().UpdateAccessTimestampAsync("pref-1", "Preference", Arg.Any<CancellationToken>());
+        await _decayService.Received().UpdateAccessTimestampAsync("pref-1", MemoryNodeKind.Preference, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public sealed class MemoryServiceAccessTrackingTests
         await Task.Delay(100);
 
         await _decayService.DidNotReceive()
-            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<MemoryNodeKind>(), Arg.Any<CancellationToken>());
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryServiceBatchTests.cs
@@ -203,7 +203,7 @@ public sealed class MemoryServiceBatchTests
             .Returns(Task.FromResult(new float[] { 0.1f }));
 
         var sut = CreateSut();
-        var count = await sut.GenerateEmbeddingsBatchAsync("Entity", batchSize: 100);
+        var count = await sut.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Entity, batchSize: 100);
 
         count.Should().Be(2);
         await _embeddingOrchestrator.Received(2).EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -227,7 +227,7 @@ public sealed class MemoryServiceBatchTests
             .Returns(Task.FromResult(Array.Empty<float>())); // persistent generation failure ⇒ empty vector
 
         var sut = CreateSut();
-        var count = await sut.GenerateEmbeddingsBatchAsync("Entity", batchSize: 100);
+        var count = await sut.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Entity, batchSize: 100);
 
         count.Should().Be(0, "the stalled page's node had an empty (degraded) embedding that was not persisted, " +
             "so it is not counted as updated — and the back-fill then stops");
@@ -248,7 +248,7 @@ public sealed class MemoryServiceBatchTests
             .Returns(Task.FromResult(new float[] { 0.5f }));
 
         var sut = CreateSut();
-        await sut.GenerateEmbeddingsBatchAsync("Fact", batchSize: 100);
+        await sut.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Fact, batchSize: 100);
 
         await _embeddingOrchestrator.Received(1)
             .EmbedAsync("Alice works_at Acme", Arg.Any<CancellationToken>());
@@ -268,17 +268,19 @@ public sealed class MemoryServiceBatchTests
             .Returns(Task.FromResult(new float[] { 0.3f }));
 
         var sut = CreateSut();
-        await sut.GenerateEmbeddingsBatchAsync("Preference", batchSize: 100);
+        await sut.GenerateEmbeddingsBatchAsync(MemoryNodeKind.Preference, batchSize: 100);
 
         await _embeddingOrchestrator.Received(1)
             .EmbedAsync("Prefers dark mode", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task GenerateEmbeddingsBatchAsync_UnsupportedLabel_ThrowsArgumentException()
+    public async Task GenerateEmbeddingsBatchAsync_UnknownNodeKind_ThrowsArgumentOutOfRange()
     {
         var sut = CreateSut();
-        var act = () => sut.GenerateEmbeddingsBatchAsync("Message");
-        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Message*");
+        // A valid MemoryNodeKind can't be an unsupported label (it's compile-checked); only an out-of-range
+        // cast can reach the switch default.
+        var act = () => sut.GenerateEmbeddingsBatchAsync((MemoryNodeKind)999);
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Services/TemporalRecallTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/TemporalRecallTests.cs
@@ -147,7 +147,7 @@ public sealed class TemporalRecallTests
 
         // Temporal recall is read-only; should NOT update access timestamps.
         await _decayService.DidNotReceive()
-            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .UpdateAccessTimestampAsync(Arg.Any<string>(), Arg.Any<MemoryNodeKind>(), Arg.Any<CancellationToken>());
     }
 
     // ── RecallAsOfAsync (bitemporal, two-clock — D6) ─────────────────────


### PR DESCRIPTION
## Summary

Replaces the free-form `string nodeLabel` parameters on the decay/maintenance surface with a closed **`MemoryNodeKind { Entity, Fact, Preference }`** enum (the enum name equals the Neo4j label). Deferred item from the 1.0 shape work.

## Changes

- **`IMemoryDecayService.CalculateRetentionScoreAsync` / `UpdateAccessTimestampAsync`** and **`IMemoryMaintenance.GenerateEmbeddingsBatchAsync`** now take `MemoryNodeKind`. An unsupported label is a **compile error** instead of a runtime `ArgumentException`; the `GenerateEmbeddingsBatchAsync` switch throws `ArgumentOutOfRangeException` only on an out-of-range cast.
- **Removes the label-injection surface.** The decay queries interpolate the label into Cypher, so `Neo4jMemoryDecayService` previously guarded it with a `ValidateLabel` allowlist — the closed enum makes an injection label impossible, so `ValidateLabel` is deleted.
- The **MCP `memory_generate_embeddings` tool** keeps its wire-level `nodeLabel` string arg and parses it to the enum (`Enum.TryParse`), returning a clear error for an unknown value.

## Tests

Removed the now-moot empty/whitespace-label and unsupported-label/injection validation tests; adjusted mock setups (`Arg.Any<string>` → `Arg.Any<MemoryNodeKind>`) and the activity tag (`memory.node_label` → `memory.node_kind`). Enum-count guard 15 → 16.

## Verified

| Check | Result |
|---|---|
| Release build | 0 warnings / 0 errors |
| Full unit suite | 2696 / 2696 |
| Full integration suite | 260 / 260 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsi9nT4PG1BBrvLBq3XZma
