### PR TITLE
docs: correct the absolute multi-tenant isolation claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Framework, Semantic Kernel, direct .NET usage, and MCP clients.
   and reasoning traces (steps, tool calls, prior executions) are all first-class citizens.
 - **Graph-native, not just vectors.** Vector, fulltext, hybrid, and graph-traversal retrieval, plus
   optional GraphRAG context — because "similar text" and "connected knowledge" are different questions.
-- **Multi-tenant from day one.** Owner and store isolation are enforced deep in the persistence layer,
-  not bolted on at the API edge.
+- **Multi-tenant capable.** Owner and store isolation are enforced throughout scoped repository,
+  recall, GraphRAG, reasoning, maintenance, and agent-tool operations.
+  Multi-tenant hosts must establish an owner scope for every agent run. Unscoped operations retain
+  global behavior for administrative and single-tenant scenarios.
 - **Time-aware.** Bitemporal recall and non-destructive decay mean memory can answer "what did we believe
   back then" as well as "what do we believe now."
 - **Drops into the ecosystem you already use.** First-class adapters for the Microsoft Agent Framework,
@@ -44,7 +46,7 @@ not by convention. AgentMemory does:
 | **What changed, and when?** | A bitemporal model separates valid-time (`valid_from`/`valid_until`) from transaction-time (`created_at`/`invalidated_at`); contradictions resolve via non-destructive `SUPERSEDED_BY`, and point-in-time recall can answer "what did we believe back then." |
 | **Why was it recalled?** | Every long-term read is logged to a read/access audit trail (who, what, when, how often); ranking is driven by explicit, configurable recency/structural signals — not an opaque score. |
 | **How is it invalidated or deleted?** | Long-term memory soft-invalidates by default (kept, recoverable); hard deletion is opt-in. Short-term session data can be cleared explicitly, always scoped to a single owner. |
-| **Can tenants see one another's memory?** | No. Owner/store isolation is enforced in the repository, recall, GraphRAG, reasoning, and maintenance layers — not just at the API surface — with an optional database-per-application tier for physical separation. |
+| **Can scoped tenants see one another's memory?** | No. Owner-scoped operations return only that owner's memory and, when enabled, shared memory. Unscoped reads are global in the default compatibility mode, so multi-tenant hosts must establish an owner scope for every operation. |
 | **How do applications meet retention and privacy requirements?** | Scoped decay/pruning, non-destructive-by-default invalidation, the read-audit trail, and physical per-application isolation are the building blocks — wire them into whatever retention or privacy policy your application needs. |
 
 ## Quick Start

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -26,8 +26,9 @@ so no bespoke agent loop is required: you register the provider on the agent and
   facts, preferences, and relationships into the graph (with a real LLM configured).
 - **Cross-session recall.** A brand-new session for the same owner/application recalls prior memory,
   because the knowledge lives in the graph rather than the MAF session state.
-- **Multi-tenant isolation.** Recall and persistence are scoped by owner and application, so one
-  tenant never sees another's memory.
+- **Multi-tenant capable.** Recall and persistence are scoped by owner and application once the host
+  establishes an owner scope for the run (see [Owner isolation](getting-started.md#owner-isolation));
+  unscoped operations remain global (shared/admin) by default.
 
 ## The three memory types
 
@@ -160,7 +161,8 @@ uses. From there, MAF drives the provider's before/after hooks on every `RunAsyn
 `WithMemoryIdentity(userId, sessionId, conversationId?, applicationId?)` stamps the run's identity onto
 the MAF session. AgentMemory reads it on every invocation to scope recall and writes:
 
-- **owner** (`userId`) — the multi-tenant isolation boundary; null means shared/global.
+- **owner** (`userId`) — the multi-tenant isolation boundary when set; null means shared/global (no
+  isolation) — always pass it from an authenticated user/tenant context, never from LLM/client input.
 - **application** (`applicationId`) — routes the memory store (shared DB by default; optionally a
   database per application).
 - **session** / **conversation** — short-term ordering and per-run context.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,10 @@ Agent Memory for .NET is a **native .NET implementation of graph-native persiste
 - **Neo4j graph-native persistence**: direct Neo4j driver usage, no ORM, with schema bootstrapping and migration support *(Plan §7.3)*
 - **Context assembly**: configurable recall with budget enforcement and truncation strategies *(Spec §3.4, Plan §14)*
 - **Extraction pipeline**: pluggable extraction from conversations to structured long-term memory *(Plan §13)*
+- **Owner/store scoping**: `MemoryScope`/`owner_id` isolation runs through the repository, recall,
+  GraphRAG, reasoning, and maintenance layers, but it is opt-in per call — a null scope (the
+  backward-compatible default) is global, not isolated. Multi-tenant hosts must establish an owner scope
+  for every agent run; see [Owner isolation](getting-started.md#owner-isolation).
 
 ### What It Does NOT Do
 
@@ -500,7 +504,7 @@ These rules are inviolable. Violation of any rule is a blocking review finding.
 | **B7** | No adapter may contain business logic that belongs in Core | Adapters are thin translation layers only |
 | **B8** | Adapters depend on Core/Abstractions — never the reverse | Dependency inversion; core doesn't know about adapters |
 
-**Enforcement:** Code review gates on all PRs, plus automated CI guards — **B1** via `AbstractionsContractGuardTests` and **B2–B6/B8** via `PackageBoundaryGuardTests` (both compiled-reference and `.csproj` scans). These run as unit tests in the Squad CI workflow on every PR. (**B7** — "no business logic in adapters" — remains a review-only rule.)
+**Enforcement:** Code review gates on all PRs, plus automated CI guards — **B1** via `AbstractionsContractGuardTests` and **B2–B6/B8** via `PackageBoundaryGuardTests` (both compiled-reference and `.csproj` scans). These run as unit tests in the CI workflow on every PR. (**B7** — "no business logic in adapters" — remains a review-only rule.)
 
 **Current Verification (as of Gap Closure Sprint + MEAI adoption D-AR2-1):**
 - ✅ Abstractions .csproj: one `<PackageReference>` — `Microsoft.Extensions.AI.Abstractions` 10.5.1 (approved, B1)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -178,6 +178,35 @@ The store tier routes across **databases within one instance**, not across insta
 
 ---
 
+## Owner isolation
+
+AgentMemory distinguishes between **scoped** and **unscoped** operations.
+
+- `MemoryScope.For("alice")` returns Alice's records and, by default, shared records.
+- `MemoryScope.Global` intentionally permits cross-owner administrative access.
+- A null read scope preserves the global, backward-compatible behavior.
+- A null write owner stores the memory as shared/global.
+
+In multi-tenant applications, establish an owner scope around the complete agent run, including any
+tool calls, by resolving `IWritableMemoryOwnerContext` from DI:
+
+```csharp
+// agent/session are whatever your MAF or Semantic Kernel integration already builds (§5/§6 below)
+using (ownerContext.BeginOwnerScope(userId))
+{
+    await agent.RunAsync(message, session);
+}
+```
+
+**Do not accept an owner ID supplied by an LLM or untrusted client as proof of authorization.** The host
+application must derive the owner from its authenticated user or tenant context. This matters
+concretely for MCP hosts: the built-in `memory://context/{session_id}` resource (`ContextResource`)
+accepts a caller-supplied `userId` parameter directly — if an untrusted MCP client or the model itself
+can set that parameter, it can request another owner's memory. Only expose it to trusted callers, or
+have the host validate/override it before the request reaches the resource.
+
+---
+
 ## 4. First Memory Store
 
 The primary facade is `IMemoryService`. Resolve it from DI:
@@ -201,7 +230,8 @@ var message = await memory.AddMessageAsync(
 
 Console.WriteLine($"Stored message: {message.MessageId}");
 
-// Recall context for a follow-up query
+// Recall context for a follow-up query. No UserId/Scope here ⇒ global/unscoped recall (fine for this
+// single-user walkthrough, but NOT for a multi-tenant app — see "Owner isolation" above).
 var recall = await memory.RecallAsync(new RecallRequest
 {
     SessionId = sessionId,

--- a/tests/AgentMemory.Tests.Unit/Documentation/ReadmeConsistencyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Documentation/ReadmeConsistencyTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+
+namespace AgentMemory.Tests.Unit.Documentation;
+
+/// <summary>
+/// CI guard against README.md re-introducing an absolute multi-tenant isolation claim. A null
+/// <c>MemoryScope</c> read means "no owner filter" (all owners), and a null write owner stores
+/// shared/global memory — isolation is opt-in per call, not automatic. See "Owner isolation" in
+/// <c>docs/getting-started.md</c>.
+/// </summary>
+public sealed class ReadmeConsistencyTests
+{
+    [Fact]
+    public void Readme_DoesNotClaimUnconditionalTenantIsolation()
+    {
+        var readme = File.ReadAllText(Path.Combine(RepoRoot(), "README.md"));
+
+        readme.Should().NotContain("Multi-tenant from day one",
+            "isolation is opt-in per call (a null MemoryScope/UserId is global), not automatic");
+        readme.Should().NotContain("Can tenants see one another's memory?",
+            "the governance table row must reflect that unscoped operations are global by default");
+        readme.Should().Contain("Multi-tenant hosts must establish an owner scope",
+            "the README must state the host's responsibility to establish an owner scope explicitly");
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "AgentMemory.slnx")))
+            dir = dir.Parent;
+        dir.Should().NotBeNull("the test must run within the repository (AgentMemory.slnx not found above {0})", AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
## Summary

The README and docs/agent-framework.md claimed isolation as unconditional ("Multi-tenant from day one", "Can tenants see one another's memory? No."). Verified against source this isn't accurate: `MemoryScope.OwnerId == null` means no owner filter (all owners) -- the same null/global default `MemoryContextAssembler` falls back to when neither an explicit `Scope` nor `UserId` is supplied -- and a null write owner stores the record as shared/global. Isolation is opt-in per call/per host, not automatic.

- **README.md**: replaced the absolute bullet and the governance-table row with conditional language -- hosts must establish an owner scope; unscoped operations are global by default.
- **docs/agent-framework.md**: same correction, plus tightened the `userId`/scoping paragraph to warn it must come from an authenticated context, never client/LLM input. Also fixed a stale "Squad CI workflow" reference (deleted several PRs ago, replaced by `ci.yml`).
- **docs/getting-started.md**: added an "Owner isolation" section covering `MemoryScope.For`/`.Global`, null-read/null-write semantics, a verified-working `BeginOwnerScope` example, and an explicit warning that an LLM/untrusted-client-supplied owner ID is not authorization -- naming `ContextResource` concretely, since it accepts a caller-supplied `userId` with no server-side check tying it to the actual caller. Also flagged the existing "First Memory Store" `RecallAsync` example as unscoped/global, since that was the first copy-paste example a reader would hit.
- **docs/architecture.md**: added a "What It Provides" bullet stating the same opt-in-per-call scoping model. Fixed the same stale Squad CI reference.
- **New test** (`tests/AgentMemory.Tests.Unit/Documentation/ReadmeConsistencyTests.cs`): asserts README.md no longer contains the old absolute phrases and does state the host's responsibility explicitly.

## One deliberate deviation from the suggested wording
Dropped "...or enable strict isolation mode" from the suggested README replacement text after confirming no such feature/flag exists anywhere in the codebase -- didn't want to fix one inaccuracy by introducing another.

## Test plan
- [x] Every technical claim (MemoryScope null semantics, the context assembler's scope fallback, `BeginOwnerScope`'s real signature, `ContextResource`'s unauthenticated `userId` parameter) verified against current source
- [x] New test builds and passes locally
- [x] Anchor (`#owner-isolation`) and existing cross-references (e.g. `agent-framework.md`'s link to `getting-started.md#7-embedding-providers`) confirmed intact -- section was added unnumbered specifically to avoid a renumbering ripple
- [x] Independent adversarial review re-verified all technical claims plus anchor/cross-reference integrity from scratch -- no discrepancies found
- [ ] CI green on this PR

## Completion criteria (from the task)
- [x] No documentation claims unconditional isolation
- [x] Null/global behavior is explained
- [x] The host's responsibility is stated
- [x] The secure owner-scope example is prominent, and the existing unscoped example is flagged as such
- [x] Documentation explicitly says model/client-provided owner IDs are not authorization

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>