### PR TITLE
ci: wire up Codecov, add Dependabot, pin actions to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # AgentMemory.slnx at the repo root pulls in every src/, tests/, samples/, and tools/ project.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      microsoft-ai:
+        patterns:
+          - "Microsoft.SemanticKernel*"
+          - "Microsoft.Agents.AI*"
+      azure:
+        patterns:
+          - "Azure.*"
+      neo4j:
+        patterns:
+          - "Neo4j.*"
+          - "Testcontainers.Neo4j"
+      xunit:
+        patterns:
+          - "xunit*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
-# Replacement for Squad CI's build-test job, scoped to main.
-# Runs alongside squad-ci.yml during the migration window — squad-ci.yml still owns the
-# required status check ("Squad CI / build-test") until this workflow's check ("CI / Complete
-# verification") has proven green on main and the branch ruleset is repointed to it.
+# Build/test verification, scoped to main. Its "CI / Complete verification" check is the
+# branch ruleset's required status check.
 
 on:
   pull_request:
@@ -72,6 +70,7 @@ jobs:
           dotnet test AgentMemory.slnx -c Release --no-build
           --filter "Category!=Integration&Category!=Performance"
           --logger "trx;LogFileName=unit.trx"
+          --collect:"XPlat Code Coverage"
           --results-directory TestResults
 
       # Testcontainers spins up neo4j:5.26 automatically — no manual service container needed.
@@ -81,6 +80,7 @@ jobs:
           -c Release --no-build
           --filter "Category=Integration"
           --logger "trx;LogFileName=integration.trx"
+          --collect:"XPlat Code Coverage"
           --results-directory TestResults
 
       # Spec §6.6 smoke tests (multi-message persistence, recall latency, depth scaling).
@@ -90,6 +90,7 @@ jobs:
           dotnet test tests/AgentMemory.Tests.Performance/AgentMemory.Tests.Performance.csproj
           -c Release --no-build
           --logger "trx;LogFileName=performance.trx"
+          --collect:"XPlat Code Coverage"
           --results-directory TestResults
 
       - name: Static upstream schema parity
@@ -127,3 +128,13 @@ jobs:
           name: test-results
           path: TestResults/*.trx
           if-no-files-found: ignore
+
+      # Public repo: works tokenless, but a CODECOV_TOKEN repo secret (from codecov.io, after
+      # linking this repo) is recommended to avoid the shared tokenless uploader's rate limits.
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          directory: TestResults
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     name: Complete verification
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: test-results
           path: TestResults/*.trx
@@ -133,7 +133,7 @@ jobs:
       # linking this repo) is recommended to avoid the shared tokenless uploader's rate limits.
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           directory: TestResults
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
     name: Verify and package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: test-results
           path: TestResults/*.trx
@@ -143,7 +143,7 @@ jobs:
 
       # upload-artifact v4+ artifacts are immutable once uploaded (can't be overwritten within a run).
       - name: Upload packages as immutable artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: nuget-packages
           path: |
@@ -161,17 +161,17 @@ jobs:
       id-token: write     # OIDC for NuGet trusted publishing + attestation signing
       attestations: write # generate build provenance attestations
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Download verified packages
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: nuget-packages
           path: artifacts
 
       - name: NuGet login (OIDC -> temp API key)
         id: login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ secrets.NUGET_USER }}
 
@@ -183,7 +183,7 @@ jobs:
           --skip-duplicate
 
       - name: Generate build provenance attestations
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: "artifacts/*.nupkg"
 

--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -20,10 +20,10 @@ jobs:
   compatibility-watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 


### PR DESCRIPTION
## Summary

**Codecov wiring:** Fixes the stuck orange/yellow Codecov check from earlier -- the Codecov GitHub App is installed on this repo but nothing ever uploaded a coverage report to it, so its check-suite sat in `queued` forever on every PR.
- Added `--collect:"XPlat Code Coverage"` to all three `dotnet test` steps in `ci.yml` (`coverlet.collector` is already referenced by all 4 test projects).
- Added a `codecov/codecov-action` upload step, `fail_ci_if_error: false` so a Codecov-side hiccup never turns a green test run red. Works tokenless on this public repo; recommend adding a `CODECOV_TOKEN` repo secret (from codecov.io, after linking the repo) to avoid the shared tokenless uploader's rate limits long-term.
- Fixed `ci.yml`'s header comment, which still described itself as `squad-ci.yml`'s temporary migration replacement (deleted in #94).

**Dependabot config (`.github/dependabot.yml`):**
- NuGet + GitHub Actions, both weekly.
- NuGet points at the repo root (`AgentMemory.slnx` pulls in every project; confirmed Dependabot's NuGet updater expands `.slnx` solutions).
- Grouped Microsoft.Extensions.*, the SemanticKernel/Agents.AI family, Azure.*, Neo4j.*/Testcontainers.Neo4j, and xunit* so routine bumps don't turn into 15 separate PRs. Verified no glob collisions between groups (e.g. `Microsoft.Extensions.AI.Abstractions` lands only in `microsoft-extensions`, not `microsoft-ai`).
- GitHub Actions grouped into one PR (small action set here, further splitting wouldn't reduce noise).

**Pin third-party actions to commit SHAs:**
Every `uses:` reference across `ci.yml`/`release.yml`/`upstream-compatibility.yml` replaced with `owner/repo@<full-sha> # vX.Y.Z`, pinned to whatever major version was already referenced (not jumping to newer majors that exist for some of these, e.g. checkout/codecov-action have since moved to v6/v7 -- that's a separate upgrade decision, left for Dependabot to propose):
| Action | Pinned to |
|---|---|
| actions/checkout | v5.0.1 |
| actions/setup-dotnet | v5.4.0 |
| actions/upload-artifact | v5.0.0 |
| actions/download-artifact | v5.0.0 |
| NuGet/login | v1.2.0 |
| actions/attest-build-provenance | v4.1.1 |
| codecov/codecov-action | v5.5.5 |

Dependabot's github-actions updater recognizes the trailing `# vX.Y.Z` comment convention and rewrites the SHA + comment together on future bumps (confirmed this in dependabot-core's actual source, not assumed).

## Test plan
- [x] `dotnet test --collect:"XPlat Code Coverage"` verified locally to produce `coverage.cobertura.xml`
- [x] All 4 workflow/config YAML files parse correctly
- [x] Every `uses:` line confirmed SHA-pinned (grep for remaining mutable `@vN` tags: none)
- [x] All 7 SHA/version pairs independently re-derived and cross-checked in a second pass before committing (adversarial review fork, zero mismatches)
- [x] Dependabot config schema verified against GitHub's live docs; confirmed `AgentMemory.slnx` is physically at the repo root
- [ ] CI green on this PR, and the Codecov check resolves for the first time
- [ ] First Dependabot run actually opens PRs as expected (can be triggered manually via Insights > Dependency graph > Dependabot after merge)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>