### PR TITLE
Guarantee owner scoping across the complete MAF invocation (#90)

### DIFF
--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -87,7 +87,8 @@ tools** to a MAF agent:
 
 ```csharp
 using AgentMemory;                       // AddNeo4jAgentMemory
-using AgentMemory.AgentFramework;        // AddAgentMemoryFramework, Neo4jMemoryContextProvider, WithMemoryIdentity
+using AgentMemory.Abstractions.Services; // ISchemaBootstrapper
+using AgentMemory.AgentFramework;        // AddAgentMemoryFramework, Neo4jMemoryContextProvider, WithMemoryIdentity, WithMemoryOwnerScoping
 using AgentMemory.AgentFramework.Tools;  // MemoryToolFactory
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -138,7 +139,12 @@ AIAgent agent = sp.GetRequiredService<IChatClient>().AsAIAgent(new ChatClientAge
         Tools        = [.. memoryTools],
     },
     AIContextProviders = [memoryProvider],   // <-- the canonical MAF registration point
-});
+}).WithMemoryOwnerScoping(sp);
+// ^ guarantees the owner scope spans the COMPLETE invocation -- recall, tool calls, and persistence --
+// not just the portion inside the context-provider hook. Passing the IServiceProvider (rather than an
+// IWritableMemoryOwnerContext instance directly) resolves it from the SAME container the provider uses,
+// so it can never read a session's identity under different StateBag keys than the provider if you ever
+// customize AgentFrameworkOptions.Default*Key. See "Identity and scoping" below.
 
 // 5. Run — memory is recalled before each turn and persisted after, automatically
 var session = (await agent.CreateSessionAsync())
@@ -166,6 +172,26 @@ the MAF session. AgentMemory reads it on every invocation to scope recall and wr
 - **application** (`applicationId`) — routes the memory store (shared DB by default; optionally a
   database per application).
 - **session** / **conversation** — short-term ordering and per-run context.
+
+**Wrap the agent once with `.WithMemoryOwnerScoping(sp)`** (shown above) so the owner scope guaranteed
+spans the *complete* invocation — passive recall, the model call, the full tool-calling loop (so
+`search_memory`/`remember_*` etc. see the same owner), and automatic persistence — as one unbroken async
+chain. This matters because `Neo4jMemoryContextProvider`'s own pre-run hook (`ProvideAIContextAsync`)
+cannot guarantee this on its own: it suspends on real I/O (embedding + recall), so by the time MAF's
+tool-calling loop runs — *after* that hook returns — a value it set on the `AsyncLocal`-backed owner
+context is no longer reliably visible. `WithMemoryOwnerScoping` closes that gap by bracketing the entire
+`RunAsync`/`RunStreamingAsync` call instead of just the hook. Apply it once at agent-construction time; you
+don't need to manually wrap every `RunAsync` call in `ownerContext.BeginOwnerScope(userId)` — the
+lower-level mechanism the wrapper uses internally, still available for hosts that need finer-grained
+control over an unwrapped agent.
+
+Prefer the `IServiceProvider` overload (`.WithMemoryOwnerScoping(sp)`) over the one that takes an
+`IWritableMemoryOwnerContext` directly: it also resolves the registered `AgentFrameworkOptions` from the
+same container `Neo4jMemoryContextProvider` uses. If you ever customize
+`AgentFrameworkOptions.Default*Key` (e.g. `DefaultUserIdKey`), the two must read the session's identity
+under the *same* StateBag keys — passing the `IServiceProvider` guarantees that; constructing the options
+by hand (or omitting them) risks the wrapper silently reading a different key than the provider wrote,
+which unscopes the whole invocation with no error.
 
 A full runnable version of this flow is
 [`samples/AgentMemory.Sample.AgentWithMemory`](../samples/AgentMemory.Sample.AgentWithMemory/) — the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,6 +198,21 @@ using (ownerContext.BeginOwnerScope(userId))
 }
 ```
 
+**For MAF specifically**, prefer wrapping the agent once at construction time instead of every call site:
+
+```csharp
+AIAgent agent = chatClient.AsAIAgent(agentOptions).WithMemoryOwnerScoping(serviceProvider);
+```
+
+Pass the `IServiceProvider` rather than resolving `IWritableMemoryOwnerContext` yourself: it also resolves
+the registered `AgentFrameworkOptions`, so if you ever customize `Default*Key`, the wrapper reads a
+session's identity under the same StateBag keys `Neo4jMemoryContextProvider` does — passing the pieces
+separately risks a silent mismatch that unscopes the whole invocation.
+
+This guarantees the owner scope spans the complete invocation — a context-provider hook alone can't
+guarantee that, since it suspends on real I/O and the tool-calling loop runs after it returns. See
+[agent-framework.md](agent-framework.md#identity-and-scoping).
+
 **Do not accept an owner ID supplied by an LLM or untrusted client as proof of authorization.** The host
 application must derive the owner from its authenticated user or tenant context. This matters
 concretely for MCP hosts: the built-in `memory://context/{session_id}` resource (`ContextResource`)

--- a/samples/AgentMemory.Sample.AgentWithMemory/Program.cs
+++ b/samples/AgentMemory.Sample.AgentWithMemory/Program.cs
@@ -97,10 +97,18 @@ static async Task RunAsync(IServiceProvider root)
 
     var memoryProvider = sp.GetRequiredService<Neo4jMemoryContextProvider>();
     var memoryTools = sp.GetRequiredService<MemoryToolFactory>().CreateAIFunctions();
-    var ownerContext = sp.GetRequiredService<IWritableMemoryOwnerContext>();
 
     IChatClient chatClient = sp.GetRequiredService<IChatClient>();
 
+    // WithMemoryOwnerScoping(sp) (#90) guarantees the owner scope spans the COMPLETE invocation -- passive
+    // recall, the model call, the full tool-calling loop, and automatic persistence -- as one unbroken
+    // async chain. This replaces manually wrapping every agent.RunAsync(...) call in
+    // ownerContext.BeginOwnerScope(userId): a context-provider hook alone can't guarantee that (it
+    // suspends on real I/O, so a value it sets does not reliably survive into tool calls that run after
+    // it returns). Passing the IServiceProvider (rather than resolving IWritableMemoryOwnerContext
+    // manually) also resolves the same AgentFrameworkOptions instance Neo4jMemoryContextProvider uses --
+    // if a host ever customizes AgentFrameworkOptions.Default*Key, this keeps the wrapper reading identity
+    // under the same StateBag keys the provider writes/reads, rather than silently drifting out of sync.
     AIAgent agent = chatClient.AsAIAgent(new ChatClientAgentOptions
     {
         Name = "MemoryAgent",
@@ -110,7 +118,7 @@ static async Task RunAsync(IServiceProvider root)
             Tools = [.. memoryTools],
         },
         AIContextProviders = [memoryProvider],
-    });
+    }).WithMemoryOwnerScoping(sp);
 
     const string applicationId = "agent-memory-dotnet-golden-path";
     const string userId = "demo-user-ruaidhri";
@@ -130,7 +138,7 @@ static async Task RunAsync(IServiceProvider root)
     })
     {
         logger.LogInformation("USER  : {Turn}", turn);
-        logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, turn, sessionA, logger, ownerContext, userId));
+        logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, turn, sessionA, logger));
     }
 
     // ── 2. Serialize and restore the session (canonical 04_memory feature) ──────
@@ -143,7 +151,7 @@ static async Task RunAsync(IServiceProvider root)
         conversationId: "golden-path-conversation-a",
         applicationId: applicationId);
     logger.LogInformation("USER  : What did I tell you?");
-    logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, "What did I tell you?", restored, logger, ownerContext, userId));
+    logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, "What did I tell you?", restored, logger));
 
     // ── 3. Durable cross-session recall ─────────────────────────────────────────
     // A brand-new session for the same owner/application still sees earlier memory, because recall is
@@ -155,13 +163,15 @@ static async Task RunAsync(IServiceProvider root)
         conversationId: "golden-path-conversation-b",
         applicationId: applicationId);
     logger.LogInformation("USER  : Remind me what you know about me.");
-    logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, "Remind me what you know about me.", sessionB, logger, ownerContext, userId));
+    logger.LogInformation("AGENT : {Text}", await SafeRunAsync(agent, "Remind me what you know about me.", sessionB, logger));
 
     // ── 4. StrictMultiTenant fails closed on a forgotten owner scope ────────────
-    // Every recall above ran inside ownerContext.BeginOwnerScope(userId). This call deliberately skips
-    // that -- with Isolation.Mode = StrictMultiTenant configured above, the context assembler now throws
-    // MemoryOwnerScopeRequiredException instead of silently resolving to global/shared memory.
-    logger.LogInformation("\n>> Demonstrating StrictMultiTenant: an unscoped recall fails closed (no BeginOwnerScope)\n");
+    // Every recall above ran through the WithMemoryOwnerScoping-wrapped agent, so it was owner-scoped
+    // automatically. This call deliberately bypasses that (it calls the context assembler directly,
+    // skipping the agent entirely) -- with Isolation.Mode = StrictMultiTenant configured above, the
+    // context assembler now throws MemoryOwnerScopeRequiredException instead of silently resolving to
+    // global/shared memory.
+    logger.LogInformation("\n>> Demonstrating StrictMultiTenant: an unscoped recall fails closed (bypassing the agent)\n");
     var contextAssembler = sp.GetRequiredService<IMemoryContextAssembler>();
     try
     {
@@ -181,23 +191,14 @@ static async Task RunAsync(IServiceProvider root)
     logger.LogInformation("\n=== Demo complete. Memory persisted in Neo4j survives sessions and serialization. ===");
 }
 
-static async Task<string?> SafeRunAsync(
-    AIAgent agent,
-    string message,
-    AgentSession session,
-    ILogger logger,
-    IWritableMemoryOwnerContext ownerContext,
-    string userId)
+static async Task<string?> SafeRunAsync(AIAgent agent, string message, AgentSession session, ILogger logger)
 {
     try
     {
-        // The session state scopes provider recall/persistence. The ambient owner scope encloses the run
-        // so any model-invoked memory tools inherit the same owner and cannot run against all owners.
-        using (ownerContext.BeginOwnerScope(userId))
-        {
-            var response = await agent.RunAsync(message, session);
-            return response.Text;
-        }
+        // Owner scoping (recall, tool calls, and persistence) is guaranteed automatically by the
+        // WithMemoryOwnerScoping-wrapped agent (#90) -- no manual BeginOwnerScope needed here.
+        var response = await agent.RunAsync(message, session);
+        return response.Text;
     }
     catch (Exception ex)
     {

--- a/samples/AgentMemory.Sample.AgentWithMemory/README.md
+++ b/samples/AgentMemory.Sample.AgentWithMemory/README.md
@@ -5,7 +5,7 @@ This is the flagship Microsoft Agent Framework sample for Agent Memory for .NET.
 - `Neo4jMemoryContextProvider` injects memory context before each agent run and persists messages after the run.
 - `MemoryToolFactory.CreateAIFunctions()` exposes model-callable memory tools.
 - `WithMemoryIdentity(...)` stamps application, owner/user, session, and conversation identity into the `AgentSession` state bag.
-- `IWritableMemoryOwnerContext.BeginOwnerScope(userId)` wraps every agent run so tool writes/searches inherit trusted host identity.
+- `.WithMemoryOwnerScoping(sp)` wraps the agent so every invocation — recall, tool calls, and persistence — is guaranteed to run in the same owner scope, automatically (#90).
 - Session serialize/restore and a second session demonstrate memory continuity beyond one in-memory run.
 - `MemoryOptions.Isolation.Mode = MemoryIsolationMode.StrictMultiTenant` is enabled, and a final step shows what happens when a call forgets `BeginOwnerScope`: it fails closed with `MemoryOwnerScopeRequiredException` instead of silently falling back to global/shared memory.
 
@@ -27,16 +27,21 @@ builder.Services.AddSingleton<IChatClient>(sp => /* OpenAI, Azure OpenAI, or Fou
 builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp => /* MEAI embedding generator */);
 ```
 
-Do not change the memory wiring when swapping providers. The important production pattern is the identity wrapper around each run:
+Do not change the memory wiring when swapping providers. The important production pattern is wrapping the
+agent once, at construction time:
 
 ```csharp
-using (ownerContext.BeginOwnerScope(userId))
-{
-    await agent.RunAsync(message, session);
-}
+AIAgent agent = chatClient.AsAIAgent(agentOptions).WithMemoryOwnerScoping(sp);
 ```
 
-The session state (`WithMemoryIdentity`) and ambient owner scope must agree. The state bag lets the provider scope recall/persistence by application, owner, session, and conversation; the ambient owner scope protects model-invoked tools from trusting user identity supplied by the model.
+The session state (`WithMemoryIdentity`) and the owner-scoping wrapper must agree. The state bag lets the
+provider scope recall/persistence by application, owner, session, and conversation; the wrapper reads that
+same identity and guarantees it encloses the complete invocation — including the tool-calling loop, which
+a context-provider hook alone cannot guarantee (#90) — so model-invoked tools can't run against a
+different or missing owner than the one the session declares. Passing the `IServiceProvider` (rather than
+an `IWritableMemoryOwnerContext` instance directly) resolves the registered `AgentFrameworkOptions` from
+the same container the provider uses, so a customized `Default*Key` can't cause the wrapper and the
+provider to silently read a session's identity under different keys.
 
 ## Multi-Tenant Isolation Mode
 

--- a/src/AgentMemory.Abstractions/Services/MemoryStoreContextExtensions.cs
+++ b/src/AgentMemory.Abstractions/Services/MemoryStoreContextExtensions.cs
@@ -1,0 +1,43 @@
+namespace AgentMemory.Abstractions.Services;
+
+/// <summary>
+/// Helpers for establishing the ambient memory store (R1b) around a unit of work, mirroring
+/// <see cref="MemoryOwnerContextExtensions.BeginOwnerScope"/> for <see cref="IWritableMemoryStoreContext"/>.
+/// </summary>
+public static class MemoryStoreContextExtensions
+{
+    /// <summary>
+    /// Sets <see cref="IWritableMemoryStoreContext.ApplicationId"/> to <paramref name="applicationId"/>
+    /// for the current async flow and restores the previous value when the returned scope is disposed.
+    /// Because the store context is typically <see cref="System.Threading.AsyncLocal{T}"/>-backed, the
+    /// value flows into any asynchronous work awaited inside the <c>using</c> block. A <c>null</c>
+    /// <paramref name="applicationId"/> scopes the work to the default store.
+    /// </summary>
+    public static IDisposable BeginStoreScope(this IWritableMemoryStoreContext context, string? applicationId)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var previous = context.ApplicationId;
+        context.ApplicationId = applicationId;
+        return new StoreScope(context, previous);
+    }
+
+    private sealed class StoreScope : IDisposable
+    {
+        private readonly IWritableMemoryStoreContext _context;
+        private readonly string? _previous;
+        private bool _disposed;
+
+        public StoreScope(IWritableMemoryStoreContext context, string? previous)
+        {
+            _context = context;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _context.ApplicationId = _previous;
+        }
+    }
+}

--- a/src/AgentMemory.AgentFramework/AgentMemory.AgentFramework.csproj
+++ b/src/AgentMemory.AgentFramework/AgentMemory.AgentFramework.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AgentMemory.Tests.Unit" />
+    <InternalsVisibleTo Include="AgentMemory.Tests.Integration" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI.Abstractions" Version="1.9.0" />

--- a/src/AgentMemory.AgentFramework/AgentSessionMemoryExtensions.cs
+++ b/src/AgentMemory.AgentFramework/AgentSessionMemoryExtensions.cs
@@ -46,4 +46,41 @@ public static class AgentSessionMemoryExtensions
 
         return session;
     }
+
+    /// <summary>
+    /// Reads the identity values <see cref="WithMemoryIdentity"/> wrote into the session's
+    /// <c>StateBag</c> — the single source of truth both Neo4j memory providers and
+    /// <see cref="MemoryOwnerScopingAgent"/> read from, instead of each duplicating the lookup. Blank
+    /// values are normalized to <c>null</c>. Does not apply any fallback (e.g. deriving a session id from
+    /// the agent) — callers that need that own it themselves.
+    /// </summary>
+    /// <param name="session">The MAF agent session, or null.</param>
+    /// <param name="options">
+    /// Options supplying the StateBag key names. Pass the same instance you registered if you
+    /// customized the keys; otherwise the defaults (<c>user_id</c>/<c>session_id</c>/…) are used.
+    /// </param>
+    public static MemoryIdentity GetMemoryIdentity(this AgentSession? session, AgentFrameworkOptions? options = null)
+    {
+        var opts = options ?? new AgentFrameworkOptions();
+        var bag = session?.StateBag;
+        if (bag is null) return default;
+
+        var json = JsonSerializerOptions.Default;
+        bag.TryGetValue(opts.DefaultSessionIdKey, out string? sessionId, json);
+        bag.TryGetValue(opts.DefaultConversationIdKey, out string? conversationId, json);
+        bag.TryGetValue(opts.DefaultUserIdKey, out string? userId, json);
+        bag.TryGetValue(opts.DefaultApplicationIdKey, out string? applicationId, json);
+
+        return new MemoryIdentity(
+            string.IsNullOrWhiteSpace(userId) ? null : userId,
+            string.IsNullOrWhiteSpace(sessionId) ? null : sessionId,
+            string.IsNullOrWhiteSpace(conversationId) ? null : conversationId,
+            string.IsNullOrWhiteSpace(applicationId) ? null : applicationId);
+    }
 }
+
+/// <summary>
+/// The memory identity (owner, session, conversation, application/store) read off a MAF
+/// <see cref="AgentSession"/>'s state bag via <see cref="AgentSessionMemoryExtensions.GetMemoryIdentity"/>.
+/// </summary>
+public readonly record struct MemoryIdentity(string? UserId, string? SessionId, string? ConversationId, string? ApplicationId);

--- a/src/AgentMemory.AgentFramework/MemoryOwnerScopingAgent.cs
+++ b/src/AgentMemory.AgentFramework/MemoryOwnerScopingAgent.cs
@@ -1,0 +1,145 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Abstractions.Services;
+
+namespace AgentMemory.AgentFramework;
+
+/// <summary>
+/// A <see cref="DelegatingAIAgent"/> decorator that guarantees the memory owner (and, optionally,
+/// application/store) scope encloses a <em>complete</em> agent invocation — passive recall (any
+/// <c>AIContextProvider</c>/<c>ChatHistoryProvider</c> hooks), the model call, the full tool-calling loop
+/// (so <c>search_memory</c>/<c>remember_*</c> etc. observe the same owner), and automatic persistence —
+/// as one unbroken async call chain (#90).
+/// </summary>
+/// <remarks>
+/// This exists because <c>AIContextProvider</c> cannot do this on its own: its
+/// <c>ProvideAIContextAsync</c>/<c>StoreAIContextAsync</c> hooks are a pre/post pair around the
+/// invocation, not a bracket around it. Setting <see cref="IWritableMemoryOwnerContext.UserId"/> inside
+/// <c>ProvideAIContextAsync</c> does not survive into the tool-calling loop, because that hook genuinely
+/// suspends on real I/O (embedding + recall) — once MAF's own <c>await</c> on the hook resumes, the
+/// <see cref="System.Threading.AsyncLocal{T}"/>-backed value set inside it is gone. Wrapping the entire
+/// invocation here, with no intervening top-level <c>await</c>, keeps the <c>AsyncLocal</c> mutation
+/// visible for the whole call chain.
+/// </remarks>
+public sealed class MemoryOwnerScopingAgent : DelegatingAIAgent
+{
+    private readonly IWritableMemoryOwnerContext _ownerContext;
+    private readonly IWritableMemoryStoreContext? _storeContext;
+    private readonly AgentFrameworkOptions? _options;
+    private readonly ILogger _logger;
+
+    public MemoryOwnerScopingAgent(
+        AIAgent innerAgent,
+        IWritableMemoryOwnerContext ownerContext,
+        IWritableMemoryStoreContext? storeContext = null,
+        AgentFrameworkOptions? options = null,
+        ILogger<MemoryOwnerScopingAgent>? logger = null)
+        : base(innerAgent)
+    {
+        _ownerContext = ownerContext ?? throw new ArgumentNullException(nameof(ownerContext));
+        _storeContext = storeContext;
+        _options = options;
+        _logger = logger ?? NullLogger<MemoryOwnerScopingAgent>.Instance;
+    }
+
+    protected override async Task<AgentResponse> RunCoreAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var identity = GetIdentity(session);
+        using var ownerScope = _ownerContext.BeginOwnerScope(identity.UserId);
+        using var storeScope = _storeContext?.BeginStoreScope(identity.ApplicationId);
+
+        return await base.RunCoreAsync(messages, session, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session,
+        AgentRunOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var identity = GetIdentity(session);
+        using var ownerScope = _ownerContext.BeginOwnerScope(identity.UserId);
+        using var storeScope = _storeContext?.BeginStoreScope(identity.ApplicationId);
+
+        await foreach (var update in base.RunCoreStreamingAsync(messages, session, options, cancellationToken)
+            .WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            yield return update;
+        }
+    }
+
+    // Matches the providers' own tolerance for a malformed StateBag value (e.g. a rehydrated/persisted
+    // session whose bag holds a non-string JSON value under an identity key) -- fail soft to an unscoped
+    // identity rather than crash the whole invocation.
+    private MemoryIdentity GetIdentity(AgentSession? session)
+    {
+        try
+        {
+            return session.GetMemoryIdentity(_options);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not extract memory identity from session state bag.");
+            return default;
+        }
+    }
+}
+
+/// <summary>
+/// Extension for applying <see cref="MemoryOwnerScopingAgent"/> to an existing <see cref="AIAgent"/>.
+/// </summary>
+public static class AIAgentMemoryScopingExtensions
+{
+    /// <summary>
+    /// Wraps <paramref name="agent"/> so every invocation — passive recall, the model call, the full
+    /// tool-calling loop, and automatic persistence — runs inside the same owner (and, if
+    /// <paramref name="storeContext"/> is supplied, application/store) scope, guaranteed for the complete
+    /// invocation rather than only the portion inside a context-provider hook (#90). Apply this once at
+    /// agent-construction time instead of manually wrapping every <c>RunAsync</c> call in
+    /// <c>ownerContext.BeginOwnerScope(userId)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="options"/> must be the SAME <see cref="AgentFrameworkOptions"/> instance (or an
+    /// equivalent one, if the host customized <c>Default*Key</c> names) that <see cref="Neo4jMemoryContextProvider"/>
+    /// / <see cref="Neo4jChatHistoryProvider"/> were configured with — otherwise this wrapper reads the
+    /// session's identity under the wrong StateBag keys, finds nothing, and silently scopes the whole
+    /// invocation (including tool calls) to no owner. Prefer the
+    /// <see cref="WithMemoryOwnerScoping(AIAgent, IServiceProvider)"/> overload, which resolves the exact
+    /// same registered options the provider uses and cannot drift out of sync.
+    /// </remarks>
+    public static AIAgent WithMemoryOwnerScoping(
+        this AIAgent agent,
+        IWritableMemoryOwnerContext ownerContext,
+        IWritableMemoryStoreContext? storeContext = null,
+        AgentFrameworkOptions? options = null,
+        ILogger<MemoryOwnerScopingAgent>? logger = null) =>
+        new MemoryOwnerScopingAgent(agent, ownerContext, storeContext, options, logger);
+
+    /// <summary>
+    /// Wraps <paramref name="agent"/> exactly like
+    /// <see cref="WithMemoryOwnerScoping(AIAgent, IWritableMemoryOwnerContext, IWritableMemoryStoreContext?, AgentFrameworkOptions?, ILogger{MemoryOwnerScopingAgent}?)"/>,
+    /// but resolves <see cref="IWritableMemoryOwnerContext"/>, the registered <see cref="AgentFrameworkOptions"/>,
+    /// and (if registered) <see cref="IWritableMemoryStoreContext"/> from <paramref name="serviceProvider"/> --
+    /// the same container <c>Neo4jMemoryContextProvider</c>/<c>Neo4jChatHistoryProvider</c> resolve theirs
+    /// from, so the StateBag key names used to read the session's identity can never drift out of sync
+    /// with the ones the provider was configured with. This is the recommended overload.
+    /// </summary>
+    public static AIAgent WithMemoryOwnerScoping(this AIAgent agent, IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        var ownerContext = serviceProvider.GetRequiredService<IWritableMemoryOwnerContext>();
+        var storeContext = serviceProvider.GetService<IWritableMemoryStoreContext>();
+        var options = serviceProvider.GetService<IOptions<AgentFrameworkOptions>>()?.Value;
+        var logger = serviceProvider.GetService<ILogger<MemoryOwnerScopingAgent>>();
+        return new MemoryOwnerScopingAgent(agent, ownerContext, storeContext, options, logger);
+    }
+}

--- a/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
@@ -59,8 +59,8 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
         CancellationToken cancellationToken = default)
     {
         var ids = ExtractIds(context.Session, context.Agent);
-        ApplyStoreContext(ids.applicationId);
-        ApplyOwnerContext(ids.userId);
+        using var storeScope = ApplyStoreContext(ids.applicationId);
+        using var ownerScope = ApplyOwnerContext(ids.userId);
         try
         {
             var recallResult = await _memoryService.RecallAsync(
@@ -103,8 +103,8 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
         CancellationToken cancellationToken = default)
     {
         var (sessionId, conversationId, userId, applicationId) = ExtractIds(context.Session, context.Agent);
-        ApplyStoreContext(applicationId);
-        ApplyOwnerContext(userId);
+        using var storeScope = ApplyStoreContext(applicationId);
+        using var ownerScope = ApplyOwnerContext(userId);
         try
         {
             // Persist request messages (user + system turns not already in memory)
@@ -175,57 +175,39 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
         AgentSession? session,
         AIAgent? agent)
     {
-        string? sessionId = null;
-        string? conversationId = null;
-        string? userId = null;
-        string? applicationId = null;
-
+        MemoryIdentity identity;
         try
         {
-            var bag = session?.StateBag;
-            if (bag is not null)
-            {
-                bag.TryGetValue(_options.DefaultSessionIdKey, out sessionId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_options.DefaultConversationIdKey, out conversationId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_options.DefaultUserIdKey, out userId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_options.DefaultApplicationIdKey, out applicationId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-            }
+            identity = session.GetMemoryIdentity(_options);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Could not extract identity from state bag.");
+            identity = default;
         }
 
-        sessionId ??= agent?.Id ?? Guid.NewGuid().ToString("N");
+        var sessionId = identity.SessionId ?? agent?.Id ?? Guid.NewGuid().ToString("N");
         // Fall back to sessionId (not a new GUID) to preserve cross-turn correlation.
-        conversationId ??= sessionId;
+        var conversationId = identity.ConversationId ?? sessionId;
 
-        return (sessionId, conversationId,
-            string.IsNullOrWhiteSpace(userId) ? null : userId,
-            string.IsNullOrWhiteSpace(applicationId) ? null : applicationId);
+        return (sessionId, conversationId, identity.UserId, identity.ApplicationId);
     }
 
     // Routes the memory store for this scope when an application_id is supplied and a writable store
-    // context is registered (R1b). No-op otherwise.
-    private void ApplyStoreContext(string? applicationId)
-    {
-        if (applicationId is not null && _storeContext is IWritableMemoryStoreContext writable)
-            writable.ApplicationId = applicationId;
-    }
+    // context is registered (R1b). No-op otherwise. Scoped (not a bare assignment) so the value is
+    // restored once this hook returns. See MemoryOwnerScopingAgent (#90) for a guarantee spanning the
+    // complete invocation including the tool-calling loop.
+    private IDisposable? ApplyStoreContext(string? applicationId) =>
+        applicationId is not null && _storeContext is IWritableMemoryStoreContext writable
+            ? writable.BeginStoreScope(applicationId)
+            : null;
 
     // Pushes the turn's owner (IC8) into the ambient context so the LLM-invokable facade tools scope by
-    // owner without trusting the model. Set unconditionally (incl. null = shared) so a previous turn's
-    // owner can't bleed through. NOTE: the default owner context is AsyncLocal-backed and a value set in
-    // this awaited hook does not flow back to the framework caller; for guaranteed scoping the host must
-    // set the owner context around the run (or register a scoped context). See
+    // owner without trusting the model. Scoped (not a bare assignment) so the value is restored once this
+    // hook returns rather than leaking into whatever runs next. NOTE: the default owner context is
+    // AsyncLocal-backed and a value set in this awaited hook does not flow back to the framework caller,
+    // so it still can't guarantee the value survives into the tool-calling loop on its own -- see
+    // MemoryOwnerScopingAgent (#90), which wraps the complete invocation for that guarantee. See also
     // docs/reviews/review-2026-06-13-cycle3.md (finding #4).
-    private void ApplyOwnerContext(string? userId)
-    {
-        if (_ownerContext is not null)
-            _ownerContext.UserId = userId;
-    }
+    private IDisposable? ApplyOwnerContext(string? userId) => _ownerContext?.BeginOwnerScope(userId);
 }

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -52,7 +52,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     {
         var messages = context.AIContext?.Messages ?? Enumerable.Empty<ChatMessage>();
         var ids = ExtractIds(context.Session, context.Agent);
-        ApplyStoreContext(ids.applicationId);
+        using var storeScope = ApplyStoreContext(ids.applicationId);
         return await BuildContextAsync(messages, ids.sessionId, ids.conversationId, cancellationToken, ids.userId)
             .ConfigureAwait(false);
     }
@@ -68,8 +68,12 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         string? userId = null)
     {
         // Set the ambient owner BEFORE recall so the LLM-invokable facade tools the agent calls mid-turn
-        // (search_memory / remember_* etc.) scope to this owner instead of running unscoped.
-        ApplyOwnerContext(userId);
+        // (search_memory / remember_* etc.) scope to this owner instead of running unscoped. Scoped (not a
+        // bare assignment) so the value is restored once this hook returns rather than leaking into
+        // whatever runs next on this ambient context. NOTE: this hook still can't, on its own, guarantee
+        // the value survives into the tool-calling loop that runs AFTER it returns -- see
+        // MemoryOwnerScopingAgent (#90), which wraps the complete invocation for that guarantee.
+        using var ownerScope = _ownerContext?.BeginOwnerScope(userId);
         try
         {
             var userMessages = messages
@@ -156,7 +160,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
 
         var responseMessages = context.ResponseMessages ?? Enumerable.Empty<ChatMessage>();
         var ids = ExtractIds(context.Session, context.Agent);
-        ApplyStoreContext(ids.applicationId);
+        using var storeScope = ApplyStoreContext(ids.applicationId);
 
         await PerformStoreAsync(responseMessages, ids.sessionId, ids.conversationId, cancellationToken, ids.userId)
             .ConfigureAwait(false);
@@ -170,7 +174,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         CancellationToken cancellationToken,
         string? userId = null)
     {
-        ApplyOwnerContext(userId);
+        using var ownerScope = _ownerContext?.BeginOwnerScope(userId);
         try
         {
             var storedMessages = new List<Message>();
@@ -226,61 +230,31 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         AgentSession? session,
         AIAgent? agent)
     {
-        string? sessionId = null;
-        string? conversationId = null;
-        string? userId = null;
-        string? applicationId = null;
-
+        MemoryIdentity identity;
         try
         {
-            var bag = session?.StateBag;
-            if (bag is not null)
-            {
-                bag.TryGetValue(_agentOptions.DefaultSessionIdKey, out sessionId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_agentOptions.DefaultConversationIdKey, out conversationId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_agentOptions.DefaultUserIdKey, out userId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-                bag.TryGetValue(_agentOptions.DefaultApplicationIdKey, out applicationId,
-                    System.Text.Json.JsonSerializerOptions.Default);
-            }
+            identity = session.GetMemoryIdentity(_agentOptions);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Could not extract identity from state bag.");
+            identity = default;
         }
 
-        sessionId ??= agent?.Id ?? Guid.NewGuid().ToString("N");
+        var sessionId = identity.SessionId ?? agent?.Id ?? Guid.NewGuid().ToString("N");
         // P2-4: Fall back to sessionId (not a new GUID) to preserve cross-turn correlation.
-        conversationId ??= sessionId;
+        var conversationId = identity.ConversationId ?? sessionId;
 
-        return (sessionId, conversationId,
-            string.IsNullOrWhiteSpace(userId) ? null : userId,
-            string.IsNullOrWhiteSpace(applicationId) ? null : applicationId);
+        return (sessionId, conversationId, identity.UserId, identity.ApplicationId);
     }
 
     // Routes the memory store for this scope when an application_id is supplied and a writable store
-    // context is registered (R1b). No-op otherwise. Mutating a singleton context is only safe for one
-    // application per host; register a scoped IMemoryStoreContext to route per request.
-    private void ApplyStoreContext(string? applicationId)
-    {
-        if (applicationId is not null && _storeContext is IWritableMemoryStoreContext writable)
-            writable.ApplicationId = applicationId;
-    }
-
-    // Pushes the turn's owner (IC8) into the ambient context so the LLM-invokable facade tools (built
-    // from IMemoryQueryFacade) scope recall by owner and owner-stamp writes — without trusting the model
-    // to pass a user id. Set unconditionally (incl. null = shared) so a previous turn's owner can't bleed
-    // through. NOTE: the default DefaultMemoryOwnerContext is AsyncLocal-backed, and a value set inside
-    // this awaited hook does NOT propagate back to the framework's caller, so it will not, on its own,
-    // reach tool calls that run after the hook returns. For guaranteed multi-tenant scoping the host must
-    // either set IWritableMemoryOwnerContext around the agent run, or register a *scoped* owner context
-    // and run each turn in its own DI scope (then provider + tools share the same instance). See
-    // docs/reviews/review-2026-06-13-cycle3.md (finding #4).
-    private void ApplyOwnerContext(string? userId)
-    {
-        if (_ownerContext is not null)
-            _ownerContext.UserId = userId;
-    }
+    // context is registered (R1b). No-op otherwise. Scoped (not a bare assignment) so the value is
+    // restored once this hook returns. Mutating a singleton context is only safe for one application per
+    // host; register a scoped IMemoryStoreContext to route per request, or use MemoryOwnerScopingAgent
+    // (#90) to guarantee the scope spans the complete invocation including the tool-calling loop.
+    private IDisposable? ApplyStoreContext(string? applicationId) =>
+        applicationId is not null && _storeContext is IWritableMemoryStoreContext writable
+            ? writable.BeginStoreScope(applicationId)
+            : null;
 }

--- a/src/AgentMemory.AgentFramework/Properties/AssemblyInfo.cs
+++ b/src/AgentMemory.AgentFramework/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AgentMemory.Tests.Unit")]
+[assembly: InternalsVisibleTo("AgentMemory.Tests.Integration")]

--- a/src/AgentMemory.Neo4j/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddOptions<MemoryStoreOptions>().Configure(o => configureStore?.Invoke(o));
         services.TryAddSingleton<DefaultMemoryStoreContext>();
         services.TryAddSingleton<IMemoryStoreContext>(sp => sp.GetRequiredService<DefaultMemoryStoreContext>());
+        services.TryAddSingleton<IWritableMemoryStoreContext>(sp => sp.GetRequiredService<DefaultMemoryStoreContext>());
         services.TryAddSingleton<IMemoryStoreProvisioner, Neo4jMemoryStoreProvisioner>();
 
         // Short-term memory repositories

--- a/tests/AgentMemory.Tests.Integration/AgentFramework/MemoryOwnerScopingAgentIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/AgentFramework/MemoryOwnerScopingAgentIntegrationTests.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using FluentAssertions;
+using AgentMemory;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Tools;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Tests.Integration.Fixtures;
+
+// InvokingContext/InvokedContext are marked [Experimental] ("evaluation purposes only") by MAF as of
+// v1.9.0 -- constructing them directly (rather than via the framework's own invocation pipeline) is
+// exactly what this test needs to drive Neo4jMemoryContextProvider's real public entry points without a
+// full IChatClient/tool-calling loop.
+#pragma warning disable MAAI001
+
+namespace AgentMemory.Tests.Integration.AgentFramework;
+
+/// <summary>
+/// Live-Neo4j proof of #90: a real, DI-resolved <see cref="Neo4jMemoryContextProvider"/> and
+/// <see cref="MemoryToolFactory"/>, invoked through <see cref="MemoryOwnerScopingAgent"/>, observe the same
+/// owner across passive recall, a model-invoked tool call, and automatic extraction/persistence -- within
+/// one invocation, and without cross-invocation leakage under real concurrency. Complements
+/// <c>MemoryOwnerScopingAgentTests</c> (unit-level, synthetic inner agent) by exercising the real provider
+/// and tool wiring against real Neo4j.
+/// </summary>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public sealed class MemoryOwnerScopingAgentIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private ServiceProvider _provider = null!;
+
+    public MemoryOwnerScopingAgentIntegrationTests(Neo4jIntegrationFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.CleanDatabaseAsync();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Deterministic preference extractor registered BEFORE AddNeo4jAgentMemory so it wins the
+        // TryAddScoped override -- same convention as ExtractionOwnerStampIntegrationTests.cs.
+        services.AddSingleton<IPreferenceExtractor, DeterministicPreferenceExtractor>();
+
+        services.AddNeo4jAgentMemory(
+            configureMemory: _ => { },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+        services.AddAgentMemoryFramework(o => o.AutoExtractOnPersist = true);
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null) await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Invocation_ScopesToolCallAndPersistenceExtractionToSameOwner()
+    {
+        using var scope = _provider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        var ownerContext = sp.GetRequiredService<IWritableMemoryOwnerContext>();
+        var scriptedAgent = new ScriptedInnerAgent(
+            sp.GetRequiredService<Neo4jMemoryContextProvider>(),
+            sp.GetRequiredService<MemoryToolFactory>().CreateAIFunctions(),
+            responseText: "Noted that you prefer dark mode.")
+            .WithMemoryOwnerScoping(ownerContext);
+
+        var session = new TestAgentSession().WithMemoryIdentity(
+            userId: "alice", sessionId: "sess-1", conversationId: "conv-1");
+
+        await scriptedAgent.RunAsync("Remember that I prefer dark mode.", session);
+
+        // The tool call (remember_fact, simulating a model-invoked tool) must be owner-stamped alice --
+        // this is the exact mechanism #90 fixes: without MemoryOwnerScopingAgent, the ambient owner set by
+        // the provider's pre-run hook does not survive into a tool call running after that hook returns.
+        var facts = sp.GetRequiredService<IFactRepository>();
+        var fact = await facts.FindByTripleAsync("Ruaidhri", "likes", "tea", scope: MemoryScope.For("alice"));
+        fact.Should().NotBeNull("the simulated tool call ran inside the owner scope established for the whole invocation");
+        fact!.OwnerId.Should().Be("alice");
+
+        // Automatic persistence + extraction (InvokedAsync -> PerformStoreAsync) must ALSO stamp alice --
+        // proving recall/tool/persistence all observe the same owner within one invocation.
+        var preferences = sp.GetRequiredService<IPreferenceRepository>();
+        var alicePrefs = await preferences.GetByCategoryAsync("style", scope: MemoryScope.For("alice"));
+        alicePrefs.Should().ContainSingle(p => p.OwnerId == "alice");
+    }
+
+    [Fact]
+    public async Task ParallelAliceAndBobInvocations_ThroughRealProviderAndTools_DoNotLeakOwnerScope()
+    {
+        using var scope = _provider.CreateScope();
+        var sp = scope.ServiceProvider;
+        var ownerContext = sp.GetRequiredService<IWritableMemoryOwnerContext>();
+        var memoryProvider = sp.GetRequiredService<Neo4jMemoryContextProvider>();
+        var tools = sp.GetRequiredService<MemoryToolFactory>().CreateAIFunctions();
+
+        var aliceAgent = new ScriptedInnerAgent(memoryProvider, tools, "ok", factSubject: "alice", factObject: "alice-marker")
+            .WithMemoryOwnerScoping(ownerContext);
+        var bobAgent = new ScriptedInnerAgent(memoryProvider, tools, "ok", factSubject: "bob", factObject: "bob-marker")
+            .WithMemoryOwnerScoping(ownerContext);
+
+        var aliceSession = new TestAgentSession().WithMemoryIdentity(userId: "alice", sessionId: "sess-a", conversationId: "conv-a");
+        var bobSession = new TestAgentSession().WithMemoryIdentity(userId: "bob", sessionId: "sess-b", conversationId: "conv-b");
+
+        await Task.WhenAll(
+            aliceAgent.RunAsync("hi", aliceSession),
+            bobAgent.RunAsync("hi", bobSession));
+
+        var facts = sp.GetRequiredService<IFactRepository>();
+        var aliceFact = await facts.FindByTripleAsync("alice", "ran_as", "alice-marker", scope: MemoryScope.For("alice"));
+        var bobFact = await facts.FindByTripleAsync("bob", "ran_as", "bob-marker", scope: MemoryScope.For("bob"));
+
+        aliceFact.Should().NotBeNull();
+        aliceFact!.OwnerId.Should().Be("alice");
+        bobFact.Should().NotBeNull();
+        bobFact!.OwnerId.Should().Be("bob");
+    }
+
+    private sealed class TestAgentSession : AgentSession;
+
+    // A minimal AIAgent standing in for MAF's real ChatClientAgent: its RunCoreAsync drives the real
+    // Neo4jMemoryContextProvider's public InvokingAsync/InvokedAsync entry points (recall + persistence)
+    // and invokes a real MemoryToolFactory AIFunction (simulating a model-invoked tool call) in between --
+    // the exact shape a genuine tool-calling loop has, without needing a scripted IChatClient.
+    private sealed class ScriptedInnerAgent : AIAgent
+    {
+        private readonly Neo4jMemoryContextProvider _memoryProvider;
+        private readonly IReadOnlyList<AIFunction> _tools;
+        private readonly string _responseText;
+        private readonly string _factSubject;
+        private readonly string _factObject;
+
+        public ScriptedInnerAgent(
+            Neo4jMemoryContextProvider memoryProvider,
+            IReadOnlyList<AIFunction> tools,
+            string responseText,
+            string factSubject = "Ruaidhri",
+            string factObject = "tea")
+        {
+            _memoryProvider = memoryProvider;
+            _tools = tools;
+            _responseText = responseText;
+            _factSubject = factSubject;
+            _factObject = factObject;
+        }
+
+        protected override async Task<AgentResponse> RunCoreAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var requestMessages = messages.ToList();
+
+            // Pre-run: passive recall, via the provider's real public entry point.
+            var invokingContext = new AIContextProvider.InvokingContext(this, session!, new AIContext { Messages = requestMessages });
+            await _memoryProvider.InvokingAsync(invokingContext, cancellationToken).ConfigureAwait(false);
+
+            // Simulated model-invoked tool call.
+            var rememberFact = _tools.First(t => t.Name == "remember_fact");
+            var predicate = _factSubject == "Ruaidhri" ? "likes" : "ran_as";
+            await rememberFact.InvokeAsync(
+                new AIFunctionArguments(new Dictionary<string, object?>
+                {
+                    ["subject"] = _factSubject,
+                    ["predicate"] = predicate,
+                    ["object"] = _factObject,
+                }!),
+                cancellationToken).ConfigureAwait(false);
+
+            var responseMessages = new List<ChatMessage> { new(ChatRole.Assistant, _responseText) };
+
+            // Post-run: persistence + extraction, via the provider's real public entry point.
+            var invokedContext = new AIContextProvider.InvokedContext(this, session!, requestMessages, responseMessages);
+            await _memoryProvider.InvokedAsync(invokedContext, cancellationToken).ConfigureAwait(false);
+
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, _responseText));
+        }
+
+        protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await RunCoreAsync(messages, session, options, cancellationToken).ConfigureAwait(false);
+            yield return new AgentResponseUpdate(ChatRole.Assistant, response.Text);
+        }
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<AgentSession>(new TestAgentSession());
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+            JsonElement serializedSession, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<AgentSession>(new TestAgentSession());
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+            AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(default(JsonElement));
+    }
+
+    // The default Stub*Extractor registrations produce no output (Phase-1 no-ops); this deterministic
+    // extractor always turns a stored message into one preference, matching
+    // ExtractionOwnerStampIntegrationTests.cs's convention.
+    private sealed class DeterministicPreferenceExtractor : IPreferenceExtractor
+    {
+        public Task<IReadOnlyList<ExtractedPreference>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ExtractedPreference>>(
+            [
+                new ExtractedPreference { Category = "style", PreferenceText = "prefers dark mode", Confidence = 0.95 },
+            ]);
+    }
+}

--- a/tests/AgentMemory.Tests.Integration/AgentMemory.Tests.Integration.csproj
+++ b/tests/AgentMemory.Tests.Integration/AgentMemory.Tests.Integration.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Agents.AI.Abstractions" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
@@ -32,6 +33,7 @@
     <ProjectReference Include="..\..\src\AgentMemory.Core\AgentMemory.Core.csproj" />
     <ProjectReference Include="..\..\src\AgentMemory.Abstractions\AgentMemory.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\AgentMemory.McpServer\AgentMemory.McpServer.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.AgentFramework\AgentMemory.AgentFramework.csproj" />
     <ProjectReference Include="..\..\tools\AgentMemory.TckBridge\AgentMemory.TckBridge.csproj" />
   </ItemGroup>
 

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/AgentSessionMemoryExtensionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/AgentSessionMemoryExtensionsTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using AgentMemory.AgentFramework;
+
+namespace AgentMemory.Tests.Unit.AgentFramework;
+
+/// <summary>
+/// Unit tests for <see cref="AgentSessionMemoryExtensions.GetMemoryIdentity"/> -- the single-source-of-truth
+/// reader added for #90, replacing the inline <c>StateBag.TryGetValue</c> duplication previously in both
+/// <see cref="Neo4jMemoryContextProvider"/> and <see cref="Neo4jChatHistoryProvider"/>.
+/// </summary>
+public sealed class AgentSessionMemoryExtensionsTests
+{
+    [Fact]
+    public void GetMemoryIdentity_RoundTripsValuesWrittenByWithMemoryIdentity()
+    {
+        var session = new TestAgentSession().WithMemoryIdentity(
+            userId: "alice", sessionId: "s1", conversationId: "c1", applicationId: "app1");
+
+        var identity = session.GetMemoryIdentity();
+
+        identity.UserId.Should().Be("alice");
+        identity.SessionId.Should().Be("s1");
+        identity.ConversationId.Should().Be("c1");
+        identity.ApplicationId.Should().Be("app1");
+    }
+
+    [Fact]
+    public void GetMemoryIdentity_NullSession_ReturnsDefault()
+    {
+        AgentSession? session = null;
+
+        var identity = session.GetMemoryIdentity();
+
+        identity.Should().Be(default(MemoryIdentity));
+    }
+
+    [Fact]
+    public void GetMemoryIdentity_NoIdentityWritten_ReturnsAllNull()
+    {
+        var session = new TestAgentSession();
+
+        var identity = session.GetMemoryIdentity();
+
+        identity.UserId.Should().BeNull();
+        identity.SessionId.Should().BeNull();
+        identity.ConversationId.Should().BeNull();
+        identity.ApplicationId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetMemoryIdentity_BlankUserId_NormalizesToNull(string blank)
+    {
+        var session = new TestAgentSession();
+        // WithMemoryIdentity itself skips null values but not blank ones, so write directly to exercise
+        // GetMemoryIdentity's own blank-normalization independent of the writer.
+        session.StateBag.SetValue(new AgentFrameworkOptions().DefaultUserIdKey, blank, System.Text.Json.JsonSerializerOptions.Default);
+
+        var identity = session.GetMemoryIdentity();
+
+        identity.UserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetMemoryIdentity_CustomKeyNames_AreRespected()
+    {
+        var options = new AgentFrameworkOptions
+        {
+            DefaultUserIdKey = "custom_user",
+            DefaultSessionIdKey = "custom_session",
+            DefaultConversationIdKey = "custom_conversation",
+            DefaultApplicationIdKey = "custom_app",
+        };
+        var session = new TestAgentSession().WithMemoryIdentity(
+            userId: "bob", sessionId: "s2", conversationId: "c2", applicationId: "app2", options: options);
+
+        var identity = session.GetMemoryIdentity(options);
+
+        identity.UserId.Should().Be("bob");
+        identity.SessionId.Should().Be("s2");
+        identity.ConversationId.Should().Be("c2");
+        identity.ApplicationId.Should().Be("app2");
+    }
+
+    // AgentSession is abstract in Microsoft.Agents.AI.Abstractions; the concrete implementation
+    // (ChatClientAgentSession) lives in the non-Abstractions Microsoft.Agents.AI package, which this test
+    // project doesn't reference. A minimal concrete subclass is all GetMemoryIdentity/WithMemoryIdentity
+    // need (they only touch StateBag).
+    private sealed class TestAgentSession : AgentSession;
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/MemoryOwnerScopingAgentTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/MemoryOwnerScopingAgentTests.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using AgentMemory.Core.Services;
+
+namespace AgentMemory.Tests.Unit.AgentFramework;
+
+/// <summary>
+/// Proves the actual cross-await AsyncLocal propagation fix for #90 -- not just wiring. Uses a REAL
+/// (non-substitute) <see cref="DefaultMemoryOwnerContext"/> and an inner agent whose <c>RunCoreAsync</c>
+/// genuinely suspends (<c>await Task.Yield()</c>) before invoking a callback that simulates a
+/// model-invoked tool call reading the ambient owner. Today's <c>Neo4jMemoryContextProviderTests</c> only
+/// assert a substitute received a property-set call, which does not prove the value survives a real
+/// suspend/resume boundary the way this test does.
+/// </summary>
+public sealed class MemoryOwnerScopingAgentTests
+{
+    // Simulates a MAF inner agent whose invocation genuinely suspends (real async I/O, e.g. recall) before
+    // the "tool calling loop" -- represented here by invoking a caller-supplied callback -- runs.
+    private sealed class FakeInnerAgent : AIAgent
+    {
+        private readonly Func<CancellationToken, Task> _simulatedToolCall;
+
+        public FakeInnerAgent(Func<CancellationToken, Task> simulatedToolCall) => _simulatedToolCall = simulatedToolCall;
+
+        protected override async Task<AgentResponse> RunCoreAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            // A genuine suspend point -- mirrors ProvideAIContextAsync awaiting real recall I/O.
+            await Task.Yield();
+            await _simulatedToolCall(cancellationToken);
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "ok"));
+        }
+
+        protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session,
+            AgentRunOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            await _simulatedToolCall(cancellationToken);
+            yield return new AgentResponseUpdate(ChatRole.Assistant, "ok");
+        }
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<AgentSession>(new TestAgentSession());
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+            JsonElement serializedSession, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<AgentSession>(new TestAgentSession());
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+            AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(default(JsonElement));
+    }
+
+    private static AgentSession SessionFor(string? userId) =>
+        new TestAgentSession().WithMemoryIdentity(userId: userId, sessionId: "s1", conversationId: "c1");
+
+    private sealed class TestAgentSession : AgentSession;
+
+    [Fact]
+    public async Task RunAsync_SimulatedToolCallAfterGenuineSuspend_ObservesConfiguredOwner()
+    {
+        var ownerContext = new DefaultMemoryOwnerContext();
+        string? observedByTool = "not-set";
+
+        var inner = new FakeInnerAgent(_ =>
+        {
+            observedByTool = ownerContext.UserId;
+            return Task.CompletedTask;
+        });
+        var scopedAgent = inner.WithMemoryOwnerScoping(ownerContext);
+
+        await scopedAgent.RunAsync("hello", SessionFor("alice"));
+
+        observedByTool.Should().Be("alice",
+            "the owner scope must still be visible to a tool call that runs after a genuine await, " +
+            "which a bare (non-scope-wrapping) assignment inside a context-provider hook cannot guarantee");
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterInvocation_RestoresPreviousAmbientOwner()
+    {
+        var ownerContext = new DefaultMemoryOwnerContext { UserId = "outer" };
+        var inner = new FakeInnerAgent(_ => Task.CompletedTask);
+        var scopedAgent = inner.WithMemoryOwnerScoping(ownerContext);
+
+        await scopedAgent.RunAsync("hello", SessionFor("alice"));
+
+        ownerContext.UserId.Should().Be("outer", "the scope must not leak past the invocation it wrapped");
+    }
+
+    [Fact]
+    public async Task RunStreamingAsync_SimulatedToolCallAfterGenuineSuspend_ObservesConfiguredOwner()
+    {
+        var ownerContext = new DefaultMemoryOwnerContext();
+        string? observedByTool = "not-set";
+
+        var inner = new FakeInnerAgent(_ =>
+        {
+            observedByTool = ownerContext.UserId;
+            return Task.CompletedTask;
+        });
+        var scopedAgent = inner.WithMemoryOwnerScoping(ownerContext);
+
+        await foreach (var _ in scopedAgent.RunStreamingAsync("hello", SessionFor("bob"))) { }
+
+        observedByTool.Should().Be("bob");
+    }
+
+    [Fact]
+    public async Task ParallelInvocations_ForDifferentOwners_DoNotLeakOwnerScope()
+    {
+        // The issue's explicit acceptance criterion: concurrent invocations for different owners must not
+        // leak into one another, even though both share the same singleton-style DefaultMemoryOwnerContext
+        // instance (matching how it's registered in DI -- a singleton, relying on AsyncLocal for
+        // per-flow isolation, not per-DI-scope isolation).
+        var ownerContext = new DefaultMemoryOwnerContext();
+        string? aliceObserved = null;
+        string? bobObserved = null;
+
+        var aliceAgent = new FakeInnerAgent(async _ =>
+        {
+            await Task.Delay(20); // interleave with the other concurrent invocation
+            aliceObserved = ownerContext.UserId;
+        }).WithMemoryOwnerScoping(ownerContext);
+
+        var bobAgent = new FakeInnerAgent(async _ =>
+        {
+            await Task.Delay(5);
+            bobObserved = ownerContext.UserId;
+        }).WithMemoryOwnerScoping(ownerContext);
+
+        await Task.WhenAll(
+            aliceAgent.RunAsync("hi", SessionFor("alice")),
+            bobAgent.RunAsync("hi", SessionFor("bob")));
+
+        aliceObserved.Should().Be("alice");
+        bobObserved.Should().Be("bob");
+    }
+
+    [Fact]
+    public async Task RunAsync_NoUserIdOnSession_ScopesToSharedGlobal()
+    {
+        var ownerContext = new DefaultMemoryOwnerContext { UserId = "stale-from-previous-turn" };
+        string? observed = "not-set";
+        var inner = new FakeInnerAgent(_ =>
+        {
+            observed = ownerContext.UserId;
+            return Task.CompletedTask;
+        });
+        var scopedAgent = inner.WithMemoryOwnerScoping(ownerContext);
+
+        await scopedAgent.RunAsync("hello", SessionFor(userId: null));
+
+        observed.Should().BeNull("an unscoped session must not inherit a stale owner left over from a previous turn");
+    }
+
+    [Fact]
+    public async Task WithMemoryOwnerScoping_ServiceProviderOverload_ResolvesCustomizedKeyNamesConsistently()
+    {
+        // Regression test for a real gap an adversarial review caught: if a host customizes
+        // AgentFrameworkOptions.Default*Key, the wrapper and the provider MUST read the session's identity
+        // under the same key -- otherwise the wrapper silently scopes the whole invocation (incl. tool
+        // calls) to no owner, even though the identity WAS written to the session correctly. The
+        // IServiceProvider overload resolves the same registered AgentFrameworkOptions the provider does,
+        // so this can't drift out of sync.
+        var services = new ServiceCollection();
+        services.AddOptions<AgentFrameworkOptions>().Configure(o => o.DefaultUserIdKey = "custom_user_key");
+        services.AddSingleton<DefaultMemoryOwnerContext>();
+        services.AddSingleton<IWritableMemoryOwnerContext>(sp => sp.GetRequiredService<DefaultMemoryOwnerContext>());
+        var provider = services.BuildServiceProvider();
+
+        var agentOptions = provider.GetRequiredService<IOptions<AgentFrameworkOptions>>().Value;
+        var session = new TestAgentSession().WithMemoryIdentity(userId: "alice", sessionId: "s1", options: agentOptions);
+
+        string? observed = "not-set";
+        var inner = new FakeInnerAgent(_ =>
+        {
+            observed = provider.GetRequiredService<IWritableMemoryOwnerContext>().UserId;
+            return Task.CompletedTask;
+        });
+
+        var scopedAgent = inner.WithMemoryOwnerScoping(provider);
+
+        await scopedAgent.RunAsync("hello", session);
+
+        observed.Should().Be("alice", "the IServiceProvider overload must read the same customized StateBag key the identity was written under");
+    }
+
+    [Fact]
+    public void WithMemoryOwnerScoping_ManualOverloadWithMismatchedOptions_DocumentsTheFootgunItReplaces()
+    {
+        // Documents the exact failure mode the IServiceProvider overload above exists to prevent: the
+        // manual (ownerContext-only) overload defaults to un-customized AgentFrameworkOptions when no
+        // options are passed, so if the session's identity was written under a CUSTOMIZED key, the
+        // wrapper reads the WRONG (default) key and gets nothing -- silently unscoping the invocation.
+        var writerOptions = new AgentFrameworkOptions { DefaultUserIdKey = "custom_user_key" };
+        var session = new TestAgentSession().WithMemoryIdentity(userId: "alice", sessionId: "s1", options: writerOptions);
+
+        // The wrapper, using default (un-customized) options because none were passed:
+        var identityAsWrapperSeesIt = session.GetMemoryIdentity(options: null);
+
+        identityAsWrapperSeesIt.UserId.Should().BeNull(
+            "this is why the IServiceProvider overload (which resolves the SAME registered options) is recommended over passing an IWritableMemoryOwnerContext directly");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Samples/AgentWithMemoryGoldenPathSourceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Samples/AgentWithMemoryGoldenPathSourceTests.cs
@@ -17,8 +17,8 @@ public sealed class AgentWithMemoryGoldenPathSourceTests
             "the agent must use the DI-provided chat client rather than constructing the mock inline");
         source.Should().Contain("WithMemoryIdentity(",
             "provider swaps must not bypass application/user/session/conversation scoping");
-        source.Should().Contain("ownerContext.BeginOwnerScope(userId)",
-            "model-invoked memory tools must inherit trusted host identity with real providers too");
+        source.Should().Contain("WithMemoryOwnerScoping(",
+            "model-invoked memory tools must inherit trusted host identity for the complete invocation (#90), guaranteed automatically rather than via a manually-wrapped BeginOwnerScope");
     }
 
     private static string FindRepoFile(string relativePath)

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryStoreContextExtensionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryStoreContextExtensionsTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using AgentMemory.Abstractions.Services;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// Mirrors <see cref="MemoryOwnerContextExtensionsTests"/> for <see cref="MemoryStoreContextExtensions.BeginStoreScope"/>.
+/// </summary>
+public sealed class MemoryStoreContextExtensionsTests
+{
+    private sealed class TestStoreContext : IWritableMemoryStoreContext
+    {
+        public string? ApplicationId { get; set; }
+    }
+
+    private static async Task<string?> ReadApplicationIdLikeAToolCall(IMemoryStoreContext ctx)
+    {
+        await Task.Yield();
+        return ctx.ApplicationId;
+    }
+
+    [Fact]
+    public async Task BeginStoreScope_FlowsApplicationIdIntoAwaitedNestedWork()
+    {
+        var ctx = new TestStoreContext();
+
+        string? observed;
+        using (ctx.BeginStoreScope("app-1"))
+        {
+            observed = await ReadApplicationIdLikeAToolCall(ctx);
+        }
+
+        observed.Should().Be("app-1");
+    }
+
+    [Fact]
+    public async Task BeginStoreScope_RestoresPreviousValue_OnDispose()
+    {
+        var ctx = new TestStoreContext();
+
+        using (ctx.BeginStoreScope("app-1"))
+        {
+            ctx.ApplicationId.Should().Be("app-1");
+            await Task.Yield();
+        }
+
+        ctx.ApplicationId.Should().BeNull("the scope restores the previous (default-store) application on dispose");
+    }
+
+    [Fact]
+    public async Task BeginStoreScope_Nested_RestoresOuterApplicationId()
+    {
+        var ctx = new TestStoreContext();
+
+        using (ctx.BeginStoreScope("app-1"))
+        {
+            ctx.ApplicationId.Should().Be("app-1");
+            using (ctx.BeginStoreScope("app-2"))
+            {
+                (await ReadApplicationIdLikeAToolCall(ctx)).Should().Be("app-2");
+            }
+            ctx.ApplicationId.Should().Be("app-1", "disposing the inner scope restores the outer application id");
+        }
+
+        ctx.ApplicationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BeginStoreScope_NullApplicationId_ScopesToDefaultStore()
+    {
+        var ctx = new TestStoreContext { ApplicationId = "app-1" };
+
+        using (ctx.BeginStoreScope(null))
+        {
+            (await ReadApplicationIdLikeAToolCall(ctx)).Should().BeNull("a null application id scopes the work to the default store");
+        }
+
+        ctx.ApplicationId.Should().Be("app-1");
+    }
+
+    [Fact]
+    public void BeginStoreScope_NullContext_Throws()
+    {
+        IWritableMemoryStoreContext ctx = null!;
+        FluentActions.Invoking(() => ctx.BeginStoreScope("x"))
+            .Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

`Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider` push the turn's owner into the `AsyncLocal`-backed `IWritableMemoryOwnerContext` from their pre-run hook (`ProvideAIContextAsync`/`ProvideChatHistoryAsync`). That hook genuinely suspends on real I/O (embedding + recall), so once MAF's own `await` on it resumes, the mutation no longer reliably reaches the tool-calling loop that runs *after* the hook returns — `search_memory`/`remember_fact`/etc. could silently run unscoped, or against a stale owner left over from a prior turn.

- New `MemoryOwnerScopingAgent : DelegatingAIAgent` — wraps the **complete** invocation (recall, model call, tool-calling loop, and persistence) in one unbroken async chain, so the owner scope is guaranteed visible throughout, not just inside the provider hook.
- `AIAgent.WithMemoryOwnerScoping(...)` — apply it once at agent-construction time instead of manually wrapping every `RunAsync` call in `ownerContext.BeginOwnerScope(userId)`.
- `AgentSessionMemoryExtensions.GetMemoryIdentity(...)` — single-source-of-truth reader, replacing duplicated inline `StateBag` lookups in both providers.
- `IWritableMemoryStoreContext.BeginStoreScope(...)` — mirrors `BeginOwnerScope` for the application/store axis; both providers' `ApplyOwnerContext`/`ApplyStoreContext` now use scoped (restore-on-dispose) semantics instead of a bare, never-undone assignment.
- Fail-closed validation (the issue's "Option D") is already delivered by #100's `IMemoryIsolationPolicy`/`StrictMultiTenant` mode — no duplicate exception type introduced.
- Canonical sample (`AgentMemory.Sample.AgentWithMemory`) and docs (`docs/agent-framework.md`, `docs/getting-started.md`) updated to demonstrate the new pattern as the supported production path.

**An adversarial review (independent fresh-agent pass) caught a real gap before this was opened**: the `ownerContext`-only overload silently reads the session's identity under the *wrong* StateBag keys — and therefore resolves no owner at all — if a host customizes `AgentFrameworkOptions`' key names without also passing matching options to the wrapper. This is exactly the class of silent failure #90 exists to eliminate. Fixed by:
- Adding a `WithMemoryOwnerScoping(IServiceProvider)` overload that resolves the *same* registered `AgentFrameworkOptions` the provider uses, so the two can't drift out of sync — this is now the recommended overload in the sample and docs.
- Registering the previously-missing `IWritableMemoryStoreContext` DI binding (`AgentMemory.Neo4j`'s `ServiceCollectionExtensions.cs` registered only the read-only `IMemoryStoreContext`), so the store/application axis can also be resolved via DI the same way.
- Two new regression tests (`MemoryOwnerScopingAgentTests.cs`) documenting the failure mode and proving the `IServiceProvider` overload avoids it.
- A `GetMemoryIdentity()` call in the wrapper is now guarded (matching the providers' existing tolerance for a malformed `StateBag` value), so a rehydrated session with unexpected content fails soft instead of crashing the whole invocation.

## Test plan

- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings/errors
- [x] Full unit suite: 2741 passed, 0 failed — including a real (non-substitute) `DefaultMemoryOwnerContext` test proving the actual cross-await propagation fix (not just wiring), a concurrent Alice/Bob invocations test, and the two new DI-overload regression tests
- [x] Full live-Neo4j integration suite (Testcontainers): 282 passed, 0 failed — including a new end-to-end test driving the real `Neo4jMemoryContextProvider` + `MemoryToolFactory` through `MemoryOwnerScopingAgent` (recall + a simulated model-invoked tool call + automatic extraction/persistence all observing the same owner) and a real-Neo4j parallel Alice/Bob test
- [x] Independent adversarial review pass, findings fixed and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)