### PR TITLE
Wire configured RecallOptions into native MAF recall (#87)

### DIFF
--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -53,6 +53,15 @@ derives from `Microsoft.Agents.AI.AIContextProvider` and implements the framewor
 This is the same **bidirectional** behavior the official provider describes ("auto-retrieve before
 invocation, auto-save after responses") — recall is passive and automatic; you never call it by hand.
 
+Native recall via `Neo4jMemoryContextProvider` respects your configured `MemoryOptions.Recall` (limits,
+`MinSimilarityScore`, `BlendMode`, etc.) — the same options that shape a direct
+`IMemoryService.RecallAsync(...)` call (#87). The one exception is `RecallOptions.Scope`: native recall
+always derives scope from the invocation's authenticated owner (via #100's isolation policy), never from a
+statically configured `Scope`, so a global config value can't silently override the real, per-invocation
+owner. `Neo4jMicrosoftMemoryFacade` (the lower-level, manually-driven alternative to the context provider)
+does not yet wire configured `RecallOptions` into its own recall call — a known gap for a future pass, not
+covered by this fix.
+
 Alongside the passive provider, AgentMemory exposes **active memory tools** the model can call
 explicitly (search memory, remember a preference, find entity connections) via
 `MemoryToolFactory.CreateAIFunctions()` — the counterpart of the Python provider's

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework.Mapping;
 
@@ -15,6 +16,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
 {
     private readonly IMemoryService _memoryService;
     private readonly IEmbeddingOrchestrator _embeddingOrchestrator;
+    private readonly RecallOptions _recallOptions;
     private readonly ContextFormatOptions _formatOptions;
     private readonly AgentFrameworkOptions _agentOptions;
     private readonly IMemoryStoreContext? _storeContext;
@@ -24,6 +26,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     public Neo4jMemoryContextProvider(
         IMemoryService memoryService,
         IEmbeddingOrchestrator embeddingOrchestrator,
+        IOptions<MemoryOptions> memoryOptions,
         IOptions<ContextFormatOptions> formatOptions,
         IOptions<AgentFrameworkOptions> agentOptions,
         ILogger<Neo4jMemoryContextProvider> logger,
@@ -36,6 +39,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     {
         _memoryService = memoryService ?? throw new ArgumentNullException(nameof(memoryService));
         _embeddingOrchestrator = embeddingOrchestrator ?? throw new ArgumentNullException(nameof(embeddingOrchestrator));
+        _recallOptions = memoryOptions?.Value.Recall ?? RecallOptions.Default;
         _formatOptions = formatOptions?.Value ?? new ContextFormatOptions();
         _agentOptions = agentOptions?.Value ?? new AgentFrameworkOptions();
         _storeContext = storeContext;
@@ -106,7 +110,14 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                 SessionId = sessionId,
                 UserId = userId,
                 Query = queryText,
-                QueryEmbedding = queryEmbedding
+                QueryEmbedding = queryEmbedding,
+                // Retrieval tuning (limits, MinSimilarityScore, BlendMode, Intent) comes from the
+                // configured RecallOptions (#87) -- but Scope is explicitly cleared: scope must always be
+                // resolved from this invocation's authenticated userId (via #100's isolation policy),
+                // never from a statically configured value. A host who ever sets
+                // MemoryOptions.Recall.Scope globally must not have it silently override the real,
+                // per-invocation owner here.
+                Options = _recallOptions with { Scope = null }
             };
 
             RecallResult recallResult;

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
 using NSubstitute;
@@ -21,6 +22,7 @@ public sealed class Neo4jMemoryContextProviderTests
         _sut = new Neo4jMemoryContextProvider(
             _memoryService,
             _embeddingOrchestrator,
+            Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()),
             Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance);
@@ -30,6 +32,83 @@ public sealed class Neo4jMemoryContextProviderTests
     {
         Context = new MemoryContext { SessionId = sessionId, AssembledAtUtc = DateTimeOffset.UtcNow }
     };
+
+    private Neo4jMemoryContextProvider CreateSutWithRecallOptions(RecallOptions recall) =>
+        new(
+            _memoryService,
+            _embeddingOrchestrator,
+            Options.Create(new MemoryOptions { Recall = recall }),
+            Options.Create(new ContextFormatOptions()),
+            Options.Create(new AgentFrameworkOptions()),
+            NullLogger<Neo4jMemoryContextProvider>.Instance);
+
+    // ── Configured RecallOptions reach native MAF recall (#87) ─────────────
+
+    [Fact]
+    public async Task BuildContextAsync_UsesConfiguredRecallOptions()
+    {
+        var configuredRecall = new RecallOptions
+        {
+            MaxFacts = 3,
+            MaxEntities = 4,
+            MinSimilarityScore = 0.85,
+            BlendMode = RetrievalBlendMode.MemoryOnly
+        };
+        var sut = CreateSutWithRecallOptions(configuredRecall);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "What do you know about this customer?") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(request =>
+                request.Options!.MaxFacts == 3 &&
+                request.Options.MaxEntities == 4 &&
+                request.Options.MinSimilarityScore == 0.85 &&
+                request.Options.BlendMode == RetrievalBlendMode.MemoryOnly),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_ConfiguredScope_NeverOverridesTheInvocationOwner()
+    {
+        // A static, globally-configured Scope must not silently override the real, per-invocation owner
+        // (#100's isolation policy resolves scope from RecallRequest.UserId) -- this is the exact risk
+        // flagged when sequencing #87 after #100.
+        var configuredRecall = new RecallOptions { Scope = MemoryScope.For("some-other-owner") };
+        var sut = CreateSutWithRecallOptions(configuredRecall);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            "s1", "c1", CancellationToken.None, userId: "alice");
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(request => request.Options!.Scope == null && request.UserId == "alice"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_NoConfiguredRecallOptions_UsesDefaults()
+    {
+        // Existing default behavior must remain unchanged when the host does not customize recall options.
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await _sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(request =>
+                request.Options!.MaxFacts == RecallOptions.Default.MaxFacts &&
+                request.Options.MaxEntities == RecallOptions.Default.MaxEntities &&
+                request.Options.BlendMode == RecallOptions.Default.BlendMode),
+            Arg.Any<CancellationToken>());
+    }
 
     // ── BuildContextAsync (internal, tested via InternalsVisibleTo) ────────
 
@@ -188,7 +267,7 @@ public sealed class Neo4jMemoryContextProviderTests
     {
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator,
+            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
         _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -207,7 +286,7 @@ public sealed class Neo4jMemoryContextProviderTests
     {
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator,
+            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
 
@@ -224,7 +303,7 @@ public sealed class Neo4jMemoryContextProviderTests
         // An unowned turn must reset the ambient owner to null (shared), never inherit a previous turn's.
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator,
+            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
         _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -246,6 +325,7 @@ public sealed class Neo4jMemoryContextProviderTests
         new(
             _memoryService,
             _embeddingOrchestrator,
+            Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()),
             Options.Create(agentOptions ?? new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance);


### PR DESCRIPTION
## Summary

`Neo4jMemoryContextProvider.BuildContextAsync` built its `RecallRequest` without assigning `.Options`, so native MAF recall always used `RecallOptions.Default` regardless of what the host configured via `MemoryOptions.Recall` — a customized `MinSimilarityScore`, per-section limit (`MaxFacts`/`MaxEntities`/etc.), or `BlendMode` silently had no effect on the automatic recall path, even though it worked correctly for a direct `IMemoryService.RecallAsync` call.

- `Neo4jMemoryContextProvider` now takes `IOptions<MemoryOptions>` and passes the configured `RecallOptions` through — **but with `Scope` explicitly cleared** (`_recallOptions with { Scope = null }`): scope must always be resolved from the invocation's authenticated `userId` via #100's isolation policy, never from a statically configured value. This directly addresses the sequencing concern raised when this issue was scoped after #100 — a host who ever sets `MemoryOptions.Recall.Scope` globally must not have it silently override the real, per-invocation owner.
- New tests: configured `RecallOptions` (limits/`MinSimilarityScore`/`BlendMode`) reach `IMemoryService.RecallAsync`; a configured `Scope` never overrides the invocation's owner; default behavior is unchanged when nothing is customized.

**An adversarial review** traced the full call path (`Neo4jMemoryContextProvider` → `MemoryService.RecallAsync` → `MemoryContextAssembler.AssembleContextAsync` → `IMemoryIsolationPolicy.ResolveReadScope`) to independently confirm no other layer reintroduces the cleared `Scope`, confirmed the DI change doesn't break any other construction site (only the test file constructs this provider directly, and it's now updated), and confirmed the new `Scope`-safety test is genuinely falsifiable (would fail if the `with { Scope = null }` were ever reverted). It flagged one out-of-scope, disclosed observation: `Neo4jMicrosoftMemoryFacade` (a lower-level, manually-driven alternative to the context provider) has the same class of gap in its own recall call — not part of this fix, since the issue's own file list scopes this to the `AIContextProvider` path; docs updated to note it as known follow-up rather than implying full coverage.

## Test plan

- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings/errors
- [x] Full unit suite: 2744 passed, 0 failed — including 3 new tests on this branch
- [x] Full live-Neo4j integration suite (Testcontainers): 282 passed, 0 failed
- [x] Independent adversarial review pass — fix confirmed sound, one out-of-scope gap disclosed in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)