### PR TITLE
docs: draft and publish the threat model and security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Full documentation lives in [docs/](https://github.com/joslat/agent-memory-dotne
 - [Schema Reference](https://github.com/joslat/agent-memory-dotnet/blob/main/docs/schema.md)
 - [Specification](https://github.com/joslat/agent-memory-dotnet/blob/main/docs/specification.md)
 - [Neo4j Memory Ecosystem](https://github.com/joslat/agent-memory-dotnet/blob/main/docs/neo4j-memory-ecosystem.md) - schema-parity/TCK compatibility tooling and the review process behind releases
+- [Threat Model](https://github.com/joslat/agent-memory-dotnet/blob/main/docs/security/threat-model.md) - what isolation/authorization properties hold today, what's a documented gap, and who owns closing it
+- [Production Checklist](https://github.com/joslat/agent-memory-dotnet/blob/main/docs/security/production-checklist.md) - what a deployment must configure itself (AgentMemory can't guarantee these alone)
+
+See [SECURITY.md](https://github.com/joslat/agent-memory-dotnet/blob/main/SECURITY.md) to report a vulnerability.
 
 ## Relationship to Upstream
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for a security vulnerability.**
+
+Use GitHub's private vulnerability reporting instead: go to the
+[Security tab](https://github.com/joslat/agent-memory-dotnet/security) → **Advisories** → **Report a
+vulnerability**. This opens a private draft advisory visible only to you and the maintainer, so the
+issue isn't disclosed before a fix is available.
+
+## Supported versions
+
+This project follows SemVer. Only the latest published `1.x` release is actively supported; there is no
+long-term-support branch at this stage.
+
+## Scope and known design tradeoffs
+
+Before reporting, it's worth reading the [threat model](docs/security/threat-model.md) — it documents,
+in detail, which isolation/authorization properties currently hold, which hold only partially, and which
+are open gaps with a stated mitigation plan. If what you found matches an already-documented gap there,
+it's still useful to report (confirms real-world impact), but it isn't a surprise to the maintainer.
+
+The [production checklist](docs/security/production-checklist.md) lists what a deployment is expected
+to configure itself (Neo4j credentials, TLS, secrets storage, rate limiting, etc.) — AgentMemory does not
+and cannot guarantee these on its own.
+
+## Supply chain
+
+Releases are published via OIDC trusted publishing (no long-lived NuGet API key), every third-party
+GitHub Action is pinned to a commit SHA with Dependabot tracking updates, and published packages carry
+build-provenance attestations. See [threat-model.md §5, TT-14](docs/security/threat-model.md) for detail.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,9 @@ Agent Memory for .NET is a **native .NET implementation of graph-native persiste
 - **Owner/store scoping**: `MemoryScope`/`owner_id` isolation runs through the repository, recall,
   GraphRAG, reasoning, and maintenance layers, but it is opt-in per call — a null scope (the
   backward-compatible default) is global, not isolated. Multi-tenant hosts must establish an owner scope
-  for every agent run; see [Owner isolation](getting-started.md#owner-isolation).
+  for every agent run; see [Owner isolation](getting-started.md#owner-isolation) and the
+  [threat model](security/threat-model.md) for exactly which isolation properties hold today, which are
+  partial, and which are open gaps with an owner and a plan.
 
 ### What It Does NOT Do
 

--- a/docs/security/production-checklist.md
+++ b/docs/security/production-checklist.md
@@ -1,0 +1,39 @@
+# Production Checklist — Agent Memory for .NET
+
+Operational checklist for deploying AgentMemory in production. Pair this with the
+[threat model](threat-model.md) — each item here closes or accepts a specific risk documented there.
+
+There is currently **no library-level "strict multi-tenant" toggle** — AgentMemory does not have a flag
+that rejects unscoped operations. Isolation depends entirely on every request path constructing an
+explicit `MemoryScope`/owner from your authenticated identity. The first checklist item below is how
+you actually achieve that today.
+
+- [ ] Every request path constructs an explicit `MemoryScope`/`UserId` derived from your authenticated
+      host identity — no code path relies on the unscoped/global default (see
+      [Owner isolation](../getting-started.md#owner-isolation); closes threat-model TT-01/TT-04).
+- [ ] Owner identity comes from the authenticated host, never from a model or MCP-supplied argument
+      (closes TT-02).
+- [ ] MCP resources/tools that accept a `userId` parameter are either not exposed to untrusted MCP
+      clients, or the host overrides/validates that parameter server-side before the request reaches
+      AgentMemory (closes TT-02).
+- [ ] `AgentMemoryMcpOptions.EnableGraphQuery` is **off** unless the caller is fully trusted (e.g. an
+      internal admin tool) — it executes arbitrary caller-supplied Cypher with no scoping or limits
+      (closes TT-08).
+- [ ] Administrative operations (`MemoryScope.Global`, cross-owner reads/writes) are not exposed to
+      tenant-facing agents or MCP clients.
+- [ ] Neo4j uses TLS and least-privilege credentials — this is also your only protection against
+      audit-record tampering (TT-11); AgentMemory does not enforce this itself.
+- [ ] Secrets (Neo4j credentials, LLM/embedding provider API keys) are stored outside configuration
+      files (a secrets manager, environment variables from a secure source, etc.).
+- [ ] A real embedding provider is configured — the built-in `StubEmbeddingGenerator` returns
+      deterministic random vectors and is suitable only for wiring/structure tests, never production.
+- [ ] Retention, invalidation, and hard-deletion policies are defined for long-term memory and audit
+      data.
+- [ ] Audit data (`:MemoryReadAudit`) has a retention and access policy of its own (closes TT-11).
+- [ ] LLM/embedding provider data-processing terms have been reviewed for the conversation and
+      extraction content your deployment will send them (closes TT-10).
+- [ ] Rate limiting is enforced at your host/API-gateway layer. AgentMemory implements **no per-owner
+      request throttling anywhere** — the only rate limiting in the codebase throttles outbound calls
+      to third-party geocoding APIs, which is unrelated. Context budgets (`ContextBudget`) only control
+      how much recalled memory fits into an LLM prompt; they are not a DoS/rate-limiting mechanism.
+- [ ] Backup and restore procedures for Neo4j have been tested.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,133 @@
+# Threat Model — Agent Memory for .NET
+
+**Status:** Living document. Every claim below was checked against the current source at the time of
+writing (not assumed from a template) — file/test references are load-bearing, not decorative. If a
+row's cited file or test is renamed or removed, this document needs a matching update.
+
+**Reporting a vulnerability?** Do not open a public issue. See [SECURITY.md](../../SECURITY.md).
+
+---
+
+## 1. Scope
+
+This threat model covers AgentMemory's memory storage, retrieval, extraction, agent-framework
+adapters, MCP resources and tools, Neo4j persistence, maintenance operations, audit data, and external
+AI/provider integrations.
+
+It does **not** cover the security of Neo4j itself, the hosting infrastructure, the operating system,
+or third-party LLM/embedding providers — those are host responsibilities (§6).
+
+## 2. Security properties
+
+These are the properties the design intends to hold. Section 5 states, per threat, whether each
+currently holds, holds only in part, or does not hold yet — a threat model's job is to be honest about
+the gap between intent and reality, not to assert everything already works.
+
+| ID | Property |
+|---|---|
+| T1 | One tenant cannot read another tenant's private memory. |
+| T2 | One tenant cannot modify, invalidate, supersede, or delete another tenant's memory. |
+| T3 | Shared memory can only be created intentionally. |
+| T4 | LLM-provided tool parameters cannot determine authorization. |
+| T5 | Partial ingestion failure is visible to callers and operators. |
+| T6 | Provenance is not silently lost. |
+| T7 | Administrative cross-owner access is explicit and auditable. |
+
+## 3. Assets
+
+- Messages (short-term conversation history)
+- Entities, facts, preferences, relationships (long-term memory)
+- Reasoning traces, steps, tool calls (reasoning memory)
+- Embeddings (vector representations of the above)
+- Owner identifiers (`owner_id` / `MemoryScope`) — the tenancy boundary itself
+- Audit records (`:MemoryReadAudit` — who read what, when, how often)
+- Neo4j credentials (connection string, username/password or equivalent)
+- LLM/embedding provider credentials (API keys for chat/embedding services the host configures)
+
+## 4. Trust boundaries
+
+```mermaid
+flowchart TB
+    Host["Authenticated host application<br/>(owns real user/tenant identity)"]
+    Agent["MAF / Semantic Kernel agent"]
+    Model["LLM / model"]
+    MAFTools["MemoryToolFactory tools<br/>(no userId parameter — ambient scope only)"]
+    MCPClient["MCP client"]
+    MCPSurface["MCP resources + tools<br/>(userId is a caller-settable parameter)"]
+    Lib["AgentMemory library<br/>(Core / Neo4j / adapters)"]
+    Neo4j[("Neo4j database")]
+    Providers["External LLM / embedding providers"]
+    AdminAPI["Administrative API<br/>(MemoryScope.Global, cross-owner ops)"]
+    TenantAPI["Tenant-facing API<br/>(owner-scoped ops only)"]
+
+    Host -- "1: sets owner identity via WithMemoryIdentity /<br/>BeginOwnerScope — host-controlled, not model-controlled" --> Agent
+    Agent -- "invokes" --> Model
+    Model -- "2: calls tools — no owner parameter exposed,<br/>scope inherited ambiently (safe by construction)" --> MAFTools
+    MAFTools --> Lib
+
+    MCPClient -- "3: calls resources/tools WITH a raw userId<br/>argument — no server-side auth check (see TT-02)" --> MCPSurface
+    MCPSurface --> Lib
+
+    Lib -- "4: Neo4j driver, parameterized Cypher,<br/>TLS + credentials expected from host" --> Neo4j
+    Lib -- "5: sends conversation/extraction content to<br/>host-configured IChatClient / IEmbeddingGenerator" --> Providers
+
+    TenantAPI -. "6: MemoryScope.Global is a distinct,<br/>explicitly-named escape hatch, not a default" .-> AdminAPI
+    Lib --- TenantAPI
+    Lib --- AdminAPI
+
+    style MCPSurface fill:#5a2a2a,stroke:#ff6b6b,stroke-width:2px,color:#fff
+    style MAFTools fill:#2a4a2a,stroke:#6bff6b,stroke-width:2px,color:#fff
+```
+
+Boundary 3 (MCP client → resources/tools) is the one boundary that does **not** currently enforce
+authorization the way boundary 2 (agent/LLM → MAF tools) does — see TT-02.
+
+## 5. Threat table
+
+| ID | Threat | Entry point | Impact | Current mitigation | Gap | Planned mitigation | Verification |
+|---|---|---|---|---|---|---|---|
+| TT-01 | Cross-owner unscoped recall (T1) | Any caller that omits `MemoryScope`/`UserId` on recall | Reads another owner's (or all owners') memory | `MemoryScope.OwnerId == null` is a documented, explicit "no filter" semantic (not silent); recall/read repositories parameterize the owner filter | The **default** for an omitted scope is global, not owner-scoped — a host that forgets to pass one gets unscoped behavior silently | Host must always construct `RecallRequest`/`MemoryScope` from authenticated identity (see [Owner isolation](../getting-started.md#owner-isolation)); no library-level "require a scope" toggle exists today (see production checklist) | `OwnerScopeIsolationIntegrationTests`, `EntityVectorReadScopeIntegrationTests`, `NonVectorReadScopeIntegrationTests` |
+| TT-02 | Arbitrary owner ID supplied through MCP (T4) | `ContextResource`, `EntityListResource`, `PreferenceListResource`, `ConversationListResource`, and the destructive `MaintenanceTools` (`memory_invalidate`, `memory_supersede`) all accept a bare, optional `userId` parameter | An untrusted MCP client or the model itself can read, invalidate, or supersede **any** owner's memory by supplying that owner's ID as a plain argument — no binding to the actual authenticated caller | Documented in each resource/tool's `[Description]` (`null = all owners (unscoped/admin)`); MAF's own tool surface (`MemoryToolFactory`) has **no such parameter** — ambient-scope-only by design, so this gap is MCP-specific, not systemic | This is a real, current gap, not a hypothetical: the parameter is genuinely unauthenticated at the library layer | Host must not expose `userId`/owner parameters on MCP resources/tools to untrusted clients — override or strip them server-side before the request reaches AgentMemory, or don't expose these MCP endpoints to untrusted callers at all | `McpResourceIsolationIntegrationTests` (the test file's own comments already flag this as an acknowledged gap) |
+| TT-03 | Accidental shared writes (T3) | Any write path where the owner argument is left null | Data intended as tenant-private lands in the shared/global bucket, readable by every owner | `BeginOwnerScope(null)` scopes to shared **deliberately and by explicit choice** — the null-write-is-shared semantic is documented on `MemoryScope` | Verified only at the owner-context mechanism level, not end-to-end at the repository/API layer (no test confirms a null-owner write actually lands as a shared node in Neo4j) | Add a repository-level integration test asserting a null-owner write produces `owner_id IS NULL` | `MemoryOwnerContextExtensionsTests.BeginOwnerScope_NullUserId_ScopesToShared` (mechanism-level only) |
+| TT-04 | Cross-owner delete/prune/decay (T2) | `Neo4jMemoryDecayService` prune/decay operations, fact/entity/relationship deletion | Another owner's memory is invalidated or hard-deleted | Prune/decay accepts the same optional `MemoryScope? scope` pattern as reads, parameterized in Cypher | Same systemic pattern as TT-01: a null/omitted scope means unscoped, not "no destructive operations allowed" — no extra safeguard beyond standard scope-gating exists for destructive ops specifically | Same host responsibility as TT-01; consider a confirmation/audit requirement specifically for unscoped destructive calls | `ReasoningTraceOwnerScopeIntegrationTests`, `RelationshipOwnerScopeIntegrationTests`, `EntityResolutionOwnerScopeIntegrationTests` |
+| TT-05 | Prompt-based memory poisoning | A conversation crafted to make the LLM extract false facts/preferences/entities | Long-term memory is polluted with attacker-controlled "facts" that later get recalled as trusted context | Confidence-threshold filtering on extracted facts/preferences/relationships; `EntityValidator` rejects degenerate entity names (too short, numeric-only, punctuation-only, stopwords) | Entity validation is a data-quality heuristic (ported from the Python original), not a security sanitizer; facts/preferences/relationships have **no** length cap or content sanitization at all | Treat all extracted content as untrusted input at recall/consumption time (host-side); consider adding length caps and stricter validation across all four extracted types, not just entities | None found — no dedicated poisoning/adversarial-extraction test exists today |
+| TT-06 | Malicious extraction output | LLM extraction returns malformed or adversarial structured output | Garbage or oversized data written to the graph; potential downstream issues wherever that data is later rendered/consumed | Same confidence filtering as TT-05; Cypher values are always parameterized (see TT-07), so this is a data-quality risk, not a Cypher-injection risk | No length/character sanitization on facts, preferences, or relationships before they're persisted | Same as TT-05 | None found |
+| TT-07 | Cypher injection | Any caller-supplied string (owner ID, session ID, query text, entity name, metadata filter key) | Arbitrary Cypher execution, full data compromise | Every sampled query file (`EntityQueries`, `FactQueries`, `PreferenceQueries`, `ReasoningQueries`, `ToolCallQueries`, `DecayQueries`) binds caller-supplied **values** via Neo4j driver parameters (`$ownerId`, `$id`, etc.), never string-interpolated. The one place a caller-influenced **identifier** (a metadata filter property key, not a value) is used, `MetadataFilterBuilder.EscapeIdentifier()` explicitly escapes it (backtick-quoting, rejects null bytes/backticks) with a documented rationale | None found in this pass — this is a real, deliberate mitigation, not an open gap | Keep enforcing "values are always parameters" as a review rule for new queries | `CypherQueryExecutionSweepTests`, `MethodBuiltQueryStructureTests` |
+| TT-08 | Huge graph traversal / resource exhaustion | Recall, GraphRAG retrieval, and the MCP `graph_query` tool | A single request consumes unbounded Neo4j resources (DoS) | `VectorRetriever`/`FulltextRetriever`/`GraphRetriever`/`HybridRetriever` all apply `LIMIT`/`Take(topK)` — no unbounded traversal found in the normal retrieval path | **`graph_query` (in `MaintenanceTools`/`GraphQueryTools`) executes arbitrary caller-supplied Cypher with no limit or depth guard at all.** It is gated by `AgentMemoryMcpOptions.EnableGraphQuery`, **disabled by default** — but if a host enables it, every other protection in this table (scoping, limits, injection-safety) is bypassed by design, because the caller is now writing the Cypher directly | Keep `EnableGraphQuery` off unless the caller is fully trusted (e.g. an internal admin tool, never exposed to an untrusted agent or MCP client) | N/A — no automated test enforces the default-off posture beyond the option's own default value |
+| TT-09 | Oversized embeddings or malformed vectors | A custom/buggy `IEmbeddingGenerator` implementation supplied by the host | Corrupt vector data written to Neo4j; potential query failures or incorrect similarity results | `Neo4jOptions.EmbeddingDimensions` + `ValidateVectorIndexDimensions` check that existing vector **indexes** match the configured dimensionality, and throw `EmbeddingDimensionMismatchException` on mismatch | That check runs at **schema bootstrap** (comparing index metadata), not on every write — a NaN, `Infinity`, or wrong-length embedding array from a misbehaving generator is not caught before being sent to Neo4j | Add per-write validation of embedding array length and finite values | None found |
+| TT-10 | External provider data leakage | Conversation content, extracted entities/facts sent to host-configured `IChatClient`/`IEmbeddingGenerator` | Sensitive data leaves the trust boundary to a third-party provider | The library only sends data through host-supplied provider interfaces — it does not bundle or default to any specific external provider | Selecting a compliant provider and reviewing its data-processing terms is entirely a host decision (§6) — the library has no visibility or control over what a given provider does with the data it receives | N/A — host responsibility | N/A |
+| TT-11 | Audit-record tampering | Any caller with the library's Neo4j credentials | `:MemoryReadAudit` records are deleted or altered, hiding evidence of past access | None beyond standard Neo4j write access — audit writes use the same driver/credentials as every other write, with no separate role or append-only enforcement | This is real and by design at the library level — AgentMemory does not implement its own audit-tamper protection | Enforce via Neo4j RBAC / least-privilege credentials at the host/deployment level (§6), not in the library | N/A — host responsibility |
+| TT-12 | Provenance loss (T6) | Any extraction write | A fact/entity/preference is persisted with no traceable `EXTRACTED_FROM`/`EXTRACTED_BY` link back to its source message | `source_message_ids` and extraction-edge creation are part of the normal extraction path | The record write (`UpsertAsync`) and the provenance-edge write (`CreateExtractedFromRelationshipAsync`) are **two separate calls, not one transaction** — the edge-creation call is wrapped in a try/catch that only logs a warning on failure. A transient failure leaves the record persisted with **no provenance link**, visible only in operator logs, not to the caller | Make record + provenance-edge creation atomic (single transaction), or surface partial-provenance failures to the caller | None found — no atomicity/failure-injection test exists today |
+| TT-13 | Stale or poisoned memory supersession (T2) | `SupersedeFactAsync`/`SupersedePreferenceAsync`, also exposed as the MCP tool `memory_supersede` | A caller (or a model, via MCP, given valid fact IDs) overwrites a correct fact with a worse one | Supersession is owner-scope-gated the same way every other operation is | **No confidence, provenance, or correctness check exists** — any in-scope caller can supersede a high-confidence fact with a low-confidence or fabricated one; via MCP this is reachable by a model with no additional authorization beyond having valid IDs | Consider requiring the winner to meet a minimum confidence/provenance bar before allowing supersession of a higher-confidence existing fact | None found |
+| TT-14 | Compromised NuGet/release pipeline | GitHub Actions supply chain, NuGet publishing | Malicious code published under the AgentMemory package names | OIDC trusted publishing (no long-lived NuGet API key), every third-party GitHub Action pinned to a commit SHA with Dependabot tracking updates, build-provenance attestations on published packages, a branch ruleset requiring review + a green required check before merge, release tags must point at current `main` HEAD (not an arbitrary ancestor) with a mandatory dated CHANGELOG entry, the full test suite plus a package-inventory check and a per-entry-point consumer-install smoke test gate every release, and `dotnet pack`/`dotnet build` never run in the publish job (it only pushes pre-verified artifacts) | The repository owner has standing bypass on the required review/status-check ruleset (needed for solo maintenance) — an intentional tradeoff, not an oversight, but worth naming explicitly | Keep bypass scoped to the current maintainer only; re-evaluate if the project ever gains additional maintainers | `release.yml`, `eng/validate-release-tag.sh`, `eng/validate-release.sh`, `eng/verify-packages-install.sh` |
+
+## 6. Host responsibilities
+
+AgentMemory cannot guarantee these alone — they belong to the application embedding it:
+
+- Authenticating users.
+- Mapping authenticated identity to an owner ID (never trusting a client- or model-supplied one — see TT-02).
+- Authorizing administrative operations (deciding who may use `MemoryScope.Global` or cross-owner APIs).
+- Protecting Neo4j credentials (secrets storage, rotation, least privilege — also closes TT-11).
+- Selecting compliant LLM/embedding providers and reviewing their data-processing terms (TT-10).
+- Defining retention and deletion policy.
+- Database backups and encryption.
+- Network restrictions (TLS to Neo4j, firewalling, etc.).
+- Rate limiting — AgentMemory implements **no per-owner request throttling anywhere**; the only rate
+  limiting in the codebase throttles *outbound* calls to third-party geocoding APIs, which is unrelated.
+
+## 7. Verification map
+
+| Property | Status | Test(s) |
+|---|---|---|
+| T1 | Holds for the Core/repository read path | `OwnerScopeIsolationIntegrationTests`, `EntityVectorReadScopeIntegrationTests`, `NonVectorReadScopeIntegrationTests` |
+| T2 | Holds for the Core/repository mutation path | `ReasoningTraceOwnerScopeIntegrationTests`, `RelationshipOwnerScopeIntegrationTests`, `EntityResolutionOwnerScopeIntegrationTests` |
+| T3 | Holds at the owner-context mechanism level; not verified end-to-end at the repository layer | `MemoryOwnerContextExtensionsTests.BeginOwnerScope_NullUserId_ScopesToShared` |
+| T4 | Holds for MAF (no parameter exposed); **does not hold for MCP** (TT-02) | `McpResourceIsolationIntegrationTests` (documents the current, imperfect behavior) |
+| T5 | Does not hold — failures are logged, not surfaced to the caller | None — open gap |
+| T6 | Does not hold — provenance-edge creation is not atomic with the record write | None — open gap |
+| T7 | Partially holds — `MemoryScope.Global` is an explicit, deliberately-named API rather than an accidental default; the read-audit trail does not currently mark a read as having used global/admin scope | None specific to the "explicit and auditable" claim — open gap on the audit-marking half |
+
+Every unresolved gap in §5/§7 needs an owner and status before it's closed: library-side gaps
+(TT-03's end-to-end test, TT-09's per-write validation, TT-12's atomicity, TT-13's confidence check,
+T7's audit marking) are maintainer-owned; everything under §6 is host-owned.


### PR DESCRIPTION
## Summary

Drafted the threat model and production checklist requested, adapted from a task template that assumed at least one feature that doesn't exist ("StrictMultiTenant" mode -- confirmed via grep to not exist anywhere in the codebase). Before writing anything, ran three parallel research passes verifying every specific claim against actual source, not the template's assumptions.

**New: `docs/security/threat-model.md`**
- Scope, 7 security properties (T1-T7), assets, a Mermaid trust-boundary diagram, a 14-row threat table, host responsibilities, and a verification map -- each row cites real test files, not invented ones, and states plainly which properties hold, hold partially, or are open gaps.
- The most important finding: the **MAF path is safe by construction** (`MemoryToolFactory`'s tools carry no `userId` parameter, ambient-scope-only), while the **MCP path is the real, current risk** -- `ContextResource` and three other resources, plus the destructive `MaintenanceTools` (`memory_invalidate`, `memory_supersede`), all accept a bare unauthenticated `userId`. This is already acknowledged in `McpResourceIsolationIntegrationTests`'s own code comments as a known gap, not something new I'm asserting.
- Also surfaced by reading the actual code rather than assuming: partial ingestion failures are logged but not surfaced to callers; provenance-edge creation is a separate, non-atomic call after the record write; supersession has no confidence/correctness check; embedding dimension validation runs at schema-bootstrap time only, not per-write. Cypher injection, on the other hand, is genuinely well-mitigated (parameterized throughout, plus deliberate identifier-escaping for metadata filter keys) -- not every row is a gap.

**New: `docs/security/production-checklist.md`**
- Operational, not architectural. Opens by stating plainly that no library-level "strict multi-tenant" toggle exists today, then gives the actual mitigation (construct an explicit scope from authenticated identity on every request path). Each item ties back to the threat-model row it closes.

**New: `SECURITY.md`**
- Points to GitHub private vulnerability reporting (confirmed enabled on this repo) rather than public issues.

**README.md, docs/architecture.md**: linked to the new documents.

## Test plan
- [x] Every technical claim independently verified against source via 3 parallel research passes before drafting
- [x] All 10 cited test files confirmed to exist exactly as named (no fabricated names)
- [x] Cross-reference links (README -> docs/security/*, architecture.md -> security/threat-model.md, SECURITY.md -> docs/security/*) confirmed to resolve correctly, including relative-path math from SECURITY.md at repo root
- [x] Markdown table structure verified (automated column-count check + manual spot-check)
- [x] Mermaid trust-boundary diagram syntax verified valid
- [x] Independent adversarial review re-verified all of the above from scratch -- no overclaims or inaccuracies found
- [ ] CI green on this PR

## Completion criteria (from the task)
- [x] Threat boundaries are documented (Mermaid diagram + threat table entry points)
- [x] Every unresolved threat has an owner and status (library-maintainer-owned vs. host-owned, called out explicitly in §7)
- [x] Host responsibilities are explicit (§6)
- [x] Docs refer back to threat IDs (production checklist items cite the TT-## row they close)
- [x] README and SECURITY.md link to the documents

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>