### PR TITLE
1.0 API surface (7): rename ct -> cancellationToken (library-wide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **All public `CancellationToken` parameters are now named `cancellationToken`** (previously ~109 were abbreviated `ct`), for a consistent library-wide convention. This is source-breaking only for callers that passed the token by name (`ct:`); positional callers are unaffected, and it is a binary-compatible change.
 - **The decay/maintenance `string nodeLabel` parameters are now a closed `MemoryNodeKind` enum** (`Entity`/`Fact`/`Preference`). `IMemoryDecayService.CalculateRetentionScoreAsync`/`UpdateAccessTimestampAsync` and `IMemoryMaintenance.GenerateEmbeddingsBatchAsync` take the enum — an unsupported label is now a compile error, not a runtime `ArgumentException`, which also removes the label-injection surface in the decay Cypher. The MCP `memory_generate_embeddings` tool keeps its wire-level `nodeLabel` string and parses it to the enum (returning a clear error for an unknown value).
 - **`DuplicatePair.Status` and `EntityResolutionResult.MatchType` are now enums** (`DuplicateStatus` and `EntityMatchType`) instead of strings, for compile-time safety.
 - **Collapsed the two `RecallAsOfAsync` overloads (and the two `AssembleContextAsOfAsync` overloads) into one** method with an optional `DateTimeOffset? systemAsOf = null` — omit it for single-clock recall (both clocks equal), pass it for bitemporal. Same behavior; fewer overloads.

--- a/src/AgentMemory.Abstractions/Repositories/IConversationRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IConversationRepository.cs
@@ -43,5 +43,5 @@ public interface IConversationRepository
     /// <summary>
     /// Lists all sessions with summary information.
     /// </summary>
-    Task<IReadOnlyList<SessionSummary>> ListSessionsAsync(int limit = 50, CancellationToken ct = default);
+    Task<IReadOnlyList<SessionSummary>> ListSessionsAsync(int limit = 50, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Repositories/IEntityRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IEntityRepository.cs
@@ -173,24 +173,24 @@ public interface IEntityRepository
     /// (optionally) shared entities. Null scope ⇒ unscoped (admin/maintenance dedup).
     /// </summary>
     Task<IReadOnlyList<(Entity Entity, double Similarity)>> FindSimilarByEmbeddingAsync(
-        string entityId, double minSimilarity = 0.85, int limit = 10, MemoryScope? scope = null, CancellationToken ct = default);
+        string entityId, double minSimilarity = 0.85, int limit = 10, MemoryScope? scope = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets pending SAME_AS duplicate pairs for manual review. Deliberately unscoped (R1): this is an
     /// admin/maintenance dedup-review surface intended to span all owners; it has no user-facing caller.
     /// </summary>
-    Task<IReadOnlyList<DuplicatePair>> GetPendingDuplicatesAsync(int limit = 50, CancellationToken ct = default);
+    Task<IReadOnlyList<DuplicatePair>> GetPendingDuplicatesAsync(int limit = 50, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets aggregate SAME_AS relationship counts grouped by status.
     /// </summary>
-    Task<DeduplicationStats> GetDeduplicationStatsAsync(CancellationToken ct = default);
+    Task<DeduplicationStats> GetDeduplicationStatsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all entities extracted from a specific message. Deliberately unscoped (R1): the result is
     /// already confined by <paramref name="messageId"/> (itself an owned handle), so no owner filter is added.
     /// </summary>
-    Task<IReadOnlyList<Entity>> GetEntitiesFromMessageAsync(string messageId, CancellationToken ct = default);
+    Task<IReadOnlyList<Entity>> GetEntitiesFromMessageAsync(string messageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Searches entities by vector similarity, returning only those that existed at <paramref name="asOf"/>.

--- a/src/AgentMemory.Abstractions/Repositories/IExtractorRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IExtractorRepository.cs
@@ -11,17 +11,17 @@ public interface IExtractorRepository
     /// <summary>
     /// Creates or updates an extractor node.
     /// </summary>
-    Task<Extractor> UpsertAsync(Extractor extractor, CancellationToken ct = default);
+    Task<Extractor> UpsertAsync(Extractor extractor, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets an extractor by its unique name.
     /// </summary>
-    Task<Extractor?> GetByNameAsync(string name, CancellationToken ct = default);
+    Task<Extractor?> GetByNameAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists all registered extractors.
     /// </summary>
-    Task<IReadOnlyList<Extractor>> ListAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<Extractor>> ListAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates an EXTRACTED_BY relationship from an entity to an extractor.
@@ -31,7 +31,7 @@ public interface IExtractorRepository
         string extractorName,
         double confidence,
         int? extractionTimeMs = null,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets entities extracted by a given extractor. Deliberately unscoped (R1): this is an
@@ -42,27 +42,27 @@ public interface IExtractorRepository
     Task<IReadOnlyList<(Entity Entity, double Confidence)>> GetEntitiesByExtractorAsync(
         string extractorName,
         int limit = 100,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets full provenance information for an entity. When <paramref name="scope"/> is supplied (R1)
     /// the lookup is confined to the owner's own or shared entity, returning null when the entity is
     /// out of scope; null scope ⇒ unscoped (admin/audit).
     /// </summary>
-    Task<EntityProvenance?> GetProvenanceAsync(string entityId, MemoryScope? scope = null, CancellationToken ct = default);
+    Task<EntityProvenance?> GetProvenanceAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets aggregate extraction statistics.
     /// </summary>
-    Task<ExtractionStats> GetExtractionStatsAsync(CancellationToken ct = default);
+    Task<ExtractionStats> GetExtractionStatsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets statistics for a specific extractor.
     /// </summary>
-    Task<ExtractorStats?> GetExtractorStatsAsync(string extractorName, CancellationToken ct = default);
+    Task<ExtractorStats?> GetExtractorStatsAsync(string extractorName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes all provenance relationships (EXTRACTED_FROM, EXTRACTED_BY) for an entity.
     /// </summary>
-    Task<int> DeleteProvenanceAsync(string entityId, CancellationToken ct = default);
+    Task<int> DeleteProvenanceAsync(string entityId, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Repositories/IMessageRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IMessageRepository.cs
@@ -84,5 +84,5 @@ public interface IMessageRepository
     /// When <paramref name="cascade"/> is true, all relationships are removed (DETACH DELETE).
     /// When false, only the node is deleted (relationships must already be removed).
     /// </summary>
-    Task<bool> DeleteAsync(string messageId, bool cascade = true, CancellationToken ct = default);
+    Task<bool> DeleteAsync(string messageId, bool cascade = true, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/EmbeddingOrchestratorExtensions.cs
+++ b/src/AgentMemory.Abstractions/Services/EmbeddingOrchestratorExtensions.cs
@@ -8,26 +8,26 @@ namespace AgentMemory.Abstractions.Services;
 public static class EmbeddingOrchestratorExtensions
 {
     /// <summary>Embeds an entity name.</summary>
-    public static Task<float[]> EmbedEntityAsync(this IEmbeddingOrchestrator orchestrator, string entityName, CancellationToken ct = default)
-        => orchestrator.EmbedAsync(entityName, ct);
+    public static Task<float[]> EmbedEntityAsync(this IEmbeddingOrchestrator orchestrator, string entityName, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync(entityName, cancellationToken);
 
     /// <summary>Embeds a Subject-Predicate-Object fact triple as a single composed string.</summary>
-    public static Task<float[]> EmbedFactAsync(this IEmbeddingOrchestrator orchestrator, string subject, string predicate, string obj, CancellationToken ct = default)
-        => orchestrator.EmbedAsync($"{subject} {predicate} {obj}", ct);
+    public static Task<float[]> EmbedFactAsync(this IEmbeddingOrchestrator orchestrator, string subject, string predicate, string obj, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync($"{subject} {predicate} {obj}", cancellationToken);
 
     /// <summary>Embeds a user preference.</summary>
-    public static Task<float[]> EmbedPreferenceAsync(this IEmbeddingOrchestrator orchestrator, string preferenceText, CancellationToken ct = default)
-        => orchestrator.EmbedAsync(preferenceText, ct);
+    public static Task<float[]> EmbedPreferenceAsync(this IEmbeddingOrchestrator orchestrator, string preferenceText, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync(preferenceText, cancellationToken);
 
     /// <summary>Embeds a conversation message.</summary>
-    public static Task<float[]> EmbedMessageAsync(this IEmbeddingOrchestrator orchestrator, string content, CancellationToken ct = default)
-        => orchestrator.EmbedAsync(content, ct);
+    public static Task<float[]> EmbedMessageAsync(this IEmbeddingOrchestrator orchestrator, string content, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync(content, cancellationToken);
 
     /// <summary>Embeds a recall query.</summary>
-    public static Task<float[]> EmbedQueryAsync(this IEmbeddingOrchestrator orchestrator, string query, CancellationToken ct = default)
-        => orchestrator.EmbedAsync(query, ct);
+    public static Task<float[]> EmbedQueryAsync(this IEmbeddingOrchestrator orchestrator, string query, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync(query, cancellationToken);
 
     /// <summary>Embeds arbitrary text. Alias for <see cref="IEmbeddingOrchestrator.EmbedAsync"/>.</summary>
-    public static Task<float[]> EmbedTextAsync(this IEmbeddingOrchestrator orchestrator, string text, CancellationToken ct = default)
-        => orchestrator.EmbedAsync(text, ct);
+    public static Task<float[]> EmbedTextAsync(this IEmbeddingOrchestrator orchestrator, string text, CancellationToken cancellationToken = default)
+        => orchestrator.EmbedAsync(text, cancellationToken);
 }

--- a/src/AgentMemory.Abstractions/Services/IEmbeddingOrchestrator.cs
+++ b/src/AgentMemory.Abstractions/Services/IEmbeddingOrchestrator.cs
@@ -10,12 +10,12 @@ public interface IEmbeddingOrchestrator
 {
     /// <summary>Generates an embedding vector for a single piece of text.</summary>
     /// <returns>The embedding vector, or an empty array when <paramref name="text"/> is blank or generation fails.</returns>
-    Task<float[]> EmbedAsync(string text, CancellationToken ct = default);
+    Task<float[]> EmbedAsync(string text, CancellationToken cancellationToken = default);
 
     /// <summary>Generates embedding vectors for a batch of texts, preserving input order.</summary>
     /// <returns>
     /// One vector per input. Blank inputs yield an empty vector; on a generation failure every
     /// vector is returned empty so positional alignment with <paramref name="texts"/> is preserved.
     /// </returns>
-    Task<IReadOnlyList<float[]>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct = default);
+    Task<IReadOnlyList<float[]>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IEnrichmentService.cs
+++ b/src/AgentMemory.Abstractions/Services/IEnrichmentService.cs
@@ -12,7 +12,7 @@ public interface IEnrichmentService
     /// </summary>
     /// <param name="entityName">The entity name to look up.</param>
     /// <param name="entityType">The entity's type (e.g. PERSON, ORGANIZATION), used to disambiguate.</param>
-    /// <param name="ct">A token to cancel the operation.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The enrichment result, or <c>null</c> if data is unavailable or an error occurs.</returns>
-    Task<EnrichmentResult?> EnrichEntityAsync(string entityName, string entityType, CancellationToken ct = default);
+    Task<EnrichmentResult?> EnrichEntityAsync(string entityName, string entityType, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IGeocodingService.cs
+++ b/src/AgentMemory.Abstractions/Services/IGeocodingService.cs
@@ -11,7 +11,7 @@ public interface IGeocodingService
     /// Resolves a free-text location string to geographic coordinates.
     /// </summary>
     /// <param name="locationText">The free-text location to geocode (e.g. "Paris, France").</param>
-    /// <param name="ct">A token to cancel the operation.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The geocoding result, or <c>null</c> if the location cannot be resolved or an error occurs.</returns>
-    Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken ct = default);
+    Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/ISchemaManager.cs
+++ b/src/AgentMemory.Abstractions/Services/ISchemaManager.cs
@@ -9,23 +9,23 @@ namespace AgentMemory.Abstractions.Services;
 public interface ISchemaManager
 {
     /// <summary>Loads the active schema version by name. Returns null if not found.</summary>
-    Task<EntitySchemaConfig?> LoadSchemaAsync(string name, CancellationToken ct = default);
+    Task<EntitySchemaConfig?> LoadSchemaAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>Loads a specific version of a schema. Returns null if not found.</summary>
-    Task<EntitySchemaConfig?> LoadSchemaVersionAsync(string name, string version, CancellationToken ct = default);
+    Task<EntitySchemaConfig?> LoadSchemaVersionAsync(string name, string version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Saves a schema to the store. Creates a new version if the name already exists.
     /// When <paramref name="setActive"/> is true, the saved version becomes the active one.
     /// </summary>
-    Task SaveSchemaAsync(EntitySchemaConfig schema, string? createdBy = null, bool setActive = true, CancellationToken ct = default);
+    Task SaveSchemaAsync(EntitySchemaConfig schema, string? createdBy = null, bool setActive = true, CancellationToken cancellationToken = default);
 
     /// <summary>Lists all schemas, optionally filtered by name prefix.</summary>
-    Task<IReadOnlyList<SchemaListItem>> ListSchemasAsync(string? nameFilter = null, CancellationToken ct = default);
+    Task<IReadOnlyList<SchemaListItem>> ListSchemasAsync(string? nameFilter = null, CancellationToken cancellationToken = default);
 
     /// <summary>Returns true if a schema with the given name exists.</summary>
-    Task<bool> SchemaExistsAsync(string name, CancellationToken ct = default);
+    Task<bool> SchemaExistsAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>Deletes a specific schema version by its unique ID. Returns true if deleted.</summary>
-    Task<bool> DeleteSchemaAsync(string schemaId, CancellationToken ct = default);
+    Task<bool> DeleteSchemaAsync(string schemaId, CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.Abstractions/Services/IStreamingExtractor.cs
+++ b/src/AgentMemory.Abstractions/Services/IStreamingExtractor.cs
@@ -25,7 +25,7 @@ public interface IStreamingExtractor
         string text,
         IEntityExtractor extractor,
         StreamingExtractionOptions? options = null,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Processes the entire document, collects all chunk results, optionally deduplicates,
@@ -36,5 +36,5 @@ public interface IStreamingExtractor
         IEntityExtractor extractor,
         StreamingExtractionOptions? options = null,
         bool deduplicate = true,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 }

--- a/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
@@ -35,16 +35,16 @@ public sealed class Neo4jChatMessageStore
         ChatMessage chatMessage,
         string sessionId,
         string conversationId,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         try
         {
             var message = MafTypeMapper.ToInternalMessage(chatMessage, sessionId, conversationId, _clock, _idGenerator);
             return await _memoryService
-                .AddMessageAsync(message.SessionId, message.ConversationId, message.Role, message.Content, message.Metadata, ct)
+                .AddMessageAsync(message.SessionId, message.ConversationId, message.Role, message.Content, message.Metadata, cancellationToken)
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -65,7 +65,7 @@ public sealed class Neo4jChatMessageStore
     public async Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(
         string sessionId,
         int limit = 50,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -75,7 +75,7 @@ public sealed class Neo4jChatMessageStore
                     SessionId = sessionId,
                     Query = string.Empty,
                     Options = new Abstractions.Options.RecallOptions { MaxRecentMessages = limit }
-                }, ct).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
 
             // RecentMessages is newest-first (recall orders DESC); return chat history chronologically
             // (oldest-first) so the agent reads the conversation in the order it happened.
@@ -84,7 +84,7 @@ public sealed class Neo4jChatMessageStore
                 .Select(MafTypeMapper.ToChatMessage)
                 .ToList();
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -98,13 +98,13 @@ public sealed class Neo4jChatMessageStore
     /// <summary>
     /// Clears all memory for the given session.
     /// </summary>
-    public async Task ClearSessionAsync(string sessionId, CancellationToken ct = default)
+    public async Task ClearSessionAsync(string sessionId, CancellationToken cancellationToken = default)
     {
         try
         {
-            await _memoryService.ClearSessionAsync(sessionId, cancellationToken: ct).ConfigureAwait(false);
+            await _memoryService.ClearSessionAsync(sessionId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMicrosoftMemoryFacade.cs
@@ -41,7 +41,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
         string sessionId,
         string conversationId,
         string? userId = null,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -52,12 +52,12 @@ public sealed class Neo4jMicrosoftMemoryFacade
                 .Select(m => m.Text));
 
             if (string.IsNullOrWhiteSpace(queryText))
-                return await _messageStore.GetMessagesAsync(sessionId, ct: ct).ConfigureAwait(false);
+                return await _messageStore.GetMessagesAsync(sessionId, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Owner-scope the recall (R1): the write path (PersistAfterRunAsync / StoreMessageAsync) takes a
             // userId, so the read path must too — otherwise a multi-tenant host would recall across owners.
             var recall = await _memoryService
-                .RecallAsync(new RecallRequest { SessionId = sessionId, Query = queryText, UserId = userId }, ct)
+                .RecallAsync(new RecallRequest { SessionId = sessionId, Query = queryText, UserId = userId }, cancellationToken)
                 .ConfigureAwait(false);
 
             // RecentMessages is newest-first (recall orders DESC); reverse it to chronological
@@ -71,7 +71,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
                 .Select(MafTypeMapper.ToChatMessage)
                 .ToList();
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -90,7 +90,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
         string sessionId,
         string conversationId,
         string? userId = null,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         if (messages.Count == 0)
             return;
@@ -101,7 +101,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
             foreach (var msg in messages)
             {
                 var stored = await _messageStore
-                    .AddMessageAsync(msg, sessionId, conversationId, ct)
+                    .AddMessageAsync(msg, sessionId, conversationId, cancellationToken)
                     .ConfigureAwait(false);
                 internalMessages.Add(stored);
             }
@@ -116,9 +116,9 @@ public sealed class Neo4jMicrosoftMemoryFacade
                             Messages = internalMessages,
                             SessionId = sessionId,
                             UserId = userId
-                        }, ct).ConfigureAwait(false);
+                        }, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }
@@ -128,7 +128,7 @@ public sealed class Neo4jMicrosoftMemoryFacade
                 }
             }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -145,12 +145,12 @@ public sealed class Neo4jMicrosoftMemoryFacade
         ChatMessage msg,
         string sessionId,
         string conversationId,
-        CancellationToken ct = default)
-        => _messageStore.AddMessageAsync(msg, sessionId, conversationId, ct);
+        CancellationToken cancellationToken = default)
+        => _messageStore.AddMessageAsync(msg, sessionId, conversationId, cancellationToken);
 
     /// <summary>
     /// Clears all memory for the given session.
     /// </summary>
-    public Task ClearSessionAsync(string sessionId, CancellationToken ct = default)
-        => _messageStore.ClearSessionAsync(sessionId, ct);
+    public Task ClearSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+        => _messageStore.ClearSessionAsync(sessionId, cancellationToken);
 }

--- a/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
+++ b/src/AgentMemory.Core/Enrichment/BackgroundEnrichmentQueue.cs
@@ -80,26 +80,26 @@ internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, ID
         return Task.CompletedTask;
     }
 
-    private Task StartWorkersAsync(CancellationToken ct)
+    private Task StartWorkersAsync(CancellationToken cancellationToken)
     {
         var workers = Enumerable
             .Range(0, _options.MaxConcurrency)
-            .Select(_ => Task.Run(() => RunWorkerAsync(ct), ct));
+            .Select(_ => Task.Run(() => RunWorkerAsync(cancellationToken), cancellationToken));
         return Task.WhenAll(workers);
     }
 
-    private async Task RunWorkerAsync(CancellationToken ct)
+    private async Task RunWorkerAsync(CancellationToken cancellationToken)
     {
         try
         {
-            await foreach (var item in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            await foreach (var item in _channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 Interlocked.Increment(ref _activeCount);
                 try
                 {
-                    await ProcessItemAsync(item, ct).ConfigureAwait(false);
+                    await ProcessItemAsync(item, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw; // shutdown — propagate to the outer catch and end the worker loop
                 }
@@ -122,9 +122,9 @@ internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, ID
         catch (OperationCanceledException) { /* expected on shutdown */ }
     }
 
-    private async Task ProcessItemAsync(EnrichmentItem item, CancellationToken ct)
+    private async Task ProcessItemAsync(EnrichmentItem item, CancellationToken cancellationToken)
     {
-        var entity = await _entityRepository.GetByIdAsync(item.EntityId, ct).ConfigureAwait(false);
+        var entity = await _entityRepository.GetByIdAsync(item.EntityId, cancellationToken).ConfigureAwait(false);
         if (entity is null)
         {
             _logger.LogWarning("Entity {EntityId} not found for background enrichment", item.EntityId);
@@ -143,7 +143,7 @@ internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, ID
         {
             try
             {
-                var result = await service.EnrichEntityAsync(entity.Name, entity.Type, ct).ConfigureAwait(false);
+                var result = await service.EnrichEntityAsync(entity.Name, entity.Type, cancellationToken).ConfigureAwait(false);
                 var status = result?.Status;
 
                 if (result is not null && status is null or EnrichmentStatus.Success)
@@ -175,7 +175,7 @@ internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, ID
 
         if (anySuccess)
         {
-            await _entityRepository.UpsertAsync(updated, ct).ConfigureAwait(false);
+            await _entityRepository.UpsertAsync(updated, cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -187,7 +187,7 @@ internal sealed class BackgroundEnrichmentQueue : IBackgroundEnrichmentQueue, ID
                 "All enrichment providers failed for entity {EntityId}; scheduling retry {Attempt}/{Max}",
                 entity.EntityId, item.RetryCount + 1, _options.MaxRetries);
 
-            await Task.Delay(_options.RetryDelay, ct).ConfigureAwait(false);
+            await Task.Delay(_options.RetryDelay, cancellationToken).ConfigureAwait(false);
             _channel.Writer.TryWrite(item with { RetryCount = item.RetryCount + 1 });
         }
         else

--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -234,13 +234,13 @@ internal sealed class ExtractionStage : IExtractionStage
     private async Task<IReadOnlyList<T>> ExtractSafeAsync<T>(
         Func<Task<IReadOnlyList<T>>> extractor,
         string extractorTypeName,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
         try
         {
             return await extractor().ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // Honor caller cancellation — do not mask it as an empty result.
         }

--- a/src/AgentMemory.Core/Extraction/ExtractorBase.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractorBase.cs
@@ -30,30 +30,30 @@ public abstract class ExtractorBase<T>
     /// supplied messages.
     /// </summary>
     /// <param name="messages">The messages to extract items from.</param>
-    /// <param name="ct">A token to observe for cancellation requests.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A task that resolves to the extracted items.</returns>
     protected abstract Task<IReadOnlyList<T>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct);
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken);
 
     /// <summary>
     /// Extracts items from the supplied messages, returning an empty list when no messages
     /// are provided or when the underlying extraction fails.
     /// </summary>
     /// <param name="messages">The messages to extract items from.</param>
-    /// <param name="ct">A token to observe for cancellation requests.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>
     /// A task that resolves to the extracted items, or an empty list if there are no
     /// messages or an error occurs during extraction.
     /// </returns>
     public async Task<IReadOnlyList<T>> ExtractAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct = default)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken = default)
     {
         if (messages.Count == 0) return Array.Empty<T>();
         try
         {
-            return await ExtractCoreAsync(messages, ct).ConfigureAwait(false);
+            return await ExtractCoreAsync(messages, cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // Honor caller cancellation — do not mask it as a successful empty result.
         }

--- a/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
+++ b/src/AgentMemory.Core/Extraction/Streaming/StreamingExtractor.cs
@@ -43,7 +43,7 @@ internal sealed class StreamingExtractor : IStreamingExtractor
         string text,
         IEntityExtractor extractor,
         StreamingExtractionOptions? options = null,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var chunks = ChunkDocument(text, options);
         _logger.LogInformation(
@@ -52,14 +52,14 @@ internal sealed class StreamingExtractor : IStreamingExtractor
 
         foreach (var chunk in chunks)
         {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             var sw = Stopwatch.StartNew();
             StreamingChunkResult chunkResult;
 
             try
             {
                 var message = BuildMessage(chunk.Text);
-                var entities = await extractor.ExtractAsync(new[] { message }, ct)
+                var entities = await extractor.ExtractAsync(new[] { message }, cancellationToken)
                     .ConfigureAwait(false);
 
                 sw.Stop();
@@ -99,7 +99,7 @@ internal sealed class StreamingExtractor : IStreamingExtractor
         IEntityExtractor extractor,
         StreamingExtractionOptions? options = null,
         bool deduplicate = true,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         var sw = Stopwatch.StartNew();
         var chunks = ChunkDocument(text, options);
@@ -110,7 +110,7 @@ internal sealed class StreamingExtractor : IStreamingExtractor
         int successfulChunks = 0;
         int failedChunks = 0;
 
-        await foreach (var chunkResult in ExtractStreamingAsync(text, extractor, options, ct)
+        await foreach (var chunkResult in ExtractStreamingAsync(text, extractor, options, cancellationToken)
             .ConfigureAwait(false))
         {
             chunkResults.Add(chunkResult);

--- a/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
+++ b/src/AgentMemory.Core/Services/EmbeddingOrchestrator.cs
@@ -29,17 +29,17 @@ internal sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
     }
 
     /// <inheritdoc/>
-    public async Task<float[]> EmbedAsync(string text, CancellationToken ct = default)
+    public async Task<float[]> EmbedAsync(string text, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(text))
             return Array.Empty<float>();
 
         try
         {
-            var result = await _generator.GenerateAsync([text], cancellationToken: ct).ConfigureAwait(false);
+            var result = await _generator.GenerateAsync([text], cancellationToken: cancellationToken).ConfigureAwait(false);
             return result[0].Vector.ToArray();
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // Honor caller cancellation — do not mask it as a successful empty vector.
         }
@@ -51,7 +51,7 @@ internal sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<float[]>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct = default)
+    public async Task<IReadOnlyList<float[]>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(texts);
         if (texts.Count == 0)
@@ -79,7 +79,7 @@ internal sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
 
         try
         {
-            var generated = await _generator.GenerateAsync(nonBlankTexts, cancellationToken: ct).ConfigureAwait(false);
+            var generated = await _generator.GenerateAsync(nonBlankTexts, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (generated.Count != nonBlankTexts.Count)
             {
                 // Contract expects one vector per input; a mismatch means the generator misbehaved.
@@ -91,7 +91,7 @@ internal sealed class EmbeddingOrchestrator : IEmbeddingOrchestrator
             for (int j = 0; j < nonBlankIndices.Count && j < generated.Count; j++)
                 results[nonBlankIndices[j]] = generated[j].Vector.ToArray();
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // Honor caller cancellation — do not mask it as successful empty vectors.
         }

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -87,11 +87,11 @@ internal sealed class LongTermMemoryService : ILongTermMemoryService
         return EnsureEmbeddingThenUpsertAsync(
             entity,
             shouldEmbed: _options.GenerateEntityEmbeddings && entity.Embedding is null,
-            embed: ct =>
+            embed: cancellationToken =>
             {
                 var text = string.IsNullOrEmpty(entity.Description) ? entity.Name : $"{entity.Name}: {entity.Description}";
                 _logger.LogDebug("Generating embedding for entity {EntityId}", entity.EntityId);
-                return _embeddingOrchestrator.EmbedTextAsync(text, ct);
+                return _embeddingOrchestrator.EmbedTextAsync(text, cancellationToken);
             },
             withEmbedding: (e, emb) => e with { Embedding = emb },
             upsert: _entityRepo.UpsertAsync,

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -294,18 +294,18 @@ internal sealed class MemoryService : IMemoryService
         };
     }
 
-    private async Task<int> BackfillEntityEmbeddingsAsync(int batchSize, CancellationToken ct)
+    private async Task<int> BackfillEntityEmbeddingsAsync(int batchSize, CancellationToken cancellationToken)
     {
         int total = 0;
         PagedResult<Entity> page;
         do
         {
-            page = await _entityRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
+            page = await _entityRepository.GetPageWithoutEmbeddingAsync(batchSize, cancellationToken).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var entity in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, ct).ConfigureAwait(false);
-                await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, ct).ConfigureAwait(false);
+                var embedding = await _embeddingOrchestrator.EmbedEntityAsync(entity.Name, cancellationToken).ConfigureAwait(false);
+                await _entityRepository.UpdateEmbeddingAsync(entity.EntityId, embedding, cancellationToken).ConfigureAwait(false);
                 // Count only nodes actually updated: the repo skips persisting an empty (degraded) embedding,
                 // so a skipped node must not inflate the "nodes updated" return value.
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
@@ -318,18 +318,18 @@ internal sealed class MemoryService : IMemoryService
         return total;
     }
 
-    private async Task<int> BackfillFactEmbeddingsAsync(int batchSize, CancellationToken ct)
+    private async Task<int> BackfillFactEmbeddingsAsync(int batchSize, CancellationToken cancellationToken)
     {
         int total = 0;
         PagedResult<Fact> page;
         do
         {
-            page = await _factRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
+            page = await _factRepository.GetPageWithoutEmbeddingAsync(batchSize, cancellationToken).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var fact in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, ct).ConfigureAwait(false);
-                await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, ct).ConfigureAwait(false);
+                var embedding = await _embeddingOrchestrator.EmbedFactAsync(fact.Subject, fact.Predicate, fact.Object, cancellationToken).ConfigureAwait(false);
+                await _factRepository.UpdateEmbeddingAsync(fact.FactId, embedding, cancellationToken).ConfigureAwait(false);
                 // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }
@@ -341,18 +341,18 @@ internal sealed class MemoryService : IMemoryService
         return total;
     }
 
-    private async Task<int> BackfillPreferenceEmbeddingsAsync(int batchSize, CancellationToken ct)
+    private async Task<int> BackfillPreferenceEmbeddingsAsync(int batchSize, CancellationToken cancellationToken)
     {
         int total = 0;
         PagedResult<Preference> page;
         do
         {
-            page = await _preferenceRepository.GetPageWithoutEmbeddingAsync(batchSize, ct).ConfigureAwait(false);
+            page = await _preferenceRepository.GetPageWithoutEmbeddingAsync(batchSize, cancellationToken).ConfigureAwait(false);
             int embeddedThisPage = 0;
             foreach (var pref in page.Items)
             {
-                var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, ct).ConfigureAwait(false);
-                await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, ct).ConfigureAwait(false);
+                var embedding = await _embeddingOrchestrator.EmbedPreferenceAsync(pref.PreferenceText, cancellationToken).ConfigureAwait(false);
+                await _preferenceRepository.UpdateEmbeddingAsync(pref.PreferenceId, embedding, cancellationToken).ConfigureAwait(false);
                 // Count only nodes actually updated (the repo skips persisting an empty/degraded embedding).
                 if (embedding.Length > 0) { total++; embeddedThisPage++; }
             }

--- a/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Caching/CachedEnrichmentService.cs
@@ -31,7 +31,7 @@ internal sealed class CachedEnrichmentService : IEnrichmentService
     public async Task<EnrichmentResult?> EnrichEntityAsync(
         string entityName,
         string entityType,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         var key = $"enrichment:{_inner.GetType().Name}:{entityName.Trim().ToLowerInvariant()}:{entityType.Trim().ToLowerInvariant()}";
 
@@ -41,7 +41,7 @@ internal sealed class CachedEnrichmentService : IEnrichmentService
             return cached;
         }
 
-        var result = await _inner.EnrichEntityAsync(entityName, entityType, ct).ConfigureAwait(false);
+        var result = await _inner.EnrichEntityAsync(entityName, entityType, cancellationToken).ConfigureAwait(false);
 
         if (result is not null && IsCacheable(result))
         {

--- a/src/AgentMemory.Enrichment/Caching/CachedGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/Caching/CachedGeocodingService.cs
@@ -28,7 +28,7 @@ internal sealed class CachedGeocodingService : IGeocodingService
         _logger = logger;
     }
 
-    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken ct = default)
+    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken cancellationToken = default)
     {
         var key = $"geocoding:{_inner.GetType().Name}:{locationText.Trim().ToLowerInvariant()}";
 
@@ -38,7 +38,7 @@ internal sealed class CachedGeocodingService : IGeocodingService
             return cached;
         }
 
-        var result = await _inner.GeocodeAsync(locationText, ct).ConfigureAwait(false);
+        var result = await _inner.GeocodeAsync(locationText, cancellationToken).ConfigureAwait(false);
 
         if (result is not null)
         {

--- a/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
@@ -63,7 +63,7 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
     public async Task<EnrichmentResult?> EnrichEntityAsync(
         string entityName,
         string entityType,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(entityName))
             return null;
@@ -84,7 +84,7 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
             };
         }
 
-        await ApplyRateLimitAsync(ct).ConfigureAwait(false);
+        await ApplyRateLimitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -100,7 +100,7 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("token", _options.ApiKey);
 
-            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
@@ -145,18 +145,18 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
                 };
             }
 
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var data = JsonNode.Parse(json);
 
             return ParseResponse(data, entityName, entityType);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // genuine caller cancellation
         }
         catch (OperationCanceledException ex)
         {
-            // HttpClient.Timeout fired (caller's ct not cancelled). A timeout is TRANSIENT, so throw rather
+            // HttpClient.Timeout fired (caller's cancellationToken not cancelled). A timeout is TRANSIENT, so throw rather
             // than returning a terminal Error result — otherwise the background queue would count it as a
             // (non-null) success and skip the retry, and the cache would store the poison Error and suppress
             // re-enrichment for the whole cache window. Throwing a non-OCE makes the queue's generic catch
@@ -181,16 +181,16 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
 
     // ---- Private helpers ----
 
-    private async Task ApplyRateLimitAsync(CancellationToken ct)
+    private async Task ApplyRateLimitAsync(CancellationToken cancellationToken)
     {
-        await _rateLock.WaitAsync(ct).ConfigureAwait(false);
+        await _rateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             var elapsed = (DateTimeOffset.UtcNow - _lastRequestTime).TotalSeconds;
             if (elapsed < _options.RateLimitSeconds)
                 await Task.Delay(
                     TimeSpan.FromSeconds(_options.RateLimitSeconds - elapsed),
-                    ct).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
 
             _lastRequestTime = DateTimeOffset.UtcNow;
         }

--- a/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/WikimediaEnrichmentService.cs
@@ -35,7 +35,7 @@ internal sealed class WikimediaEnrichmentService : IEnrichmentService
     public async Task<EnrichmentResult?> EnrichEntityAsync(
         string entityName,
         string entityType,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(entityName))
             return null;
@@ -51,7 +51,7 @@ internal sealed class WikimediaEnrichmentService : IEnrichmentService
             var baseUrl = _options.WikipediaBaseUrl.Replace("{lang}", lang).TrimEnd('/');
             var url = $"{baseUrl}/page/summary/{title}";
 
-            using var response = await client.GetAsync(url, ct).ConfigureAwait(false);
+            using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -66,7 +66,7 @@ internal sealed class WikimediaEnrichmentService : IEnrichmentService
                 return null;
             }
 
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var summary = JsonSerializer.Deserialize<WikipediaSummaryResponse>(json, JsonOptions);
 
             if (summary is null)
@@ -83,13 +83,13 @@ internal sealed class WikimediaEnrichmentService : IEnrichmentService
                 RetrievedAtUtc = DateTimeOffset.UtcNow
             };
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // genuine caller cancellation
         }
         catch (OperationCanceledException ex)
         {
-            // HttpClient.Timeout fired (caller's ct not cancelled). Surface a distinct timeout log; keep
+            // HttpClient.Timeout fired (caller's cancellationToken not cancelled). Surface a distinct timeout log; keep
             // the graceful null contract.
             _logger.LogWarning(ex, "Enrichment request for entity '{EntityName}' timed out", entityName);
             return null;

--- a/src/AgentMemory.Enrichment/Geocoding/NominatimGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/Geocoding/NominatimGeocodingService.cs
@@ -32,7 +32,7 @@ internal sealed class NominatimGeocodingService : IGeocodingService
         _logger = logger;
     }
 
-    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken ct = default)
+    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(locationText))
             return null;
@@ -43,7 +43,7 @@ internal sealed class NominatimGeocodingService : IGeocodingService
             var encodedQuery = Uri.EscapeDataString(locationText);
             var url = $"{_options.BaseUrl.TrimEnd('/')}/search?q={encodedQuery}&format=json&limit=1&addressdetails=1";
 
-            using var response = await client.GetAsync(url, ct).ConfigureAwait(false);
+            using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -52,7 +52,7 @@ internal sealed class NominatimGeocodingService : IGeocodingService
                 return null;
             }
 
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var results = JsonSerializer.Deserialize<NominatimResult[]>(json, JsonOptions);
 
             if (results is null || results.Length == 0)
@@ -81,13 +81,13 @@ internal sealed class NominatimGeocodingService : IGeocodingService
                 Provider = "Nominatim"
             };
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // genuine caller cancellation
         }
         catch (OperationCanceledException ex)
         {
-            // HttpClient.Timeout fired (the caller's ct was NOT cancelled). Surface it as a distinct,
+            // HttpClient.Timeout fired (the caller's cancellationToken was NOT cancelled). Surface it as a distinct,
             // operationally-visible timeout rather than a generic failure indistinguishable from
             // "location not found"; keep the graceful null contract.
             _logger.LogWarning(ex, "Geocoding request for '{LocationText}' timed out", locationText);

--- a/src/AgentMemory.Enrichment/RateLimiting/RateLimitedGeocodingService.cs
+++ b/src/AgentMemory.Enrichment/RateLimiting/RateLimitedGeocodingService.cs
@@ -27,9 +27,9 @@ internal sealed class RateLimitedGeocodingService : IGeocodingService, IDisposab
         _logger = logger;
     }
 
-    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken ct = default)
+    public async Task<GeocodingResult?> GeocodeAsync(string locationText, CancellationToken cancellationToken = default)
     {
-        await _semaphore.WaitAsync(ct).ConfigureAwait(false);
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             var minInterval = TimeSpan.FromSeconds(1.0 / _rateLimitPerSecond);
@@ -39,11 +39,11 @@ internal sealed class RateLimitedGeocodingService : IGeocodingService, IDisposab
             {
                 var delay = minInterval - elapsed;
                 _logger.LogDebug("Rate limiter delaying geocoding request by {DelayMs}ms", delay.TotalMilliseconds);
-                await Task.Delay(delay, ct).ConfigureAwait(false);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
 
             _lastRequestTime = DateTimeOffset.UtcNow;
-            return await _inner.GeocodeAsync(locationText, ct).ConfigureAwait(false);
+            return await _inner.GeocodeAsync(locationText, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageEntityExtractor.cs
@@ -29,7 +29,7 @@ internal sealed class AzureLanguageEntityExtractor : ExtractorBase<ExtractedEnti
     }
 
     protected override async Task<IReadOnlyList<ExtractedEntity>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var allEntities = new List<AzureRecognizedEntity>();
 
@@ -41,7 +41,7 @@ internal sealed class AzureLanguageEntityExtractor : ExtractorBase<ExtractedEnti
                     continue;
 
                 var entities = await _context.GetOrRecognizeEntitiesAsync(
-                    message.Content, _options.DefaultLanguage, _client, ct).ConfigureAwait(false);
+                    message.Content, _options.DefaultLanguage, _client, cancellationToken).ConfigureAwait(false);
                 allEntities.AddRange(entities);
             }
         }

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageFactExtractor.cs
@@ -27,7 +27,7 @@ internal sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>,
     }
 
     protected override async Task<IReadOnlyList<ExtractedFact>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var facts = new List<ExtractedFact>();
 
@@ -36,17 +36,17 @@ internal sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>,
             if (string.IsNullOrWhiteSpace(message.Content))
                 continue;
 
-            await AddKeyPhraseFacts(message, facts, ct).ConfigureAwait(false);
-            await AddLinkedEntityFacts(message, facts, ct).ConfigureAwait(false);
+            await AddKeyPhraseFacts(message, facts, cancellationToken).ConfigureAwait(false);
+            await AddLinkedEntityFacts(message, facts, cancellationToken).ConfigureAwait(false);
         }
 
         return facts;
     }
 
-    private async Task AddKeyPhraseFacts(Message message, List<ExtractedFact> facts, CancellationToken ct)
+    private async Task AddKeyPhraseFacts(Message message, List<ExtractedFact> facts, CancellationToken cancellationToken)
     {
         var keyPhrases = await _client.ExtractKeyPhrasesAsync(
-            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
+            message.Content, _options.DefaultLanguage, cancellationToken).ConfigureAwait(false);
 
         var context = message.Content.Length > 100
             ? message.Content[..100] + "..."
@@ -67,10 +67,10 @@ internal sealed class AzureLanguageFactExtractor : ExtractorBase<ExtractedFact>,
         }
     }
 
-    private async Task AddLinkedEntityFacts(Message message, List<ExtractedFact> facts, CancellationToken ct)
+    private async Task AddLinkedEntityFacts(Message message, List<ExtractedFact> facts, CancellationToken cancellationToken)
     {
         var linkedEntities = await _client.RecognizeLinkedEntitiesAsync(
-            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
+            message.Content, _options.DefaultLanguage, cancellationToken).ConfigureAwait(false);
 
         foreach (var entity in linkedEntities)
         {

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguagePreferenceExtractor.cs
@@ -27,7 +27,7 @@ internal sealed class AzureLanguagePreferenceExtractor : ExtractorBase<Extracted
     }
 
     protected override async Task<IReadOnlyList<ExtractedPreference>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var preferences = new List<ExtractedPreference>();
 
@@ -36,7 +36,7 @@ internal sealed class AzureLanguagePreferenceExtractor : ExtractorBase<Extracted
             if (string.IsNullOrWhiteSpace(message.Content))
                 continue;
 
-            await ExtractPreferencesFromMessage(message, preferences, ct).ConfigureAwait(false);
+            await ExtractPreferencesFromMessage(message, preferences, cancellationToken).ConfigureAwait(false);
         }
 
         return preferences;
@@ -45,13 +45,13 @@ internal sealed class AzureLanguagePreferenceExtractor : ExtractorBase<Extracted
     private async Task ExtractPreferencesFromMessage(
         Message message,
         List<ExtractedPreference> preferences,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
         var sentiment = await _client.AnalyzeSentimentAsync(
-            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
+            message.Content, _options.DefaultLanguage, cancellationToken).ConfigureAwait(false);
 
         var keyPhrases = await _client.ExtractKeyPhrasesAsync(
-            message.Content, _options.DefaultLanguage, ct).ConfigureAwait(false);
+            message.Content, _options.DefaultLanguage, cancellationToken).ConfigureAwait(false);
 
         var stronglyPositive = sentiment.PositiveScore >= _options.PreferenceSentimentThreshold;
         var stronglyNegative = sentiment.NegativeScore >= _options.PreferenceSentimentThreshold;

--- a/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/AzureLanguageRelationshipExtractor.cs
@@ -30,7 +30,7 @@ internal sealed class AzureLanguageRelationshipExtractor : ExtractorBase<Extract
     }
 
     protected override async Task<IReadOnlyList<ExtractedRelationship>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var relationships = new List<ExtractedRelationship>();
 
@@ -40,7 +40,7 @@ internal sealed class AzureLanguageRelationshipExtractor : ExtractorBase<Extract
                 continue;
 
             var entityList = await _context.GetOrRecognizeEntitiesAsync(
-                message.Content, _options.DefaultLanguage, _client, ct).ConfigureAwait(false);
+                message.Content, _options.DefaultLanguage, _client, cancellationToken).ConfigureAwait(false);
 
             for (int i = 0; i < entityList.Count - 1; i++)
             {

--- a/src/AgentMemory.Extraction.AzureLanguage/Internal/AzureExtractionContext.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/Internal/AzureExtractionContext.cs
@@ -13,7 +13,7 @@ internal sealed class AzureExtractionContext
     private readonly ConcurrentDictionary<string, IReadOnlyList<AzureRecognizedEntity>> _entityCache = new();
 
     public async Task<IReadOnlyList<AzureRecognizedEntity>> GetOrRecognizeEntitiesAsync(
-        string content, string? language, ITextAnalyticsClientWrapper client, CancellationToken ct)
+        string content, string? language, ITextAnalyticsClientWrapper client, CancellationToken cancellationToken)
     {
         // The same text analyzed under different languages yields different results, so the
         // cache key must include the language to avoid cross-language collisions.
@@ -22,7 +22,7 @@ internal sealed class AzureExtractionContext
         if (_entityCache.TryGetValue(cacheKey, out var cached))
             return cached;
 
-        var result = await client.RecognizeEntitiesAsync(content, language, ct).ConfigureAwait(false);
+        var result = await client.RecognizeEntitiesAsync(content, language, cancellationToken).ConfigureAwait(false);
         var list = result.ToList();
         _entityCache.TryAdd(cacheKey, list);
         return list;

--- a/src/AgentMemory.Extraction.AzureLanguage/Internal/ITextAnalyticsClientWrapper.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/Internal/ITextAnalyticsClientWrapper.cs
@@ -6,14 +6,14 @@ namespace AgentMemory.Extraction.AzureLanguage.Internal;
 internal interface ITextAnalyticsClientWrapper
 {
     Task<IReadOnlyList<AzureRecognizedEntity>> RecognizeEntitiesAsync(
-        string document, string? language, CancellationToken ct);
+        string document, string? language, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<string>> ExtractKeyPhrasesAsync(
-        string document, string? language, CancellationToken ct);
+        string document, string? language, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<AzureLinkedEntity>> RecognizeLinkedEntitiesAsync(
-        string document, string? language, CancellationToken ct);
+        string document, string? language, CancellationToken cancellationToken);
 
     Task<AzureSentimentResult> AnalyzeSentimentAsync(
-        string document, string? language, CancellationToken ct);
+        string document, string? language, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Extraction.AzureLanguage/Internal/TextAnalyticsClientWrapper.cs
+++ b/src/AgentMemory.Extraction.AzureLanguage/Internal/TextAnalyticsClientWrapper.cs
@@ -12,34 +12,34 @@ internal sealed class TextAnalyticsClientWrapper : ITextAnalyticsClientWrapper
     public TextAnalyticsClientWrapper(TextAnalyticsClient client) => _client = client;
 
     public async Task<IReadOnlyList<AzureRecognizedEntity>> RecognizeEntitiesAsync(
-        string document, string? language, CancellationToken ct)
+        string document, string? language, CancellationToken cancellationToken)
     {
-        var response = await _client.RecognizeEntitiesAsync(document, language, ct).ConfigureAwait(false);
+        var response = await _client.RecognizeEntitiesAsync(document, language, cancellationToken).ConfigureAwait(false);
         return response.Value
             .Select(e => new AzureRecognizedEntity(e.Text, e.Category.ToString(), e.ConfidenceScore, e.SubCategory))
             .ToList();
     }
 
     public async Task<IReadOnlyList<string>> ExtractKeyPhrasesAsync(
-        string document, string? language, CancellationToken ct)
+        string document, string? language, CancellationToken cancellationToken)
     {
-        var response = await _client.ExtractKeyPhrasesAsync(document, language, ct).ConfigureAwait(false);
+        var response = await _client.ExtractKeyPhrasesAsync(document, language, cancellationToken).ConfigureAwait(false);
         return response.Value.ToList();
     }
 
     public async Task<IReadOnlyList<AzureLinkedEntity>> RecognizeLinkedEntitiesAsync(
-        string document, string? language, CancellationToken ct)
+        string document, string? language, CancellationToken cancellationToken)
     {
-        var response = await _client.RecognizeLinkedEntitiesAsync(document, language, ct).ConfigureAwait(false);
+        var response = await _client.RecognizeLinkedEntitiesAsync(document, language, cancellationToken).ConfigureAwait(false);
         return response.Value
             .Select(e => new AzureLinkedEntity(e.Name, e.Url?.ToString()))
             .ToList();
     }
 
     public async Task<AzureSentimentResult> AnalyzeSentimentAsync(
-        string document, string? language, CancellationToken ct)
+        string document, string? language, CancellationToken cancellationToken)
     {
-        var response = await _client.AnalyzeSentimentAsync(document, language, cancellationToken: ct).ConfigureAwait(false);
+        var response = await _client.AnalyzeSentimentAsync(document, language, cancellationToken: cancellationToken).ConfigureAwait(false);
         var doc = response.Value;
         return new AzureSentimentResult(
             doc.Sentiment.ToString().ToLowerInvariant(),

--- a/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmEntityExtractor.cs
@@ -49,7 +49,7 @@ internal sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEnti
     }
 
     protected override async Task<IReadOnlyList<ExtractedEntity>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var conversationText = ConversationTextBuilder.Build(messages);
         return await _runner.RunAsync(
@@ -57,7 +57,7 @@ internal sealed class LlmEntityExtractor : ExtractorBase<ExtractedEntity>, IEnti
             "Extract entities from this conversation:",
             conversationText,
             ProjectEntities,
-            ct).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmFactExtractor.cs
@@ -46,7 +46,7 @@ internal sealed class LlmFactExtractor : ExtractorBase<ExtractedFact>, IFactExtr
     }
 
     protected override async Task<IReadOnlyList<ExtractedFact>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var conversationText = ConversationTextBuilder.Build(messages);
         return await _runner.RunAsync(
@@ -54,7 +54,7 @@ internal sealed class LlmFactExtractor : ExtractorBase<ExtractedFact>, IFactExtr
             "Extract facts from this conversation:",
             conversationText,
             ProjectFacts,
-            ct).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedFact> ProjectFacts(LlmExtractionResponse dto)

--- a/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmPreferenceExtractor.cs
@@ -45,7 +45,7 @@ internal sealed class LlmPreferenceExtractor : ExtractorBase<ExtractedPreference
     }
 
     protected override async Task<IReadOnlyList<ExtractedPreference>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var conversationText = ConversationTextBuilder.Build(messages);
         return await _runner.RunAsync(
@@ -53,7 +53,7 @@ internal sealed class LlmPreferenceExtractor : ExtractorBase<ExtractedPreference
             "Extract preferences from this conversation:",
             conversationText,
             ProjectPreferences,
-            ct).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedPreference> ProjectPreferences(LlmExtractionResponse dto)

--- a/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
+++ b/src/AgentMemory.Extraction.Llm/LlmRelationshipExtractor.cs
@@ -45,7 +45,7 @@ internal sealed class LlmRelationshipExtractor : ExtractorBase<ExtractedRelation
     }
 
     protected override async Task<IReadOnlyList<ExtractedRelationship>> ExtractCoreAsync(
-        IReadOnlyList<Message> messages, CancellationToken ct)
+        IReadOnlyList<Message> messages, CancellationToken cancellationToken)
     {
         var conversationText = ConversationTextBuilder.Build(messages);
         return await _runner.RunAsync(
@@ -53,7 +53,7 @@ internal sealed class LlmRelationshipExtractor : ExtractorBase<ExtractedRelation
             "Extract relationships from this conversation:",
             conversationText,
             ProjectRelationships,
-            ct).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static IReadOnlyList<ExtractedRelationship> ProjectRelationships(LlmExtractionResponse dto)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jConversationRepository.cs
@@ -86,7 +86,7 @@ internal sealed class Neo4jConversationRepository : IConversationRepository
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<SessionSummary>> ListSessionsAsync(int limit = 50, CancellationToken ct = default)
+    public async Task<IReadOnlyList<SessionSummary>> ListSessionsAsync(int limit = 50, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Listing sessions, limit={Limit}", limit);
 
@@ -105,7 +105,7 @@ internal sealed class Neo4jConversationRepository : IConversationRepository
                     : null;
                 return new SessionSummary(sessionId, convCount, msgCount, lastPreview, lastActivity);
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Conversation MapToConversation(INode node) =>

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -616,7 +616,7 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Similarity)>> FindSimilarByEmbeddingAsync(
-        string entityId, double minSimilarity = 0.85, int limit = 10, MemoryScope? scope = null, CancellationToken ct = default)
+        string entityId, double minSimilarity = 0.85, int limit = 10, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
@@ -639,11 +639,11 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
                 var score = r["score"].As<double>();
                 return (MapToEntity(node, ReadEmbedding(node)), score);
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<DuplicatePair>> GetPendingDuplicatesAsync(
-        int limit = 50, CancellationToken ct = default)
+        int limit = 50, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting pending duplicate pairs, limit={Limit}", limit);
 
@@ -659,10 +659,10 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
                 // This API returns only pending pairs — GetPendingDuplicates hard-filters status: 'pending'.
                 return new DuplicatePair(source, target, similarity, DuplicateStatus.Pending);
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<DeduplicationStats> GetDeduplicationStatsAsync(CancellationToken ct = default)
+    public async Task<DeduplicationStats> GetDeduplicationStatsAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting deduplication stats");
 
@@ -679,11 +679,11 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
                 ConfirmedCount: record["confirmed"].As<int>(),
                 RejectedCount: record["rejected"].As<int>(),
                 MergedCount: record["merged"].As<int>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Entity>> GetEntitiesFromMessageAsync(
-        string messageId, CancellationToken ct = default)
+        string messageId, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting entities from message {MessageId}", messageId);
 
@@ -696,7 +696,7 @@ internal sealed class Neo4jEntityRepository : IEntityRepository
                 var node = r["e"].As<INode>();
                 return MapToEntity(node, ReadEmbedding(node));
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<(Entity Entity, double Score)>> SearchByVectorAsOfAsync(

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jExtractorRepository.cs
@@ -27,7 +27,7 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
     }
 
     /// <inheritdoc />
-    public async Task<Extractor> UpsertAsync(Extractor extractor, CancellationToken ct = default)
+    public async Task<Extractor> UpsertAsync(Extractor extractor, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Upserting extractor {Name}", extractor.Name);
 
@@ -44,11 +44,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
             if (records.Count > 0)
                 return MapToExtractor(records[0]["ex"].As<INode>());
             return extractor;
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<Extractor?> GetByNameAsync(string name, CancellationToken ct = default)
+    public async Task<Extractor?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting extractor by name {Name}", name);
 
@@ -58,11 +58,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             if (records.Count == 0) return null;
             return MapToExtractor(records[0]["ex"].As<INode>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<Extractor>> ListAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<Extractor>> ListAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Listing all extractors");
 
@@ -71,7 +71,7 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
             var cursor = await runner.RunAsync(ExtractorQueries.List, new { }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Select(r => MapToExtractor(r["ex"].As<INode>())).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -80,7 +80,7 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
         string extractorName,
         double confidence,
         int? extractionTimeMs = null,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Creating EXTRACTED_BY: Entity {EntityId} -> Extractor {Extractor}", entityId, extractorName);
 
@@ -93,14 +93,14 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
                 confidence,
                 extraction_time_ms = (object?)extractionTimeMs
             }).ConfigureAwait(false);
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<(Entity Entity, double Confidence)>> GetEntitiesByExtractorAsync(
         string extractorName,
         int limit = 100,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting entities by extractor {Extractor}, limit={Limit}", extractorName, limit);
 
@@ -114,11 +114,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
                 var conf = r["confidence"].As<double>();
                 return (MapToEntity(node), conf);
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<EntityProvenance?> GetProvenanceAsync(string entityId, MemoryScope? scope = null, CancellationToken ct = default)
+    public async Task<EntityProvenance?> GetProvenanceAsync(string entityId, MemoryScope? scope = null, CancellationToken cancellationToken = default)
     {
         bool hasOwner = scope?.HasOwnerFilter == true;
         bool includeShared = scope?.IncludeShared ?? true;
@@ -158,11 +158,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
                 .ToList();
 
             return new EntityProvenance(id, sources, extractors);
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<ExtractionStats> GetExtractionStatsAsync(CancellationToken ct = default)
+    public async Task<ExtractionStats> GetExtractionStatsAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting extraction stats");
 
@@ -177,11 +177,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
                 record["totalEntities"].As<int>(),
                 record["totalMessages"].As<int>(),
                 record["avgPerMessage"].As<double>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<ExtractorStats?> GetExtractorStatsAsync(string extractorName, CancellationToken ct = default)
+    public async Task<ExtractorStats?> GetExtractorStatsAsync(string extractorName, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting stats for extractor {Extractor}", extractorName);
 
@@ -200,11 +200,11 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
                 record["entityCount"].As<int>(),
                 record["avgConfidence"] is not null ? record["avgConfidence"].As<double>() : 0.0,
                 record["totalExtractions"].As<int>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<int> DeleteProvenanceAsync(string entityId, CancellationToken ct = default)
+    public async Task<int> DeleteProvenanceAsync(string entityId, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Deleting provenance for entity {EntityId}", entityId);
 
@@ -213,7 +213,7 @@ internal sealed class Neo4jExtractorRepository : IExtractorRepository
             var cursor = await runner.RunAsync(ExtractorQueries.DeleteEntityProvenance, new { entityId }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 ? records[0]["deleted"].As<int>() : 0;
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static Extractor MapToExtractor(INode node)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jMessageRepository.cs
@@ -242,7 +242,7 @@ internal sealed class Neo4jMessageRepository : IMessageRepository
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<bool> DeleteAsync(string messageId, bool cascade = true, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(string messageId, bool cascade = true, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Deleting message {Id}, cascade={Cascade}", messageId, cascade);
 
@@ -252,7 +252,7 @@ internal sealed class Neo4jMessageRepository : IMessageRepository
             var cursor = await runner.RunAsync(query, new { id = messageId }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<Message>> GetRecentBySessionAsOfAsync(

--- a/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConflictDetectionService.cs
@@ -125,7 +125,7 @@ internal sealed class Neo4jConflictDetectionService : IConflictDetectionService
     }
 
     private Task<IReadOnlyList<FactConflict>> DetectFactContradictionsAsync(
-        ConflictDetectionOptions opts, CancellationToken ct) =>
+        ConflictDetectionOptions opts, CancellationToken cancellationToken) =>
         _tx.ReadAsync(async runner =>
         {
             var parameters = new Dictionary<string, object?>
@@ -154,5 +154,5 @@ internal sealed class Neo4jConflictDetectionService : IConflictDetectionService
                     ownerKey == "*" ? null : ownerKey,
                     members);
             }).ToList();
-        }, ct);
+        }, cancellationToken);
 }

--- a/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jConsolidationService.cs
@@ -95,23 +95,23 @@ internal sealed class Neo4jConsolidationService : IConsolidationService
         return report;
     }
 
-    private Task<int> ReadCountAsync(string cypher, object parameters, CancellationToken ct) =>
+    private Task<int> ReadCountAsync(string cypher, object parameters, CancellationToken cancellationToken) =>
         _tx.ReadAsync(async runner =>
         {
             var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
             var record = await cursor.SingleAsync().ConfigureAwait(false);
             return record["count"].As<int>();
-        }, ct);
+        }, cancellationToken);
 
-    private Task<int> WriteCountAsync(string cypher, object parameters, CancellationToken ct) =>
+    private Task<int> WriteCountAsync(string cypher, object parameters, CancellationToken cancellationToken) =>
         _tx.WriteAsync(async runner =>
         {
             var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
             var record = await cursor.SingleAsync().ConfigureAwait(false);
             return record["count"].As<int>();
-        }, ct);
+        }, cancellationToken);
 
-    private Task RecordRunAsync(ConsolidationReport report, DateTimeOffset ranAt, CancellationToken ct) =>
+    private Task RecordRunAsync(ConsolidationReport report, DateTimeOffset ranAt, CancellationToken cancellationToken) =>
         _tx.WriteAsync(async runner =>
         {
             await runner.RunAsync(ConsolidationQueries.RecordConsolidationRun, new
@@ -123,5 +123,5 @@ internal sealed class Neo4jConsolidationService : IConsolidationService
                 duplicateEntities = report.DuplicateEntitiesDetected,
                 longTraceCandidates = report.LongTraceCandidates,
             }).ConfigureAwait(false);
-        }, ct);
+        }, cancellationToken);
 }

--- a/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
+++ b/src/AgentMemory.Neo4j/Services/Neo4jSchemaManager.cs
@@ -36,29 +36,29 @@ internal sealed class Neo4jSchemaManager : ISchemaManager
     }
 
     /// <inheritdoc />
-    public async Task<EntitySchemaConfig?> LoadSchemaAsync(string name, CancellationToken ct = default)
+    public async Task<EntitySchemaConfig?> LoadSchemaAsync(string name, CancellationToken cancellationToken = default)
     {
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadActiveByName, new { name }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count == 0 ? null : MapToConfig(records[0]["s"].As<INode>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<EntitySchemaConfig?> LoadSchemaVersionAsync(string name, string version, CancellationToken ct = default)
+    public async Task<EntitySchemaConfig?> LoadSchemaVersionAsync(string name, string version, CancellationToken cancellationToken = default)
     {
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = await runner.RunAsync(SchemaPersistenceQueries.LoadByNameVersion, new { name, version }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count == 0 ? null : MapToConfig(records[0]["s"].As<INode>());
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task SaveSchemaAsync(EntitySchemaConfig schema, string? createdBy = null, bool setActive = true, CancellationToken ct = default)
+    public async Task SaveSchemaAsync(EntitySchemaConfig schema, string? createdBy = null, bool setActive = true, CancellationToken cancellationToken = default)
     {
         var id = _idGenerator.GenerateId();
         var createdAtUtc = _clock.UtcNow.ToString("O");
@@ -82,13 +82,13 @@ internal sealed class Neo4jSchemaManager : ISchemaManager
                 createdAtUtc,
                 createdBy = (object?)createdBy
             }).ConfigureAwait(false);
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug("Saved schema {Name} v{Version} (active={Active})", schema.Name, schema.Version, setActive);
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<SchemaListItem>> ListSchemasAsync(string? nameFilter = null, CancellationToken ct = default)
+    public async Task<IReadOnlyList<SchemaListItem>> ListSchemasAsync(string? nameFilter = null, CancellationToken cancellationToken = default)
     {
         return await _tx.ReadAsync(async runner =>
         {
@@ -102,29 +102,29 @@ internal sealed class Neo4jSchemaManager : ISchemaManager
                 VersionCount = r["versionCount"].As<int>(),
                 IsActive = r["isActive"].As<bool>()
             }).ToList();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<bool> SchemaExistsAsync(string name, CancellationToken ct = default)
+    public async Task<bool> SchemaExistsAsync(string name, CancellationToken cancellationToken = default)
     {
         return await _tx.ReadAsync(async runner =>
         {
             var cursor = await runner.RunAsync(SchemaPersistenceQueries.Exists, new { name }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["exists"].As<bool>();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<bool> DeleteSchemaAsync(string schemaId, CancellationToken ct = default)
+    public async Task<bool> DeleteSchemaAsync(string schemaId, CancellationToken cancellationToken = default)
     {
         return await _tx.WriteAsync(async runner =>
         {
             var cursor = await runner.RunAsync(SchemaPersistenceQueries.DeleteById, new { id = schemaId }).ConfigureAwait(false);
             var records = await cursor.ToListAsync().ConfigureAwait(false);
             return records.Count > 0 && records[0]["deleted"].As<bool>();
-        }, ct).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static EntitySchemaConfig MapToConfig(INode node)

--- a/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
+++ b/src/AgentMemory.Observability/InstrumentedEnrichmentService.cs
@@ -21,7 +21,7 @@ internal sealed class InstrumentedEnrichmentService : IEnrichmentService
     public async Task<EnrichmentResult?> EnrichEntityAsync(
         string entityName,
         string entityType,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.enrichment");
         activity?.SetTag("memory.enrichment.entity_name", entityName);
@@ -30,7 +30,7 @@ internal sealed class InstrumentedEnrichmentService : IEnrichmentService
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.EnrichEntityAsync(entityName, entityType, ct).ConfigureAwait(false);
+            var result = await _inner.EnrichEntityAsync(entityName, entityType, cancellationToken).ConfigureAwait(false);
             _metrics.EnrichmentRequests.Add(1);
 
             // Providers (e.g. Diffbot) return a status-bearing result instead of throwing, so a non-null

--- a/src/AgentMemory.SemanticKernel/Neo4jTextSearch.cs
+++ b/src/AgentMemory.SemanticKernel/Neo4jTextSearch.cs
@@ -65,14 +65,14 @@ public sealed class Neo4jTextSearch : ITextSearch<TextSearchResult>
         return new KernelSearchResults<TextSearchResult>(BuildTextSearchResults(result.Context, cancellationToken), result.TotalItemsRetrieved);
     }
 
-    private async Task<RecallResult> RecallAsync(string query, CancellationToken ct)
+    private async Task<RecallResult> RecallAsync(string query, CancellationToken cancellationToken)
     {
         try
         {
             return await _memoryService.RecallAsync(
-                new RecallRequest { SessionId = _sessionId, UserId = _userId, Query = query }, ct).ConfigureAwait(false);
+                new RecallRequest { SessionId = _sessionId, UserId = _userId, Query = query }, cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             // Honor cancellation — do not mask it as an empty result.
             throw;
@@ -89,36 +89,36 @@ public sealed class Neo4jTextSearch : ITextSearch<TextSearchResult>
 
     private static async IAsyncEnumerable<string> YieldSingle(
         string value,
-        [EnumeratorCancellation] CancellationToken ct)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ct.ThrowIfCancellationRequested();
+        cancellationToken.ThrowIfCancellationRequested();
         await Task.CompletedTask.ConfigureAwait(false);
         yield return value;
     }
 
     private static async IAsyncEnumerable<TextSearchResult> BuildTextSearchResults(
         MemoryContext ctx,
-        [EnumeratorCancellation] CancellationToken ct)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await Task.CompletedTask.ConfigureAwait(false);
         foreach (var msg in ctx.RecentMessages.Items.Concat(ctx.RelevantMessages.Items))
         {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             yield return new TextSearchResult(msg.Content) { Name = msg.Role };
         }
         foreach (var entity in ctx.RelevantEntities.Items)
         {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             yield return new TextSearchResult(entity.Description ?? entity.Name) { Name = entity.Name };
         }
         foreach (var fact in ctx.RelevantFacts.Items)
         {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             yield return new TextSearchResult($"{fact.Subject} {fact.Predicate} {fact.Object}") { Name = fact.Subject };
         }
         foreach (var pref in ctx.RelevantPreferences.Items)
         {
-            ct.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
             yield return new TextSearchResult(pref.PreferenceText) { Name = pref.Category };
         }
     }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
@@ -200,7 +200,7 @@ public sealed class Neo4jChatMessageStoreTests
         _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
-        var act = async () => await _sut.GetMessagesAsync("s1", ct: cts.Token);
+        var act = async () => await _sut.GetMessagesAsync("s1", cancellationToken: cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMicrosoftMemoryFacadeTests.cs
@@ -189,7 +189,7 @@ public sealed class Neo4jMicrosoftMemoryFacadeTests
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         var messages = new List<ChatMessage> { new(ChatRole.User, "find relevant history") };
-        var act = async () => await _sut.GetContextForRunAsync(messages, "s1", "c1", ct: cts.Token);
+        var act = async () => await _sut.GetContextForRunAsync(messages, "s1", "c1", cancellationToken: cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
@@ -227,7 +227,7 @@ public sealed class Neo4jMicrosoftMemoryFacadeTests
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         var messages = new List<ChatMessage> { new(ChatRole.User, "Hello") };
-        var act = async () => await _sut.PersistAfterRunAsync(messages, "s1", "c1", ct: cts.Token);
+        var act = async () => await _sut.PersistAfterRunAsync(messages, "s1", "c1", cancellationToken: cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }

--- a/tests/AgentMemory.Tests.Unit/Enrichment/DiffbotEnrichmentServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/DiffbotEnrichmentServiceTests.cs
@@ -227,7 +227,7 @@ public sealed class DiffbotEnrichmentServiceTests
     [Fact]
     public async Task EnrichEntity_Timeout_ThrowsTimeoutException_ForRetryability()
     {
-        // cycle-6: an HttpClient.Timeout arrives as a TaskCanceledException with the caller's ct NOT
+        // cycle-6: an HttpClient.Timeout arrives as a TaskCanceledException with the caller's cancellationToken NOT
         // cancelled. It must be treated as TRANSIENT — thrown, not returned as a terminal Error — so the
         // background queue retries it and the cache doesn't store a poison Error that suppresses re-enrichment.
         var handler = new ThrowingHttpMessageHandler(new TaskCanceledException("Request timed out"));

--- a/tests/AgentMemory.Tests.Unit/Enrichment/NominatimGeocodingServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/NominatimGeocodingServiceTests.cs
@@ -151,7 +151,7 @@ public sealed class NominatimGeocodingServiceTests
     [Fact]
     public async Task Geocode_Timeout_ReturnsNull_DoesNotThrow()
     {
-        // cycle-6: an HttpClient.Timeout (TaskCanceledException with the caller's ct NOT cancelled) must
+        // cycle-6: an HttpClient.Timeout (TaskCanceledException with the caller's cancellationToken NOT cancelled) must
         // degrade gracefully to null — NOT propagate as an exception, and NOT be confused with a genuine
         // caller cancellation (which still throws, see Geocode_CancellationToken_Honored).
         var httpClient = new HttpClient(new ThrowingHandler(new TaskCanceledException("timed out")));

--- a/tests/AgentMemory.Tests.Unit/Extraction/ExtractorBaseCancellationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/ExtractorBaseCancellationTests.cs
@@ -16,7 +16,7 @@ public sealed class ExtractorBaseCancellationTests
         private readonly Exception _toThrow;
         public CoreThrows(Exception toThrow) : base(NullLogger.Instance) => _toThrow = toThrow;
         protected override Task<IReadOnlyList<ExtractedEntity>> ExtractCoreAsync(
-            IReadOnlyList<Message> messages, CancellationToken ct) => throw _toThrow;
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken) => throw _toThrow;
     }
 
     private static IReadOnlyList<Message> OneMessage() => new[]
@@ -55,7 +55,7 @@ public sealed class ExtractorBaseCancellationTests
     public async Task ExtractAsync_SpuriousCancellation_WithUncancelledToken_DegradesToEmpty()
     {
         // An OperationCanceledException whose token is NOT cancellation-requested (e.g. a client-side HTTP
-        // timeout) is a failure to degrade, not a caller cancellation — the `when (ct.IsCancellationRequested)`
+        // timeout) is a failure to degrade, not a caller cancellation — the `when (cancellationToken.IsCancellationRequested)`
         // filter must let it fall through to the resilient empty path.
         var sut = new CoreThrows(new OperationCanceledException());
 

--- a/tools/AgentMemory.TckBridge/BridgeAdmin.cs
+++ b/tools/AgentMemory.TckBridge/BridgeAdmin.cs
@@ -20,11 +20,11 @@ internal sealed class BridgeAdmin
     }
 
     /// <summary>Deletes every node and relationship in the configured store database.</summary>
-    public async Task WipeAllDataAsync(CancellationToken ct = default)
+    public async Task WipeAllDataAsync(CancellationToken cancellationToken = default)
     {
         // Uses the resolved store-tier session (honors Neo4jOptions.Database) rather than a bare
         // driver session, so the wipe targets the same database the rest of the bridge writes to.
         await using var session = _sessionFactory.OpenSession(AccessMode.Write);
-        await session.RunAsync("MATCH (n) DETACH DELETE n").WaitAsync(ct).ConfigureAwait(false);
+        await session.RunAsync("MATCH (n) DETACH DELETE n").WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tools/AgentMemory.TckBridge/Program.cs
+++ b/tools/AgentMemory.TckBridge/Program.cs
@@ -66,24 +66,24 @@ var app = builder.Build();
 
 // ---- Bronze endpoints ----
 
-app.MapPost("/setup", async (ISchemaBootstrapper bootstrapper, INeo4jSessionFactory sessionFactory, CancellationToken ct) =>
+app.MapPost("/setup", async (ISchemaBootstrapper bootstrapper, INeo4jSessionFactory sessionFactory, CancellationToken cancellationToken) =>
 {
-    await bootstrapper.BootstrapAsync(ct).ConfigureAwait(false);
-    await WaitForVectorIndexesOnlineAsync(sessionFactory, ct).ConfigureAwait(false);
+    await bootstrapper.BootstrapAsync(cancellationToken).ConfigureAwait(false);
+    await WaitForVectorIndexesOnlineAsync(sessionFactory, cancellationToken).ConfigureAwait(false);
     // Bridge protocol: /setup returns {"ok": true} (the runner reads result.get("ok", True)); matches
     // the upstream C# reference conformance server's shape.
     return Results.Ok(new { ok = true });
 });
 
-app.MapPost("/teardown", async (BridgeAdmin admin, CancellationToken ct) =>
+app.MapPost("/teardown", async (BridgeAdmin admin, CancellationToken cancellationToken) =>
 {
-    await admin.WipeAllDataAsync(ct).ConfigureAwait(false);
+    await admin.WipeAllDataAsync(cancellationToken).ConfigureAwait(false);
     return Results.NoContent();
 });
 
-app.MapPost("/clear_all_data", async (BridgeAdmin admin, CancellationToken ct) =>
+app.MapPost("/clear_all_data", async (BridgeAdmin admin, CancellationToken cancellationToken) =>
 {
-    await admin.WipeAllDataAsync(ct).ConfigureAwait(false);
+    await admin.WipeAllDataAsync(cancellationToken).ConfigureAwait(false);
     return Results.NoContent();
 });
 
@@ -94,17 +94,17 @@ app.MapPost("/add_message", async (
     IIdGenerator idGenerator,
     IClock clock,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // Upstream auto-creates/reuses one conversation per session (Bronze assumption); the server
     // assigns both the conversation id (on first message) and the message id + timestamp.
-    var conversations = await conversationRepo.GetBySessionAsync(req.SessionId, ct).ConfigureAwait(false);
+    var conversations = await conversationRepo.GetBySessionAsync(req.SessionId, cancellationToken).ConfigureAwait(false);
     var conversation = conversations.Count > 0 ? conversations[0] : null;
     string conversationId;
     if (conversation is null)
     {
         conversationId = idGenerator.GenerateId();
-        await shortTerm.AddConversationAsync(conversationId, req.SessionId, userId: null, metadata: null, ct)
+        await shortTerm.AddConversationAsync(conversationId, req.SessionId, userId: null, metadata: null, cancellationToken)
             .ConfigureAwait(false);
     }
     else
@@ -112,7 +112,7 @@ app.MapPost("/add_message", async (
         conversationId = conversation.ConversationId;
     }
 
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Content, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Content, cancellationToken).ConfigureAwait(false);
     var message = new Message
     {
         MessageId = idGenerator.GenerateId(),
@@ -124,7 +124,7 @@ app.MapPost("/add_message", async (
         Embedding = embedding,
         Metadata = req.Metadata ?? new Dictionary<string, object>(),
     };
-    var saved = await shortTerm.AddMessageAsync(message, ct).ConfigureAwait(false);
+    var saved = await shortTerm.AddMessageAsync(message, cancellationToken).ConfigureAwait(false);
     return Results.Ok(ToDto(saved));
 });
 
@@ -132,13 +132,13 @@ app.MapPost("/get_conversation", async (
     GetConversationRequest req,
     IConversationRepository conversationRepo,
     IShortTermMemoryService shortTerm,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var conversations = await conversationRepo.GetBySessionAsync(req.SessionId, ct).ConfigureAwait(false);
+    var conversations = await conversationRepo.GetBySessionAsync(req.SessionId, cancellationToken).ConfigureAwait(false);
     var conversation = conversations.Count > 0 ? conversations[0] : null;
 
     // Chronological (oldest-first), no cap — NOT GetRecentMessagesAsync, which is newest-first.
-    IReadOnlyList<Message> messages = await shortTerm.GetAllSessionMessagesAsync(req.SessionId, ct)
+    IReadOnlyList<Message> messages = await shortTerm.GetAllSessionMessagesAsync(req.SessionId, cancellationToken)
         .ConfigureAwait(false);
     if (req.Limit is int limit)
         messages = messages.Take(limit).ToList();
@@ -162,12 +162,12 @@ app.MapPost("/search_messages", async (
     SearchMessagesRequest req,
     IShortTermMemoryService shortTerm,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, cancellationToken).ConfigureAwait(false);
     var limit = req.Limit ?? 10;
     var minScore = req.Threshold ?? 0.7;
-    var results = await shortTerm.SearchMessagesAsync(req.SessionId, embedding, limit, minScore, ct)
+    var results = await shortTerm.SearchMessagesAsync(req.SessionId, embedding, limit, minScore, cancellationToken)
         .ConfigureAwait(false);
     return Results.Ok(results.Select(ToDto).ToList());
 });
@@ -175,17 +175,17 @@ app.MapPost("/search_messages", async (
 app.MapPost("/list_sessions", async (
     ListSessionsRequest req,
     IConversationRepository conversationRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     var limit = req.Limit ?? 100;
-    var sessions = await conversationRepo.ListSessionsAsync(limit, ct).ConfigureAwait(false);
+    var sessions = await conversationRepo.ListSessionsAsync(limit, cancellationToken).ConfigureAwait(false);
     return Results.Ok(sessions.Select(ToSessionDto).ToList());
 });
 
 app.MapPost("/delete_message", async (
     DeleteMessageRequest req,
     IMessageRepository messageRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // delete_message returns {"deleted": bool} — the confirmed contract: bridge-protocol.adoc's wire
     // spec names a "deleted" field and the TCK runner reads result.get("deleted", False)
@@ -194,19 +194,19 @@ app.MapPost("/delete_message", async (
     // form, while IIdGenerator stores them as unhyphenated 32-char hex ("N" format). Normalize the
     // incoming id to the stored format so the lookup matches regardless of hyphenation.
     var messageId = Guid.TryParse(req.MessageId, out var parsed) ? parsed.ToString("N") : req.MessageId;
-    var deleted = await messageRepo.DeleteAsync(messageId, cascade: true, ct).ConfigureAwait(false);
+    var deleted = await messageRepo.DeleteAsync(messageId, cascade: true, cancellationToken).ConfigureAwait(false);
     return Results.Ok(new { deleted });
 });
 
 app.MapPost("/clear_session", async (
     ClearSessionRequest req,
     IShortTermMemoryService shortTerm,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // Owner-agnostic by design: messages/conversations carry no owner_id in .NET (only reasoning
     // traces do), so ownerId stays null rather than weakening owner scoping to satisfy an upstream
     // assumption that has no .NET equivalent (see plan §5, intentional divergence).
-    await shortTerm.ClearSessionAsync(req.SessionId, ownerId: null, ct).ConfigureAwait(false);
+    await shortTerm.ClearSessionAsync(req.SessionId, ownerId: null, cancellationToken).ConfigureAwait(false);
     return Results.NoContent();
 });
 
@@ -221,9 +221,9 @@ app.MapPost("/add_entity", async (
     IIdGenerator idGenerator,
     IClock clock,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, $"{req.Name} {req.Description}".Trim(), ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, $"{req.Name} {req.Description}".Trim(), cancellationToken).ConfigureAwait(false);
     var entity = await longTerm.AddEntityAsync(new Entity
     {
         EntityId = idGenerator.GenerateId(),
@@ -233,7 +233,7 @@ app.MapPost("/add_entity", async (
         Confidence = 1.0,
         Embedding = embedding,
         CreatedAtUtc = clock.UtcNow,
-    }, ct).ConfigureAwait(false);
+    }, cancellationToken).ConfigureAwait(false);
     return Results.Ok(new TckEntity(
         entity.EntityId, entity.Name, entity.Type, entity.Subtype, entity.Description,
         entity.Embedding, entity.CanonicalName, entity.CreatedAtUtc));
@@ -245,9 +245,9 @@ app.MapPost("/add_preference", async (
     IIdGenerator idGenerator,
     IClock clock,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Preference, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Preference, cancellationToken).ConfigureAwait(false);
     var preference = await longTerm.AddPreferenceAsync(new Preference
     {
         PreferenceId = idGenerator.GenerateId(),
@@ -257,7 +257,7 @@ app.MapPost("/add_preference", async (
         Confidence = 1.0,
         Embedding = embedding,
         CreatedAtUtc = clock.UtcNow,
-    }, ct).ConfigureAwait(false);
+    }, cancellationToken).ConfigureAwait(false);
     return Results.Ok(new TckPreference(
         preference.PreferenceId, preference.Category, preference.PreferenceText,
         preference.Context, preference.Embedding));
@@ -269,9 +269,9 @@ app.MapPost("/add_fact", async (
     IIdGenerator idGenerator,
     IClock clock,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, $"{req.Subject} {req.Predicate} {req.Obj}", ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, $"{req.Subject} {req.Predicate} {req.Obj}", cancellationToken).ConfigureAwait(false);
     var fact = await longTerm.AddFactAsync(new Fact
     {
         FactId = idGenerator.GenerateId(),
@@ -281,7 +281,7 @@ app.MapPost("/add_fact", async (
         Confidence = 1.0,
         Embedding = embedding,
         CreatedAtUtc = clock.UtcNow,
-    }, ct).ConfigureAwait(false);
+    }, cancellationToken).ConfigureAwait(false);
     return Results.Ok(new TckFact(fact.FactId, fact.Subject, fact.Predicate, fact.Object, fact.Embedding));
 });
 
@@ -297,11 +297,11 @@ app.MapPost("/search_entities", async (
     SearchEntitiesRequest req,
     ILongTermMemoryService longTerm,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, cancellationToken).ConfigureAwait(false);
     var limit = req.Limit ?? 10;
-    var results = await longTerm.SearchEntitiesAsync(embedding, limit, minScore: 0.0, scope: sharedScope, ct)
+    var results = await longTerm.SearchEntitiesAsync(embedding, limit, minScore: 0.0, scope: sharedScope, cancellationToken)
         .ConfigureAwait(false);
     return Results.Ok(results.Select(ToEntityDto).ToList());
 });
@@ -310,11 +310,11 @@ app.MapPost("/search_preferences", async (
     SearchPreferencesRequest req,
     ILongTermMemoryService longTerm,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Query, cancellationToken).ConfigureAwait(false);
     var limit = req.Limit ?? 10;
-    var results = await longTerm.SearchPreferencesAsync(embedding, limit, minScore: 0.0, scope: sharedScope, ct)
+    var results = await longTerm.SearchPreferencesAsync(embedding, limit, minScore: 0.0, scope: sharedScope, cancellationToken)
         .ConfigureAwait(false);
     // Category is applied as a post-search filter (not a separate category-only lookup) so /search_preferences
     // stays a single semantic-search call, matching the bridge-protocol shape (query + optional category).
@@ -326,9 +326,9 @@ app.MapPost("/search_preferences", async (
 app.MapPost("/get_entity_by_name", async (
     GetEntityByNameRequest req,
     ILongTermMemoryService longTerm,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var entities = await longTerm.GetEntitiesByNameAsync(req.Name, includeAliases: true, scope: sharedScope, ct)
+    var entities = await longTerm.GetEntitiesByNameAsync(req.Name, includeAliases: true, scope: sharedScope, cancellationToken)
         .ConfigureAwait(false);
     // TCK contract: Entity or null (SPEC-3.6.2). GetEntitiesByNameAsync can return several rows (exact-name
     // plus alias matches) and its Cypher defines no order, so entities[0] would be nondeterministic when
@@ -345,7 +345,7 @@ app.MapPost("/get_related_entities", async (
     GetRelatedEntitiesRequest req,
     ILongTermMemoryService longTerm,
     IEntityRepository entityRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // ILongTermMemoryService has no "related entities" method — GetEntityRelationshipsAsync (the closest
     // graph-traversal primitive) returns Relationship edges (source/target ids), not the entities themselves,
@@ -363,7 +363,7 @@ app.MapPost("/get_related_entities", async (
         var nextFrontier = new HashSet<string>();
         foreach (var id in frontier)
         {
-            var relationships = await longTerm.GetEntityRelationshipsAsync(id, scope: sharedScope, ct).ConfigureAwait(false);
+            var relationships = await longTerm.GetEntityRelationshipsAsync(id, scope: sharedScope, cancellationToken).ConfigureAwait(false);
             foreach (var rel in relationships)
             {
                 if (req.RelationshipType is { Length: > 0 } && rel.RelationshipType != req.RelationshipType)
@@ -382,7 +382,7 @@ app.MapPost("/get_related_entities", async (
     var related = new List<Entity>(relatedIds.Count);
     foreach (var id in relatedIds)
     {
-        var entity = await entityRepo.GetByIdAsync(id, ct).ConfigureAwait(false);
+        var entity = await entityRepo.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
         // GetByIdAsync is unscoped; keep only shared-bucket entities so a shared relationship that happens to
         // point at an owned entity can't leak it (defense-in-depth alongside the shared-scope traversal above
         // and the add_relationship guard below).
@@ -401,7 +401,7 @@ app.MapPost("/add_relationship", async (
     IEntityRepository entityRepo,
     IIdGenerator idGenerator,
     IClock clock,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     var sourceId = NormalizeId(req.SourceId);
     var targetId = NormalizeId(req.TargetId);
@@ -410,7 +410,7 @@ app.MapPost("/add_relationship", async (
     // either endpoint already exists and is NOT shared.
     foreach (var (label, id) in new[] { ("source_id", sourceId), ("target_id", targetId) })
     {
-        var existing = await entityRepo.GetByIdAsync(id, ct).ConfigureAwait(false);
+        var existing = await entityRepo.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
         if (existing is { OwnerId: not null })
             return Results.BadRequest(new { error = $"{label} references a non-shared entity" });
     }
@@ -423,7 +423,7 @@ app.MapPost("/add_relationship", async (
         Confidence = 1.0,
         Attributes = req.Properties ?? new Dictionary<string, object>(),
         CreatedAtUtc = clock.UtcNow,
-    }, ct).ConfigureAwait(false);
+    }, cancellationToken).ConfigureAwait(false);
     return Results.Ok(new TckRelationship(
         relationship.RelationshipId, relationship.SourceEntityId, relationship.TargetEntityId,
         relationship.RelationshipType, relationship.Attributes));
@@ -435,7 +435,7 @@ app.MapPost("/add_relationship", async (
 app.MapPost("/merge_duplicate_entities", async (
     MergeDuplicateEntitiesRequest req,
     IEntityRepository entityRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     var sourceId = NormalizeId(req.SourceId);
     var targetId = NormalizeId(req.TargetId);
@@ -446,22 +446,22 @@ app.MapPost("/merge_duplicate_entities", async (
     // Owner-isolation guard (mirrors add_relationship): the scoped MergeEntitiesAsync already no-ops across
     // the isolation boundary, but reject up-front with a clear error if either endpoint is a non-shared
     // (owned) entity, and 404 if either is missing — a merge needs both sides to exist.
-    var source = await entityRepo.GetByIdAsync(sourceId, ct).ConfigureAwait(false);
-    var target = await entityRepo.GetByIdAsync(targetId, ct).ConfigureAwait(false);
+    var source = await entityRepo.GetByIdAsync(sourceId, cancellationToken).ConfigureAwait(false);
+    var target = await entityRepo.GetByIdAsync(targetId, cancellationToken).ConfigureAwait(false);
     if (source is null || target is null)
         return Results.NotFound(new { error = "source_id or target_id not found" });
     if (source.OwnerId is not null || target.OwnerId is not null)
         return Results.BadRequest(new { error = "merge endpoints must reference shared entities" });
 
-    await entityRepo.MergeEntitiesAsync(sourceId, targetId, sharedScope, ct).ConfigureAwait(false);
+    await entityRepo.MergeEntitiesAsync(sourceId, targetId, sharedScope, cancellationToken).ConfigureAwait(false);
 
     // canonical_name is optional in the wire contract (the TCK never sends it, but honor it for
     // completeness): apply it to the surviving target without disturbing the merge's own field updates.
-    var merged = await entityRepo.GetByIdAsync(targetId, ct).ConfigureAwait(false);
+    var merged = await entityRepo.GetByIdAsync(targetId, cancellationToken).ConfigureAwait(false);
     if (merged is null)
         return Results.NotFound(new { error = "target entity not found after merge" });
     if (req.CanonicalName is not null)
-        merged = await entityRepo.UpsertAsync(merged with { CanonicalName = req.CanonicalName }, ct).ConfigureAwait(false);
+        merged = await entityRepo.UpsertAsync(merged with { CanonicalName = req.CanonicalName }, cancellationToken).ConfigureAwait(false);
 
     return Results.Ok(ToEntityDto(merged));
 });
@@ -473,14 +473,14 @@ app.MapPost("/start_trace", async (
     StartTraceRequest req,
     IReasoningMemoryService reasoning,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // Bridge embeds the task explicitly (via the injected IEmbeddingGenerator) rather than relying on
     // ReasoningMemoryService's own auto-embedding, mirroring add_entity/add_preference/add_fact's pattern
     // above — the bridge only has access to the public IEmbeddingGenerator, not the internal orchestrator.
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Task, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Task, cancellationToken).ConfigureAwait(false);
     var trace = await reasoning.StartTraceAsync(
-        req.SessionId, req.Task, taskEmbedding: embedding, ownerId: null, cancellationToken: ct)
+        req.SessionId, req.Task, taskEmbedding: embedding, ownerId: null, cancellationToken: cancellationToken)
         .ConfigureAwait(false);
     return Results.Ok(ToTraceDto(trace, Array.Empty<TckReasoningStep>()));
 });
@@ -496,14 +496,14 @@ app.MapPost("/add_step", async (
     IReasoningMemoryService reasoning,
     IReasoningTraceRepository traceRepo,
     IReasoningStepRepository stepRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // AddStepAsync requires a caller-supplied stepNumber, but the TCK's add_step contract has no such
     // parameter (bridge-protocol.adoc: trace_id, thought?, action?, observation? only) — there is no
     // "peek next step number" primitive either, so the next number is derived the same way a caller would
     // discover it: read the trace's current step count and add one. Costs one extra read per add_step call.
     var traceId = NormalizeId(req.TraceId);
-    await addStepGate.WaitAsync(ct).ConfigureAwait(false);
+    await addStepGate.WaitAsync(cancellationToken).ConfigureAwait(false);
     try
     {
         // Look the trace up via the repository (which returns null on miss) rather than
@@ -511,13 +511,13 @@ app.MapPost("/add_step", async (
         // makes a missing trace a clean 404, and the same OwnerId check keeps mutation confined to the shared
         // bucket — so both a nonexistent AND a non-shared trace are treated as not-found, matching
         // get_trace_with_steps.
-        var trace = await traceRepo.GetByIdAsync(traceId, ct).ConfigureAwait(false);
+        var trace = await traceRepo.GetByIdAsync(traceId, cancellationToken).ConfigureAwait(false);
         if (trace is not { OwnerId: null })
             return Results.NotFound(new { error = "trace not found" });
-        var existingSteps = await stepRepo.GetByTraceAsync(traceId, ct).ConfigureAwait(false);
+        var existingSteps = await stepRepo.GetByTraceAsync(traceId, cancellationToken).ConfigureAwait(false);
         var stepNumber = existingSteps.Count + 1;
         var step = await reasoning.AddStepAsync(
-            traceId, stepNumber, req.Thought, req.Action, req.Observation, cancellationToken: ct)
+            traceId, stepNumber, req.Thought, req.Action, req.Observation, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
         return Results.Ok(ToStepDto(step, Array.Empty<ToolCall>()));
     }
@@ -530,7 +530,7 @@ app.MapPost("/add_step", async (
 app.MapPost("/record_tool_call", async (
     RecordToolCallRequest req,
     IReasoningMemoryService reasoning,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // RecordToolCallAsync's own default is ToolCallStatus.Pending, but the TCK's BaseAdapter contract default
     // is SUCCESS (record_tool_call(..., status: ToolCallStatus = ToolCallStatus.SUCCESS)); the TCK's HTTP
@@ -558,7 +558,7 @@ app.MapPost("/record_tool_call", async (
         : null;
     var toolCall = await reasoning.RecordToolCallAsync(
         NormalizeId(req.StepId), req.ToolName, argumentsJson, resultJson, status, req.DurationMs, req.Error,
-        cancellationToken: ct)
+        cancellationToken: cancellationToken)
         .ConfigureAwait(false);
     return Results.Ok(ToToolCallDto(toolCall));
 });
@@ -566,9 +566,9 @@ app.MapPost("/record_tool_call", async (
 app.MapPost("/complete_trace", async (
     CompleteTraceRequest req,
     IReasoningMemoryService reasoning,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
-    var trace = await reasoning.CompleteTraceAsync(NormalizeId(req.TraceId), req.Outcome, req.Success, ct)
+    var trace = await reasoning.CompleteTraceAsync(NormalizeId(req.TraceId), req.Outcome, req.Success, cancellationToken)
         .ConfigureAwait(false);
     return Results.Ok(ToTraceDto(trace, Array.Empty<TckReasoningStep>()));
 });
@@ -578,23 +578,23 @@ app.MapPost("/get_trace_with_steps", async (
     IReasoningTraceRepository traceRepo,
     IReasoningStepRepository stepRepo,
     IToolCallRepository toolCallRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // Uses the repositories directly (not IReasoningMemoryService.GetTraceWithStepsAsync, which throws
     // TraceNotFound) so a nonexistent trace_id can return the TCK-mandated 200 null (SPEC-4.5.3) rather than
     // a 500 — the same null-on-not-found convention as Bronze's /get_entity_by_name-style lookups.
     var traceId = NormalizeId(req.TraceId);
-    var trace = await traceRepo.GetByIdAsync(traceId, ct).ConfigureAwait(false);
+    var trace = await traceRepo.GetByIdAsync(traceId, cancellationToken).ConfigureAwait(false);
     TckReasoningTrace? dto = null;
     // Shared-bucket only: a non-shared (owner-scoped) trace is treated as not-found (200 null) so a known/
     // guessed private trace id can't be read through the owner-agnostic bridge.
     if (trace is { OwnerId: null })
     {
-        var steps = await stepRepo.GetByTraceAsync(traceId, ct).ConfigureAwait(false);
+        var steps = await stepRepo.GetByTraceAsync(traceId, cancellationToken).ConfigureAwait(false);
         var stepDtos = new List<TckReasoningStep>(steps.Count);
         foreach (var step in steps)
         {
-            var toolCalls = await toolCallRepo.GetByStepAsync(step.StepId, ct).ConfigureAwait(false);
+            var toolCalls = await toolCallRepo.GetByStepAsync(step.StepId, cancellationToken).ConfigureAwait(false);
             stepDtos.Add(ToStepDto(step, toolCalls));
         }
         dto = ToTraceDto(trace, stepDtos);
@@ -605,13 +605,13 @@ app.MapPost("/get_trace_with_steps", async (
 app.MapPost("/list_traces", async (
     ListTracesRequest req,
     IReasoningMemoryService reasoning,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     var limit = req.Limit ?? 100;
     IReadOnlyList<ReasoningTrace> traces;
     if (!string.IsNullOrEmpty(req.SessionId))
     {
-        traces = await reasoning.ListTracesAsync(req.SessionId, limit, scope: sharedScope, ct).ConfigureAwait(false);
+        traces = await reasoning.ListTracesAsync(req.SessionId, limit, scope: sharedScope, cancellationToken).ConfigureAwait(false);
     }
     else
     {
@@ -619,7 +619,7 @@ app.MapPost("/list_traces", async (
         // first-class IReasoningMemoryService.ListAllTracesAsync (which replaced the earlier raw-Cypher
         // fallback), scoped to this bridge's shared sentinel bucket so it can never surface another owner's
         // private trace.
-        var page = await reasoning.ListAllTracesAsync(scope: sharedScope, limit: limit, cancellationToken: ct).ConfigureAwait(false);
+        var page = await reasoning.ListAllTracesAsync(scope: sharedScope, limit: limit, cancellationToken: cancellationToken).ConfigureAwait(false);
         traces = page.Items;
     }
     return Results.Ok(traces.Select(t => ToTraceDto(t, Array.Empty<TckReasoningStep>())).ToList());
@@ -628,12 +628,12 @@ app.MapPost("/list_traces", async (
 app.MapPost("/get_tool_stats", async (
     GetToolStatsRequest req,
     IToolCallRepository toolCallRepo,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     // Served by the first-class IToolCallRepository.GetStatsAsync (which replaced the earlier raw-Cypher
     // fallback), scoped to this bridge's shared sentinel bucket. The repository query deliberately avoids the
     // global (:Tool) aggregate node (which spans all owners) and classifies success/failure the same way.
-    var stats = await toolCallRepo.GetStatsAsync(req.ToolName, sharedScope, ct).ConfigureAwait(false);
+    var stats = await toolCallRepo.GetStatsAsync(req.ToolName, sharedScope, cancellationToken).ConfigureAwait(false);
     return Results.Ok(stats.Select(s => new TckToolStats(
         s.ToolName, s.TotalCalls, s.SuccessfulCalls, s.FailedCalls, s.SuccessRate, s.AvgDurationMs)).ToList());
 });
@@ -645,7 +645,7 @@ app.MapPost("/get_similar_traces", async (
     GetSimilarTracesRequest req,
     IReasoningMemoryService reasoning,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
-    CancellationToken ct) =>
+    CancellationToken cancellationToken) =>
 {
     var limit = req.Limit ?? 5;
     // Reject a non-positive limit up front with a clear 400: a negative LIMIT throws inside Neo4j (an
@@ -655,9 +655,9 @@ app.MapPost("/get_similar_traces", async (
     // success_only=true (the adapter default) ⇒ only traces with success=true; success_only=false ⇒ no
     // success filter (include unsuccessful/incomplete traces). Map to SearchSimilarTracesAsync's successFilter.
     bool? successFilter = (req.SuccessOnly ?? true) ? true : (bool?)null;
-    var embedding = await EmbedTextAsync(embeddingGenerator, req.Task, ct).ConfigureAwait(false);
+    var embedding = await EmbedTextAsync(embeddingGenerator, req.Task, cancellationToken).ConfigureAwait(false);
     var traces = await reasoning.SearchSimilarTracesAsync(
-        embedding, successFilter, limit, minScore: 0.0, scope: sharedScope, ct).ConfigureAwait(false);
+        embedding, successFilter, limit, minScore: 0.0, scope: sharedScope, cancellationToken).ConfigureAwait(false);
     return Results.Ok(traces.Select(t => ToTraceDto(t, Array.Empty<TckReasoningStep>())).ToList());
 });
 
@@ -724,9 +724,9 @@ static JsonElement? ParseJsonOrNull(string? json)
 // (GenerateAsync with a one-element input, then unwrap the sole result's vector) so the bridge's embedding
 // invocation matches the codebase's canonical MEAI usage rather than inventing a parallel call shape.
 static async Task<float[]> EmbedTextAsync(
-    IEmbeddingGenerator<string, Embedding<float>> generator, string text, CancellationToken ct)
+    IEmbeddingGenerator<string, Embedding<float>> generator, string text, CancellationToken cancellationToken)
 {
-    var generated = await generator.GenerateAsync([text], cancellationToken: ct).ConfigureAwait(false);
+    var generated = await generator.GenerateAsync([text], cancellationToken: cancellationToken).ConfigureAwait(false);
     return generated[0].Vector.ToArray();
 }
 
@@ -734,16 +734,16 @@ static async Task<float[]> EmbedTextAsync(
 // Neo4jIntegrationFixture.WaitForVectorIndexesAsync (vector index population is asynchronous in Neo4j).
 // Bounded so a stuck server can't hang /setup forever.
 static async Task WaitForVectorIndexesOnlineAsync(
-    INeo4jSessionFactory sessionFactory, CancellationToken ct, int timeoutSeconds = 30)
+    INeo4jSessionFactory sessionFactory, CancellationToken cancellationToken, int timeoutSeconds = 30)
 {
-    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
     var token = timeoutCts.Token;
     while (true)
     {
         // Caller cancellation always propagates; the bounded timeout just ends the wait (best-effort —
         // schema is already bootstrapped, indexes finish coming online shortly after).
-        ct.ThrowIfCancellationRequested();
+        cancellationToken.ThrowIfCancellationRequested();
         try
         {
             await using var session = sessionFactory.OpenSession(AccessMode.Read);
@@ -779,7 +779,7 @@ static async Task WaitForVectorIndexesOnlineAsync(
         }
     }
 
-    ct.ThrowIfCancellationRequested();
+    cancellationToken.ThrowIfCancellationRequested();
 }
 
 // Exposed so a future WebApplicationFactory<Program>-based integration test (plan §4, Part C item 3)

--- a/tools/AgentMemory.TckBridge/Program.cs
+++ b/tools/AgentMemory.TckBridge/Program.cs
@@ -750,10 +750,11 @@ static async Task WaitForVectorIndexesOnlineAsync(
             // NOTE: SHOW INDEXES needs an explicit YIELD before a WHERE/RETURN can reference its columns —
             // "SHOW INDEXES WHERE ... RETURN ..." is a syntax error in Neo4j 5.x, which the catch below would
             // swallow and turn into a full-timeout busy-loop. Keep the YIELD.
+            // WaitAsync(token) bounds the query execution itself: if the driver hangs before returning the
+            // cursor, the bounded timeout still ends the wait (SingleAsync(token) alone only bounds the fetch).
             var result = await session.RunAsync(
                 "SHOW INDEXES YIELD type, state WHERE type = 'VECTOR' AND state <> 'ONLINE' RETURN count(*) AS pending")
-                .ConfigureAwait(false);
-            // Pass the bounded token so a stalled driver call cannot run past the timeout.
+                .WaitAsync(token).ConfigureAwait(false);
             var record = await result.SingleAsync(token).ConfigureAwait(false);
             if (record["pending"].As<long>() == 0) return;
         }


### PR DESCRIPTION
## Summary

Mechanical, library-wide parameter rename for a consistent convention: every abbreviated **`ct`** `CancellationToken` parameter (~109 across the public interfaces, implementations, tools, tests, and samples) is now **`cancellationToken`**, matching the ~471 that already used the full name. XML `<param name="ct">` tags were renamed to match.

## Why it's safe

Done as a single word-boundary `\bct\b` → `cancellationToken` rename, verified by a **clean full-solution build (0 errors / 0 warnings)**. A pre-sweep audit confirmed `ct` was *only* ever the cancellation-token parameter — no local variables, no string literals (only the XML doc `<param name="ct">` tags), no member/type named `ct` — so nothing else was touched. The compiler is the proof.

Source-breaking **only** for callers that passed the token by name (`ct:`); positional callers are unaffected, and it's binary-compatible.

## Also (folded in from review)

One small, unrelated behavior fix the rename surfaced in `tools/AgentMemory.TckBridge` (a test tool, not a shipped package): the `/setup` vector-index readiness wait now bounds the Neo4j `RunAsync` with `WaitAsync(token)`, not just `SingleAsync(token)`, so a driver hang before the cursor returns can't exceed the timeout. Beneficial and low-risk; kept in this PR as a single commit for traceability.

## Verified

| Check | Result |
|---|---|
| Release build (solution + bridge + CLI) | 0 warnings / 0 errors |
| Full unit suite | 2699 / 2699 |
| Full integration suite | 260 / 260 (incl. in-process TCK bridge Bronze round-trip) |

The rename is parameter-names-only and never wire-observable, so TCK is unaffected (confirmed by the in-process bridge round-trip test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsi9nT4PG1BBrvLBq3XZma
