### PR TITLE
tests: close the two live owner-isolation coverage gaps

### DIFF
--- a/tests/AgentMemory.Tests.Integration/Extraction/ExtractionOwnerStampIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Extraction/ExtractionOwnerStampIntegrationTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using FluentAssertions;
+using AgentMemory;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Tests.Integration.Fixtures;
+using Neo4j.Driver;
+
+namespace AgentMemory.Tests.Integration.Extraction;
+
+/// <summary>
+/// Live-Neo4j proof that the full extraction pipeline -- real DI registration
+/// (<c>AddNeo4jAgentMemory</c>), real repositories, real Neo4j -- stamps the supplied owner on every
+/// persisted memory type and wires provenance. <c>MemoryExtractionPipelineTests</c> verifies the same
+/// contract at the pipeline-unit level (mocked stages), which can't catch a DI-wiring, persistence-
+/// mapping, or repository regression that silently drops or mis-stamps the owner end to end. Closes
+/// tests/README.md's "End-to-end owner-stamp on extraction" gap.
+/// </summary>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public sealed class ExtractionOwnerStampIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private ServiceProvider _provider = null!;
+
+    public ExtractionOwnerStampIntegrationTests(Neo4jIntegrationFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.CleanDatabaseAsync();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Deterministic extractors registered BEFORE AddNeo4jAgentMemory: AddAgentMemoryCore registers
+        // the no-op stub extractors via TryAddScoped, so registering these first makes them win -- the
+        // same override mechanism a real host uses to plug in a production extractor.
+        services.AddSingleton<IEntityExtractor, DeterministicEntityExtractor>();
+        services.AddSingleton<IFactExtractor, DeterministicFactExtractor>();
+        services.AddSingleton<IPreferenceExtractor, DeterministicPreferenceExtractor>();
+        services.AddSingleton<IRelationshipExtractor, DeterministicRelationshipExtractor>();
+
+        services.AddNeo4jAgentMemory(
+            configureMemory: _ => { },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+
+        // Real, deterministic embeddings at the fixture's dimensionality (same text -> same vector) --
+        // matches ShakedownEndToEndTests' convention.
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null) await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task FullExtractionPipeline_StampsSuppliedOwner_OnEveryPersistedType_AndWiresProvenance()
+    {
+        using var scope = _provider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        var shortTerm = sp.GetRequiredService<IShortTermMemoryService>();
+        var pipeline = sp.GetRequiredService<IMemoryExtractionPipeline>();
+
+        const string sessionId = "session-owner-stamp";
+        const string conversationId = "conv-owner-stamp";
+
+        await shortTerm.AddConversationAsync(conversationId, sessionId, userId: "alice");
+        var message = await shortTerm.AddMessageAsync(new Message
+        {
+            MessageId = $"m-{Guid.NewGuid():N}",
+            ConversationId = conversationId,
+            SessionId = sessionId,
+            Role = "user",
+            Content = "Ada works at Acme and prefers dark mode.",
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+
+        var result = await pipeline.ExtractAsync(new ExtractionRequest
+        {
+            SessionId = sessionId,
+            UserId = "alice",
+            Messages = [message],
+        });
+
+        // The deterministic extractors always return exactly these -- confirm the pipeline actually ran
+        // them (a regression that no-ops extraction would otherwise pass every assertion below vacuously).
+        result.Metadata["entityCount"].Should().Be(2);
+        result.Metadata["factCount"].Should().Be(1);
+        result.Metadata["preferenceCount"].Should().Be(1);
+        result.Metadata["relationshipCount"].Should().Be(1);
+
+        var entities = sp.GetRequiredService<IEntityRepository>();
+        var facts = sp.GetRequiredService<IFactRepository>();
+        var preferences = sp.GetRequiredService<IPreferenceRepository>();
+        var relationships = sp.GetRequiredService<IRelationshipRepository>();
+
+        var aliceScope = MemoryScope.For("alice");
+        var bobScope = MemoryScope.For("bob");
+
+        // Entities: owner-stamped; Alice can retrieve; Bob cannot.
+        var adaMatches = await entities.GetByNameAsync("Ada", scope: aliceScope);
+        adaMatches.Should().ContainSingle();
+        var ada = adaMatches[0];
+        ada.OwnerId.Should().Be("alice");
+        (await entities.GetByNameAsync("Ada", scope: bobScope)).Should().BeEmpty("Bob must not see Alice's private entity");
+
+        var acmeMatches = await entities.GetByNameAsync("Acme", scope: aliceScope);
+        acmeMatches.Should().ContainSingle();
+        acmeMatches[0].OwnerId.Should().Be("alice");
+
+        // Facts: owner-stamped; Alice can retrieve; Bob cannot.
+        var fact = await facts.FindByTripleAsync("Ada", "works_at", "Acme", scope: aliceScope);
+        fact.Should().NotBeNull();
+        fact!.OwnerId.Should().Be("alice");
+        (await facts.FindByTripleAsync("Ada", "works_at", "Acme", scope: bobScope)).Should().BeNull("Bob must not see Alice's private fact");
+
+        // Preferences: owner-stamped; Alice can retrieve; Bob cannot.
+        var alicePrefs = await preferences.GetByCategoryAsync("style", scope: aliceScope);
+        alicePrefs.Should().ContainSingle(p => p.PreferenceText == "prefers dark mode" && p.OwnerId == "alice");
+        (await preferences.GetByCategoryAsync("style", scope: bobScope)).Should().BeEmpty("Bob must not see Alice's private preference");
+
+        // Relationships: owner-stamped, using the same owner-isolation semantics as every other type.
+        var aliceRels = await relationships.GetBySourceEntityAsync(ada.EntityId, scope: aliceScope);
+        aliceRels.Should().ContainSingle(r => r.RelationshipType == "WORKS_AT" && r.OwnerId == "alice");
+        (await relationships.GetBySourceEntityAsync(ada.EntityId, scope: bobScope)).Should().BeEmpty("Bob must not see Alice's private relationship");
+
+        // Provenance: EXTRACTED_FROM edges exist from every persisted item back to the source message.
+        // PersistenceStage wires this for entities, facts, and preferences (not relationships):
+        // 2 entities + 1 fact + 1 preference = 4.
+        var provenanceCount = await _fixture.TransactionRunner.ReadAsync(async runner =>
+        {
+            var cursor = await runner.RunAsync(
+                "MATCH (m:Message {id: $messageId})<-[:EXTRACTED_FROM]-(n) RETURN count(n) AS c",
+                new Dictionary<string, object?> { ["messageId"] = message.MessageId });
+            var record = await cursor.SingleAsync();
+            return global::Neo4j.Driver.ValueExtensions.As<long>(record["c"]);
+        });
+        provenanceCount.Should().Be(4, "the 2 entities, the fact, and the preference each get an EXTRACTED_FROM edge to the source message");
+
+        // Not silently persisted as shared: no owner-less copy exists (an unscoped read still finds it
+        // under alice's owner_id, not under a null owner_id -- the whole point of stamping).
+        (await entities.GetByNameAsync("Ada", scope: null)).Should().ContainSingle(e => e.OwnerId == "alice");
+    }
+
+    // ── Deterministic test extractors ──
+    // The default Stub*Extractor registrations produce no output (Phase-1 no-ops), so a live test needs
+    // real-ish extractors that deterministically produce one of each type plus a relationship between two
+    // of the entities, per the issue's acceptance criteria.
+
+    private sealed class DeterministicEntityExtractor : IEntityExtractor
+    {
+        public Task<IReadOnlyList<ExtractedEntity>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ExtractedEntity>>(
+            [
+                new ExtractedEntity { Name = "Ada", Type = "Person", Confidence = 0.95 },
+                new ExtractedEntity { Name = "Acme", Type = "Organization", Confidence = 0.95 },
+            ]);
+    }
+
+    private sealed class DeterministicFactExtractor : IFactExtractor
+    {
+        public Task<IReadOnlyList<ExtractedFact>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ExtractedFact>>(
+            [
+                new ExtractedFact { Subject = "Ada", Predicate = "works_at", Object = "Acme", Confidence = 0.95 },
+            ]);
+    }
+
+    private sealed class DeterministicPreferenceExtractor : IPreferenceExtractor
+    {
+        public Task<IReadOnlyList<ExtractedPreference>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ExtractedPreference>>(
+            [
+                new ExtractedPreference { Category = "style", PreferenceText = "prefers dark mode", Confidence = 0.95 },
+            ]);
+    }
+
+    private sealed class DeterministicRelationshipExtractor : IRelationshipExtractor
+    {
+        public Task<IReadOnlyList<ExtractedRelationship>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ExtractedRelationship>>(
+            [
+                new ExtractedRelationship { SourceEntity = "Ada", TargetEntity = "Acme", RelationshipType = "WORKS_AT", Confidence = 0.95 },
+            ]);
+    }
+}

--- a/tests/AgentMemory.Tests.Integration/McpServer/McpResourceIsolationIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/McpServer/McpResourceIsolationIntegrationTests.cs
@@ -1,7 +1,13 @@
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Stubs;
 using AgentMemory.McpServer.Resources;
 using AgentMemory.Neo4j.Repositories;
 using AgentMemory.Neo4j.Services;
@@ -14,6 +20,9 @@ namespace AgentMemory.Tests.Integration.McpServer;
 /// <see cref="AgentMemory.Abstractions.Services.IGraphQueryService"/> (gap-1/gap-4). These resources do
 /// NOT delegate to the owner-scoped repositories, so their scoping must be proven end-to-end against a
 /// real graph: an owner-scoped read must return the owner's + shared rows and never another owner's.
+/// <see cref="ContextResource"/> is covered separately below: it takes <see cref="IMemoryContextAssembler"/>
+/// rather than <see cref="AgentMemory.Abstractions.Services.IGraphQueryService"/>, so its tests build a
+/// real DI container (closes tests/README.md's "MCP ContextResource" gap).
 /// </summary>
 [Collection("Neo4j Integration")]
 [Trait("Category", "Integration")]
@@ -23,6 +32,8 @@ public class McpResourceIsolationIntegrationTests : IAsyncLifetime
     private readonly Neo4jGraphQueryService _graph;
     private readonly Neo4jEntityRepository _entities;
     private readonly Neo4jPreferenceRepository _prefs;
+    private readonly StubEmbeddingGenerator _embedder;
+    private ServiceProvider _provider = null!;
 
     public McpResourceIsolationIntegrationTests(Neo4jIntegrationFixture fixture)
     {
@@ -30,10 +41,33 @@ public class McpResourceIsolationIntegrationTests : IAsyncLifetime
         _graph = new Neo4jGraphQueryService(fixture.TransactionRunner, NullLogger<Neo4jGraphQueryService>.Instance);
         _entities = new Neo4jEntityRepository(fixture.TransactionRunner, NullLogger<Neo4jEntityRepository>.Instance);
         _prefs = new Neo4jPreferenceRepository(fixture.TransactionRunner, NullLogger<Neo4jPreferenceRepository>.Instance);
+        _embedder = new StubEmbeddingGenerator(NullLogger<StubEmbeddingGenerator>.Instance, Neo4jIntegrationFixture.TestEmbeddingDimensions);
     }
 
-    public Task InitializeAsync() => _fixture.CleanDatabaseAsync();
-    public Task DisposeAsync() => Task.CompletedTask;
+    public Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeo4jAgentMemory(
+            configureMemory: _ => { },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+        _provider = services.BuildServiceProvider(validateScopes: true);
+
+        return _fixture.CleanDatabaseAsync();
+    }
+
+    public async Task DisposeAsync() => await _provider.DisposeAsync();
 
     [Fact]
     public async Task EntityListResource_ScopedToOwner_ExcludesOtherOwners()
@@ -82,7 +116,82 @@ public class McpResourceIsolationIntegrationTests : IAsyncLifetime
         ids.Should().Contain("conv-alice").And.Contain("conv-shared").And.NotContain("conv-bob");
     }
 
+    [Fact]
+    public async Task ContextResource_ScopedToOwner_ExcludesOtherOwners()
+    {
+        await SeedEntityAsync("AliceCo", ownerId: "alice");
+        await SeedEntityAsync("BobCo", ownerId: "bob");
+        await SeedEntityAsync("SharedCo", ownerId: null);
+
+        var names = await GetContextEntityNamesAsync(userId: "alice");
+
+        names.Should().Contain("AliceCo").And.Contain("SharedCo").And.NotContain("BobCo");
+    }
+
+    [Fact]
+    public async Task ContextResource_ScopedToOtherOwner_ExcludesFirstOwner()
+    {
+        await SeedEntityAsync("AliceCo", ownerId: "alice");
+        await SeedEntityAsync("BobCo", ownerId: "bob");
+        await SeedEntityAsync("SharedCo", ownerId: null);
+
+        var names = await GetContextEntityNamesAsync(userId: "bob");
+
+        names.Should().Contain("BobCo").And.Contain("SharedCo").And.NotContain("AliceCo");
+    }
+
+    [Fact]
+    public async Task ContextResource_Unscoped_ReturnsAllOwners()
+    {
+        // Explicit regression test documenting current behavior: ContextResource's userId is optional,
+        // and an omitted/null value is unscoped (global), not "no access" -- matching every other MCP
+        // resource in this file and the null-MemoryScope semantic documented on MemoryScope itself. This
+        // makes that behavior visible rather than leaving it implicit (tests/README.md gap).
+        await SeedEntityAsync("AliceCo", ownerId: "alice");
+        await SeedEntityAsync("BobCo", ownerId: "bob");
+
+        var names = await GetContextEntityNamesAsync(userId: null);
+
+        names.Should().Contain("AliceCo").And.Contain("BobCo");
+    }
+
     // ── Helpers ──
+
+    // All seeded entities embed from this same marker text (not their own Name) and the query below
+    // embeds the identical marker -- so every candidate scores a perfect 1.0 match regardless of its
+    // actual name, matching OwnerScopeIsolationIntegrationTests' "identical embeddings" convention. Only
+    // the owner WHERE-filter can then determine which of them come back.
+    private const string EmbeddingMarker = "context-resource-isolation-test";
+
+    private async Task SeedEntityAsync(string name, string? ownerId)
+    {
+        var embedding = await EmbedAsync(EmbeddingMarker);
+        await _entities.UpsertAsync(new Entity
+        {
+            EntityId = $"e-{Guid.NewGuid():N}",
+            Name = name,
+            Type = "Organization",
+            OwnerId = ownerId,
+            Confidence = 0.9,
+            Embedding = embedding,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        });
+    }
+
+    private async Task<List<string?>> GetContextEntityNamesAsync(string? userId)
+    {
+        using var scope = _provider.CreateScope();
+        var assembler = scope.ServiceProvider.GetRequiredService<IMemoryContextAssembler>();
+
+        var json = await ContextResource.GetContext(assembler, session_id: "ctx-session", query: EmbeddingMarker, userId: userId);
+        return NamesFrom(json, "entities", "name");
+    }
+
+    private async Task<float[]> EmbedAsync(string text)
+    {
+        var generated = await _embedder.GenerateAsync([text]);
+        return generated[0].Vector.ToArray();
+    }
 
     private Task SeedConversationAsync(string id, string? userId) =>
         _fixture.TransactionRunner.WriteAsync(async runner =>

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,9 +65,12 @@ collection rather than per-test:
 - **R1 multi-user isolation suite** (multi-subsystem, live): `OwnerScopeIsolationIntegrationTests`,
   `EntityResolutionOwnerScopeIntegrationTests`, `McpResourceIsolationIntegrationTests`,
   `Neo4jMemoryDecayServiceIntegrationTests`, `ExtractorProvenanceScopeIntegrationTests`,
-  `OverFetchStarvationIntegrationTests`, plus the `*ReadScope` / `*OwnerScope` repository tests. The
-  shared pattern: seed `alice` / `bob` / shared(`null`) rows and assert a scoped read returns the
-  owner's + shared rows and **never** another owner's.
+  `OverFetchStarvationIntegrationTests`, `ExtractionOwnerStampIntegrationTests`, plus the
+  `*ReadScope` / `*OwnerScope` repository tests. The shared pattern: seed `alice` / `bob` /
+  shared(`null`) rows and assert a scoped read returns the owner's + shared rows and **never**
+  another owner's. `ExtractionOwnerStampIntegrationTests` is the one that runs the real DI-registered
+  `IMemoryExtractionPipeline` (deterministic test extractors standing in for an LLM) end to end, rather
+  than seeding repositories directly.
 
 ## Conventions & guardrails
 
@@ -79,14 +82,10 @@ collection rather than per-test:
 
 ## Known coverage gaps / follow-ups
 
-- **End-to-end owner-stamp on extraction** is verified at the *pipeline* unit level
-  (`MemoryExtractionPipelineTests`: `request.UserId` → resolution scope + persistence owner-stamp) but
-  there is no *live* test that supplying a `userId` to `extract_and_persist` / `memory_extract_session`
-  results in owner-stamped persisted nodes through the full ingest path (the stub extractors produce no
-  entities, so a live test would need a real-ish extractor).
-- **MCP `ContextResource`** owner-confinement is unit-covered (it routes through
-  `IMemoryContextAssembler`, asserted via mock) but — unlike the Entity/Preference/Conversation list
-  resources — has no live-Neo4j isolation test.
+None currently tracked here. The two gaps previously listed — end-to-end owner-stamp verification
+through the full extraction/persistence path, and live-Neo4j isolation for the MCP `ContextResource` —
+were closed by `ExtractionOwnerStampIntegrationTests` and the `ContextResource_*` tests added to
+`McpResourceIsolationIntegrationTests`, respectively (see issue #99).
 
 The isolation design and full per-finding history are recorded in the maintainers' internal project archive
 (not part of the published docs).


### PR DESCRIPTION
Closes #99

## Summary

Both gaps were documented in `tests/README.md`'s "Known coverage gaps" section and covered only at the unit/mock level, so a DI-wiring, persistence-mapping, or repository regression could pass every existing test while silently persisting or exposing memory without owner isolation.

**New: `tests/AgentMemory.Tests.Integration/Extraction/ExtractionOwnerStampIntegrationTests.cs`**
Runs the real DI-registered pipeline (`AddNeo4jAgentMemory`, real repositories, live Neo4j) with deterministic test extractors standing in for an LLM -- the default `Stub*Extractor` registrations produce no output, so a live test needs something that actually returns an entity/fact/preference/relationship to verify against. Confirms:
- `owner_id="alice"` is stamped on every persisted type
- `EXTRACTED_FROM` provenance edges exist (2 entities + 1 fact + 1 preference = 4; relationships don't get one, per `PersistenceStage`)
- Alice can retrieve via the real repository scoped reads; Bob cannot
- Nothing was silently persisted as shared

**Extended: `tests/AgentMemory.Tests.Integration/McpServer/McpResourceIsolationIntegrationTests.cs`**
Added 3 tests for `ContextResource` specifically -- it takes `IMemoryContextAssembler`, not `IGraphQueryService` like the other three MCP resources this file already covers, so it needed a real DI container rather than the existing direct-repository-construction pattern:
- Scoped to owner excludes the other owner's private memory
- The inverse case
- An explicit regression test documenting that an omitted owner is unscoped/global today (not a redesign -- just making that behavior visible, per the issue's ask)

**`tests/README.md`**: removed the two now-closed gap entries, added `ExtractionOwnerStampIntegrationTests` to the R1 multi-user isolation suite listing.

## Test plan
- [x] Verified against a live Neo4j Testcontainer -- all 7 tests in the extended MCP file pass (4 pre-existing + 3 new), the 1 new extraction test passes
- [x] Full solution builds with 0 warnings/errors
- [x] Independent adversarial review confirmed none of these are vacuously-passing or false-negative-prone: re-verified the embedding-match threshold (`RecallOptions.MinSimilarityScore` defaults to 0.7; identical vectors always score above that), the entity-resolution non-collision risk (direct repository seeding bypasses the resolver entirely; `UpsertAsync` merges on a unique GUID, not embedding similarity), the provenance count logic (relationships genuinely don't get an `EXTRACTED_FROM` edge, confirmed by re-reading `PersistenceStage.cs`), and that all four "Bob cannot retrieve" repository methods (`GetByNameAsync`, `FindByTripleAsync`, `GetByCategoryAsync`, `GetBySourceEntityAsync`) genuinely apply an owner WHERE-filter rather than silently ignoring scope
- [ ] CI green on this PR

## Acceptance criteria (from the issue)
- [x] A live integration test executes the complete extraction and persistence path with `UserId = "alice"`
- [x] Extracted entities/facts/preferences are persisted with `owner_id = "alice"`
- [x] Extracted relationships use the expected owner-isolation semantics
- [x] Provenance relationships are verified in live Neo4j
- [x] Bob cannot retrieve memory extracted for Alice
- [x] A live `ContextResource` test returns Alice plus shared memory
- [x] The same response excludes Bob's private memory
- [x] The inverse Bob isolation case is tested
- [x] The no-owner behavior is explicitly tested and documented
- [x] The corresponding entries are removed from tests/README.md's "Known coverage gaps" section

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>