### PR TITLE
1.0 API surface (8): Diffbot keyed-DI (opt-in enrichment provider)

### DIFF
--- a/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
+++ b/src/AgentMemory.Enrichment/Enrichment/DiffbotEnrichmentService.cs
@@ -42,7 +42,7 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
         PropertyNameCaseInsensitive = true
     };
 
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly DiffbotEnrichmentOptions _options;
     private readonly ILogger<DiffbotEnrichmentService> _logger;
 
@@ -51,11 +51,11 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
     private DateTimeOffset _lastRequestTime = DateTimeOffset.MinValue;
 
     public DiffbotEnrichmentService(
-        HttpClient httpClient,
+        IHttpClientFactory httpClientFactory,
         IOptions<DiffbotEnrichmentOptions> options,
         ILogger<DiffbotEnrichmentService> logger)
     {
-        _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
         _options = options.Value;
         _logger = logger;
     }
@@ -88,6 +88,11 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
 
         try
         {
+            // Resolve the client per request from the factory so its handler rotates on the factory's
+            // schedule. This service is a singleton (shared rate-limit state), so injecting a single
+            // HttpClient would pin its handler for the process lifetime (captive dependency); mirroring
+            // WikimediaEnrichmentService avoids that while keeping the semaphore shared.
+            var client = _httpClientFactory.CreateClient(ClientName);
             var diffbotType = TypeMapping[entityType];
             // Escape DQL string-literal metacharacters (backslash FIRST, then the double quote) so a name
             // like John "Jack" Doe doesn't produce a malformed query that silently returns nothing.
@@ -100,7 +105,7 @@ internal sealed class DiffbotEnrichmentService : IEnrichmentService, IDisposable
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("token", _options.ApiKey);
 
-            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {

--- a/src/AgentMemory.Enrichment/EnrichmentServiceKeys.cs
+++ b/src/AgentMemory.Enrichment/EnrichmentServiceKeys.cs
@@ -1,0 +1,22 @@
+namespace AgentMemory.Enrichment;
+
+/// <summary>
+/// Service keys for keyed <see cref="AgentMemory.Abstractions.Services.IEnrichmentService"/>
+/// registrations. Use with <c>GetRequiredKeyedService</c> or the
+/// <c>[FromKeyedServices]</c> attribute to resolve a specific enrichment provider.
+/// </summary>
+public static class EnrichmentServiceKeys
+{
+    /// <summary>
+    /// Key for the Diffbot-backed enrichment service registered by
+    /// <see cref="ServiceCollectionExtensions.AddDiffbotEnrichment"/>. Diffbot is registered as a
+    /// keyed, <b>opt-in</b> service: it coexists with the default (Wikimedia) unkeyed
+    /// <see cref="AgentMemory.Abstractions.Services.IEnrichmentService"/> registration but is
+    /// <b>excluded from the automatic background enrichment queue</b> (which resolves the unkeyed
+    /// <c>IEnumerable&lt;IEnrichmentService&gt;</c>, and .NET DI never surfaces keyed registrations there).
+    /// To use Diffbot, resolve it explicitly by this key via
+    /// <c>GetRequiredKeyedService&lt;IEnrichmentService&gt;(EnrichmentServiceKeys.Diffbot)</c> or
+    /// <c>[FromKeyedServices(EnrichmentServiceKeys.Diffbot)]</c> and invoke it yourself.
+    /// </summary>
+    public const string Diffbot = "Diffbot";
+}

--- a/src/AgentMemory.Enrichment/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Enrichment/ServiceCollectionExtensions.cs
@@ -101,9 +101,19 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers <see cref="DiffbotEnrichmentService"/> as a typed HTTP client.
-    /// The service is available via <see cref="DiffbotEnrichmentService"/> directly.
+    /// Registers Diffbot as a <b>keyed, opt-in</b> <see cref="IEnrichmentService"/> (key:
+    /// <see cref="EnrichmentServiceKeys.Diffbot"/>), wrapped in the shared cache decorator for parity
+    /// with the Wikimedia chain and decorated for observability by <c>AddAgentMemoryObservability</c>.
     /// </summary>
+    /// <remarks>
+    /// Because Diffbot is registered <i>by key</i>, it does <b>not</b> participate in the automatic
+    /// background enrichment queue: that queue resolves the unkeyed
+    /// <c>IEnumerable&lt;IEnrichmentService&gt;</c>, and .NET DI never surfaces keyed registrations
+    /// through an unkeyed enumerable. This is deliberate — Diffbot is a paid API, so it is opt-in rather
+    /// than firing on every enqueued entity. To use it, resolve it explicitly via
+    /// <c>GetRequiredKeyedService&lt;IEnrichmentService&gt;(EnrichmentServiceKeys.Diffbot)</c> or
+    /// <c>[FromKeyedServices(EnrichmentServiceKeys.Diffbot)]</c> and invoke it yourself.
+    /// </remarks>
     public static IServiceCollection AddDiffbotEnrichment(
         this IServiceCollection services,
         Action<DiffbotEnrichmentOptions> configure)
@@ -116,11 +126,32 @@ public static class ServiceCollectionExtensions
             .Validate(o => o.Timeout > TimeSpan.Zero, "Diffbot Timeout must be positive.")
             .ValidateOnStart();
 
-        services.AddHttpClient<DiffbotEnrichmentService>((sp, client) =>
+        // Cache options default when Diffbot is registered standalone (without AddEnrichmentServices).
+        services.AddOptions<EnrichmentCacheOptions>();
+        services.AddMemoryCache();
+
+        // Named HTTP client resolved per request via IHttpClientFactory (see DiffbotEnrichmentService),
+        // mirroring the Wikimedia registration so the handler rotates on the factory's schedule instead
+        // of being pinned for the process lifetime by the keyed singleton below (captive dependency).
+        services.AddHttpClient(DiffbotEnrichmentService.ClientName, (sp, client) =>
         {
             var opts = sp.GetRequiredService<IOptions<DiffbotEnrichmentOptions>>().Value;
             client.Timeout = opts.Timeout;
         });
+
+        // Single shared instance so the rate-limit semaphore / last-request time apply across all calls.
+        services.TryAddSingleton<DiffbotEnrichmentService>();
+
+        // Enrichment decorator chain: Cache → Diffbot, registered against the abstraction as a KEYED,
+        // opt-in service. It coexists with the default unkeyed IEnrichmentService (Wikimedia) but is
+        // excluded from the unkeyed IEnumerable<IEnrichmentService> the background enrichment queue
+        // consumes, so it never auto-runs — callers resolve it by key (see the method docs above).
+        services.TryAddKeyedSingleton<IEnrichmentService>(EnrichmentServiceKeys.Diffbot, (sp, _) =>
+            new CachedEnrichmentService(
+                sp.GetRequiredService<DiffbotEnrichmentService>(),
+                sp.GetRequiredService<IMemoryCache>(),
+                sp.GetRequiredService<IOptions<EnrichmentCacheOptions>>(),
+                sp.GetRequiredService<ILogger<CachedEnrichmentService>>()));
 
         return services;
     }

--- a/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
@@ -79,7 +79,9 @@ public static class ServiceCollectionExtensions
     {
         for (var i = services.Count - 1; i >= 0; i--)
         {
-            if (services[i].ServiceType == typeof(T))
+            // Keyed descriptors are handled separately; their non-keyed implementation
+            // accessors throw, so the unkeyed decoration path must skip them.
+            if (services[i].ServiceType == typeof(T) && !services[i].IsKeyedService)
             {
                 return services[i];
             }
@@ -177,17 +179,74 @@ public static class ServiceCollectionExtensions
 
     private static void DecorateEnrichmentService(IServiceCollection services)
     {
+        // Default (unkeyed) enrichment provider, e.g. Wikimedia via AddEnrichmentServices.
         var descriptor = FindDescriptor<IEnrichmentService>(services);
-        if (descriptor is null) return;
-        services.Remove(descriptor);
-        services.Add(new ServiceDescriptor(
-            typeof(IEnrichmentService),
-            provider =>
+        if (descriptor is not null)
+        {
+            services.Remove(descriptor);
+            services.Add(new ServiceDescriptor(
+                typeof(IEnrichmentService),
+                provider =>
+                {
+                    var inner = CreateInstance<IEnrichmentService>(provider, descriptor);
+                    var metrics = provider.GetRequiredService<MemoryMetrics>();
+                    return new InstrumentedEnrichmentService(inner, metrics);
+                },
+                descriptor.Lifetime));
+        }
+
+        // Keyed enrichment providers, e.g. Diffbot via AddDiffbotEnrichment.
+        DecorateKeyedEnrichmentServices(services);
+    }
+
+    private static void DecorateKeyedEnrichmentServices(IServiceCollection services)
+    {
+        // Snapshot the keyed IEnrichmentService descriptors before mutating the collection.
+        var keyed = new List<ServiceDescriptor>();
+        foreach (var d in services)
+        {
+            if (d.ServiceType == typeof(IEnrichmentService) && d.IsKeyedService)
             {
-                var inner = CreateInstance<IEnrichmentService>(provider, descriptor);
-                var metrics = provider.GetRequiredService<MemoryMetrics>();
-                return new InstrumentedEnrichmentService(inner, metrics);
-            },
-            descriptor.Lifetime));
+                keyed.Add(d);
+            }
+        }
+
+        foreach (var descriptor in keyed)
+        {
+            services.Remove(descriptor);
+            services.Add(new ServiceDescriptor(
+                typeof(IEnrichmentService),
+                descriptor.ServiceKey,
+                (provider, _) =>
+                {
+                    var inner = CreateKeyedInstance<IEnrichmentService>(provider, descriptor);
+                    var metrics = provider.GetRequiredService<MemoryMetrics>();
+                    return new InstrumentedEnrichmentService(inner, metrics);
+                },
+                descriptor.Lifetime));
+        }
+    }
+
+    private static T CreateKeyedInstance<T>(IServiceProvider provider, ServiceDescriptor descriptor)
+        where T : notnull
+    {
+        if (descriptor.KeyedImplementationInstance is T instance)
+        {
+            return instance;
+        }
+
+        if (descriptor.KeyedImplementationFactory is not null)
+        {
+            return (T)descriptor.KeyedImplementationFactory(provider, descriptor.ServiceKey);
+        }
+
+        if (descriptor.KeyedImplementationType is not null)
+        {
+            return (T)ActivatorUtilities.CreateInstance(provider, descriptor.KeyedImplementationType);
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot resolve inner keyed service for {typeof(T).Name}. " +
+            "The service descriptor has no implementation instance, factory, or type.");
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Enrichment/DiffbotEnrichmentServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/DiffbotEnrichmentServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using AgentMemory.Abstractions.Domain.Enrichment;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Enrichment;
@@ -17,8 +18,12 @@ public sealed class DiffbotEnrichmentServiceTests
     {
         var opts = options ?? new DiffbotEnrichmentOptions { ApiKey = "test-key" };
         var client = new HttpClient(handler) { Timeout = opts.Timeout };
+        // The service now resolves its client per request via IHttpClientFactory (handler rotation);
+        // stub the factory to hand back the mock-backed client for the "Diffbot" named client.
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(client);
         return new DiffbotEnrichmentService(
-            client,
+            factory,
             Microsoft.Extensions.Options.Options.Create(opts),
             NullLogger<DiffbotEnrichmentService>.Instance);
     }

--- a/tests/AgentMemory.Tests.Unit/Observability/EnrichmentServiceDecorationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/EnrichmentServiceDecorationTests.cs
@@ -1,0 +1,126 @@
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Enrichment;
+using AgentMemory.Observability;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgentMemory.Tests.Unit.Observability;
+
+/// <summary>
+/// DI-resolution tests for enrichment-service decoration. Covers both the default (unkeyed,
+/// Wikimedia) path and the keyed (Diffbot) path that <c>AddAgentMemoryObservability</c> must wrap.
+/// </summary>
+public sealed class EnrichmentServiceDecorationTests
+{
+    private static ServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return services;
+    }
+
+    private static void ConfigureDiffbot(DiffbotEnrichmentOptions o) => o.ApiKey = "test-key";
+
+    [Fact]
+    public void AddDiffbotEnrichment_RegistersDiffbotBehindKeyedEnrichmentService()
+    {
+        var services = BaseServices();
+        services.AddDiffbotEnrichment(ConfigureDiffbot);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Resolvable via the abstraction (keyed), not just the internal concrete type.
+        var enrichment = provider.GetRequiredKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot);
+        enrichment.Should().BeOfType<CachedEnrichmentService>("Diffbot is wrapped in the cache decorator");
+
+        // Opt-in contract (by design): Diffbot registers ONLY under the key, never as an unkeyed
+        // IEnrichmentService. The background enrichment queue injects the unkeyed
+        // IEnumerable<IEnrichmentService>, which .NET DI resolves WITHOUT keyed registrations — so
+        // Diffbot never auto-runs and must be resolved explicitly by key.
+        provider.GetService<IEnrichmentService>().Should().BeNull("Diffbot is keyed/opt-in, not a default provider");
+        provider.GetServices<IEnrichmentService>().Should().BeEmpty(
+            "keyed registrations are excluded from the unkeyed IEnumerable the enrichment queue consumes");
+    }
+
+    [Fact]
+    public void AddAgentMemoryObservability_DecoratesKeyedDiffbotEnrichmentService()
+    {
+        var services = BaseServices();
+        services.AddDiffbotEnrichment(ConfigureDiffbot);
+        services.AddAgentMemoryObservability();
+
+        using var provider = services.BuildServiceProvider();
+
+        var enrichment = provider.GetRequiredKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot);
+        enrichment.Should().BeOfType<InstrumentedEnrichmentService>("observability wraps the keyed provider");
+    }
+
+    [Fact]
+    public void AddAgentMemoryObservability_DecoratesUnkeyedEnrichmentService()
+    {
+        var services = BaseServices();
+        services.AddEnrichmentServices();
+        services.AddAgentMemoryObservability();
+
+        using var provider = services.BuildServiceProvider();
+
+        var enrichment = provider.GetRequiredService<IEnrichmentService>();
+        enrichment.Should().BeOfType<InstrumentedEnrichmentService>("the default (Wikimedia) provider is still decorated");
+    }
+
+    [Fact]
+    public void AddAgentMemoryObservability_DecoratesBothDefaultAndKeyedProviders()
+    {
+        var services = BaseServices();
+        services.AddEnrichmentServices();
+        services.AddDiffbotEnrichment(ConfigureDiffbot);
+        services.AddAgentMemoryObservability();
+
+        using var provider = services.BuildServiceProvider();
+
+        var wikimedia = provider.GetRequiredService<IEnrichmentService>();
+        var diffbot = provider.GetRequiredKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot);
+
+        wikimedia.Should().BeOfType<InstrumentedEnrichmentService>();
+        diffbot.Should().BeOfType<InstrumentedEnrichmentService>();
+        wikimedia.Should().NotBeSameAs(diffbot, "each provider is decorated independently");
+    }
+
+    [Fact]
+    public void EnrichmentQueue_ResolvesOnlyUnkeyedProviders_DiffbotStaysOptInByKey()
+    {
+        // Pins the opt-in contract from the consumer's angle: BackgroundEnrichmentQueue injects
+        // IEnumerable<IEnrichmentService> (unkeyed), which .NET DI resolves WITHOUT keyed registrations.
+        // So with both providers registered, only Wikimedia participates in the auto queue; Diffbot is
+        // reachable solely by key. If someone later registers Diffbot unkeyed (auto-running a paid API
+        // on every enqueued entity), this test fails.
+        var services = BaseServices();
+        services.AddEnrichmentServices();                 // unkeyed Wikimedia
+        services.AddDiffbotEnrichment(ConfigureDiffbot);  // keyed Diffbot
+        services.AddAgentMemoryObservability();
+
+        using var provider = services.BuildServiceProvider();
+
+        // What the enrichment queue would receive: the unkeyed enumerable — Wikimedia only.
+        var queueProviders = provider.GetServices<IEnrichmentService>().ToList();
+        queueProviders.Should().ContainSingle("only the unkeyed (Wikimedia) provider auto-participates in the queue");
+        queueProviders[0].Should().BeOfType<InstrumentedEnrichmentService>();
+
+        // Diffbot remains resolvable, but exclusively by key.
+        provider.GetRequiredKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot)
+            .Should().BeOfType<InstrumentedEnrichmentService>();
+    }
+
+    [Fact]
+    public void AddAgentMemoryObservability_WithoutEnrichmentService_IsNoOp()
+    {
+        var services = BaseServices();
+        services.AddAgentMemoryObservability();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<IEnrichmentService>().Should().BeNull();
+        provider.GetKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

The last deferred item of the 1.0 API-surface lockdown. Registers Diffbot as a **keyed, opt-in** `IEnrichmentService` (key: `EnrichmentServiceKeys.Diffbot`) so it coexists with the default unkeyed (Wikimedia) provider and receives the same cache + observability decoration — **without** auto-running in the background enrichment queue.

## Why opt-in (not auto-pipeline)

`BackgroundEnrichmentQueue` resolves the unkeyed `IEnumerable<IEnrichmentService>`, and .NET DI excludes keyed registrations from an unkeyed enumerable. Diffbot therefore runs **only when resolved explicitly by key**. This is deliberate: Diffbot is a **paid API** and should be opt-in rather than firing on every enqueued entity. The behavior is unchanged from before this PR (Diffbot never participated in the auto queue), now made explicit and documented.

- XML docs on `AddDiffbotEnrichment` / `EnrichmentServiceKeys` state the opt-in contract.
- A new consumer-angle test pins it: registering Diffbot must **not** add it to the unkeyed enumerable the queue consumes.
- Resolve via `GetRequiredKeyedService<IEnrichmentService>(EnrichmentServiceKeys.Diffbot)` or `[FromKeyedServices(EnrichmentServiceKeys.Diffbot)]`.

## Observability

`AddAgentMemoryObservability` now decorates **keyed** `IEnrichmentService` descriptors too — `FindDescriptor` skips keyed descriptors (their non-keyed implementation accessors throw), and a new `DecorateKeyedEnrichmentServices` + `CreateKeyedInstance` path wraps them with `InstrumentedEnrichmentService`, keeping metrics parity with Wikimedia.

## Captive-dependency fix

Capturing the Diffbot service inside the keyed singleton would pin a transient typed-client's `HttpClient` handler for the process lifetime (no `IHttpClientFactory` rotation). Fixed by mirroring `WikimediaEnrichmentService`:

- `DiffbotEnrichmentService` now depends on `IHttpClientFactory` and resolves its client per request (named client `"Diffbot"`), so the handler rotates on the factory's schedule.
- Registered as a singleton (`TryAddSingleton<DiffbotEnrichmentService>()`) so its rate-limit semaphore / last-request time are shared across calls.

## Verification

- Release build: **0 warnings**.
- Unit suite: **2705 passing** (+1 new opt-in contract test), 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)