### PR TITLE
Persist and extract from the complete turn, not just the response (#89)

### DIFF
--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -48,7 +48,7 @@ derives from `Microsoft.Agents.AI.AIContextProvider` and implements the framewor
 | MAF hook (C#) | When | What AgentMemory does | Python equivalent |
 |---|---|---|---|
 | `ProvideAIContextAsync(InvokingContext)` → `AIContext` | **Before** the model call | Embeds the user turn, recalls relevant memory, and returns it as `AIContext.Messages` to prepend to the prompt. | `before_run` |
-| `StoreAIContextAsync(InvokedContext)` | **After** the response | Persists the response messages and (optionally) runs extraction into the graph. Skipped if the run threw (`context.InvokeException`). | `after_run` |
+| `StoreAIContextAsync(InvokedContext)` | **After** the response | Persists the response messages and (optionally) runs extraction over the complete turn (request + response) into the graph. Skipped if the run threw (`context.InvokeException`). | `after_run` |
 
 This is the same **bidirectional** behavior the official provider describes ("auto-retrieve before
 invocation, auto-save after responses") — recall is passive and automatic; you never call it by hand.
@@ -58,7 +58,28 @@ Native recall via `Neo4jMemoryContextProvider` respects your configured `MemoryO
 `IMemoryService.RecallAsync(...)` call (#87). The one exception is `RecallOptions.Scope`: native recall
 always derives scope from the invocation's authenticated owner (via #100's isolation policy), never from a
 statically configured `Scope`, so a global config value can't silently override the real, per-invocation
-owner. `Neo4jMicrosoftMemoryFacade` (the lower-level, manually-driven alternative to the context provider)
+owner. Automatic extraction (`AutoExtractOnPersist`) considers the **complete turn** — both what the user asked
+and what the assistant answered (#89), filtered to user-role content so a system prompt or other non-user
+text isn't minted into spurious entities/facts/preferences every turn — so a preference or fact the user
+states is captured even if the assistant never repeats it back. `Neo4jChatHistoryProvider` persists both
+request and response messages as real `:Message` nodes (unchanged), so extraction there has full
+provenance. `Neo4jMemoryContextProvider` deliberately does **not** persist request messages as new nodes
+— only response messages are — because a host may already have `Neo4jChatHistoryProvider`,
+`Neo4jChatMessageStore`, or their own component persisting the same request messages on the same agent,
+and there is no idempotency mechanism (no caller-supplied message id, no upsert-by-content) that would let
+this provider safely avoid creating a duplicate `:Message` node for the same logical message. The
+practical effect: a fact/preference extracted from the user's own request is still created and recallable,
+but both its `EXTRACTED_FROM` provenance edge and its own `source_message_ids` property will reference a
+message id that was never persisted, unless another component also persisted that exact message.
+
+**This asymmetry is deliberate for requests, but note it does not (yet) extend to responses**: both
+`Neo4jMemoryContextProvider` and `Neo4jChatHistoryProvider` persist response messages unconditionally, with
+the same lack of an idempotency mechanism — so combining both providers (or either with
+`Neo4jChatMessageStore`/a custom component) on the same agent can still duplicate **response** `:Message`
+nodes today. Avoid wiring more than one message-persisting component onto the same agent until a real
+cross-component idempotency mechanism exists.
+
+`Neo4jMicrosoftMemoryFacade` (the lower-level, manually-driven alternative to the context provider)
 does not yet wire configured `RecallOptions` into its own recall call — a known gap for a future pass, not
 covered by this fix.
 

--- a/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
@@ -104,26 +104,45 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
     {
         var (sessionId, conversationId, userId, applicationId) = ExtractIds(context.Session, context.Agent);
         using var storeScope = ApplyStoreContext(applicationId);
+        await PerformStoreAsync(
+            context.RequestMessages, context.ResponseMessages ?? [], sessionId, conversationId, cancellationToken, userId)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Internal helper exposed for unit testing.</summary>
+    internal async Task PerformStoreAsync(
+        IEnumerable<ChatMessage> requestMessages,
+        IEnumerable<ChatMessage> responseMessages,
+        string sessionId,
+        string conversationId,
+        CancellationToken cancellationToken,
+        string? userId = null)
+    {
         using var ownerScope = ApplyOwnerContext(userId);
         try
         {
-            // Persist request messages (user + system turns not already in memory)
-            foreach (var msg in context.RequestMessages)
+            // Persist request messages (user + system turns not already in memory). Both request and
+            // response messages are genuinely persisted here, so -- unlike Neo4jMemoryContextProvider,
+            // which deliberately does NOT persist request messages to avoid duplicating what this
+            // provider already stores -- extraction can safely see both with full provenance (#89).
+            var storedRequests = new List<Abstractions.Domain.Message>();
+            foreach (var msg in requestMessages)
             {
                 if (string.IsNullOrWhiteSpace(msg.Text)) continue;
                 var message = MafTypeMapper.ToInternalMessage(
                     msg, sessionId, conversationId, _clock, _idGenerator);
-                await _memoryService
+                var stored = await _memoryService
                     .AddMessageAsync(
                         message.SessionId, message.ConversationId,
                         message.Role, message.Content, message.Metadata,
                         cancellationToken)
                     .ConfigureAwait(false);
+                storedRequests.Add(stored);
             }
 
             // Persist response messages
             var storedResponses = new List<Abstractions.Domain.Message>();
-            foreach (var msg in context.ResponseMessages ?? [])
+            foreach (var msg in responseMessages)
             {
                 if (string.IsNullOrWhiteSpace(msg.Text)) continue;
                 var stored = await _memoryService
@@ -136,15 +155,20 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
                 storedResponses.Add(stored);
             }
 
-            // Optionally trigger knowledge extraction on the persisted responses
-            if (_options.AutoExtractOnPersist && storedResponses.Count > 0)
+            // Optionally trigger knowledge extraction on the complete persisted turn (#89): a fact or
+            // preference the user states in their request is now captured even if the assistant never
+            // repeats it back. Extraction input is filtered to user-role request messages -- persistence
+            // above still stores every role (unchanged), but a system prompt or other non-user content
+            // in RequestMessages shouldn't be minted into spurious entities/facts/preferences every turn.
+            var turnMessages = storedRequests.Where(m => m.Role == "user").Concat(storedResponses).ToList();
+            if (_options.AutoExtractOnPersist && turnMessages.Count > 0)
             {
                 try
                 {
                     await _memoryService.ExtractAndPersistAsync(
                         new Abstractions.Domain.ExtractionRequest
                         {
-                            Messages = storedResponses,
+                            Messages = turnMessages,
                             SessionId = sessionId,
                             UserId = userId
                         }, cancellationToken).ConfigureAwait(false);

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -16,6 +16,8 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
 {
     private readonly IMemoryService _memoryService;
     private readonly IEmbeddingOrchestrator _embeddingOrchestrator;
+    private readonly IClock _clock;
+    private readonly IIdGenerator _idGenerator;
     private readonly RecallOptions _recallOptions;
     private readonly ContextFormatOptions _formatOptions;
     private readonly AgentFrameworkOptions _agentOptions;
@@ -26,6 +28,8 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     public Neo4jMemoryContextProvider(
         IMemoryService memoryService,
         IEmbeddingOrchestrator embeddingOrchestrator,
+        IClock clock,
+        IIdGenerator idGenerator,
         IOptions<MemoryOptions> memoryOptions,
         IOptions<ContextFormatOptions> formatOptions,
         IOptions<AgentFrameworkOptions> agentOptions,
@@ -39,6 +43,8 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     {
         _memoryService = memoryService ?? throw new ArgumentNullException(nameof(memoryService));
         _embeddingOrchestrator = embeddingOrchestrator ?? throw new ArgumentNullException(nameof(embeddingOrchestrator));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _idGenerator = idGenerator ?? throw new ArgumentNullException(nameof(idGenerator));
         _recallOptions = memoryOptions?.Value.Recall ?? RecallOptions.Default;
         _formatOptions = formatOptions?.Value ?? new ContextFormatOptions();
         _agentOptions = agentOptions?.Value ?? new AgentFrameworkOptions();
@@ -169,16 +175,18 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
             return;
         }
 
+        var requestMessages = context.RequestMessages ?? Enumerable.Empty<ChatMessage>();
         var responseMessages = context.ResponseMessages ?? Enumerable.Empty<ChatMessage>();
         var ids = ExtractIds(context.Session, context.Agent);
         using var storeScope = ApplyStoreContext(ids.applicationId);
 
-        await PerformStoreAsync(responseMessages, ids.sessionId, ids.conversationId, cancellationToken, ids.userId)
+        await PerformStoreAsync(requestMessages, responseMessages, ids.sessionId, ids.conversationId, cancellationToken, ids.userId)
             .ConfigureAwait(false);
     }
 
     /// <summary>Internal helper exposed for unit testing.</summary>
     internal async Task PerformStoreAsync(
+        IEnumerable<ChatMessage> requestMessages,
         IEnumerable<ChatMessage> responseMessages,
         string sessionId,
         string conversationId,
@@ -188,6 +196,21 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         using var ownerScope = _ownerContext?.BeginOwnerScope(userId);
         try
         {
+            // Response messages are persisted as new :Message nodes, as before. Request messages are
+            // deliberately NOT persisted here (#89): a host may already have a Neo4jChatHistoryProvider,
+            // Neo4jChatMessageStore, or their own component persisting the same request messages on this
+            // agent, and there is no idempotency mechanism (no MERGE-by-id, no caller-supplied id) that
+            // would let this provider safely avoid creating a second, duplicate :Message node for the
+            // same logical message. Building transient (never-persisted) Message objects for extraction
+            // only avoids that risk entirely while still capturing what the user said. Filtered to
+            // ChatRole.User -- the same filter recall already applies (BuildContextAsync above) -- so a
+            // system prompt or other non-user content accumulated in RequestMessages doesn't get minted
+            // into spurious entities/facts/preferences every turn.
+            var transientRequestMessages = requestMessages
+                .Where(msg => msg.Role == ChatRole.User && !string.IsNullOrWhiteSpace(msg.Text))
+                .Select(msg => MafTypeMapper.ToInternalMessage(msg, sessionId, conversationId, _clock, _idGenerator))
+                .ToList();
+
             var storedMessages = new List<Message>();
             foreach (var msg in responseMessages)
             {
@@ -203,14 +226,25 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                 storedMessages.Add(stored);
             }
 
-            if (_agentOptions.AutoExtractOnPersist && storedMessages.Count > 0)
+            // Extraction sees the complete turn (#89): a fact or preference the user states in their
+            // request is now captured even if the assistant never repeats it back. Because
+            // transientRequestMessages were never persisted as :Message nodes above, provenance for
+            // anything extracted from them is incomplete: the EXTRACTED_FROM edge silently fails to
+            // attach (the MATCH in PersistenceStage's linking Cypher finds no such node), AND the
+            // extracted node's own source_message_ids property will still list the transient (never
+            // persisted) message id, i.e. a dangling reference, not just a missing edge. The extracted
+            // fact/preference itself is still created and recallable correctly; only its link back to the
+            // literal source message is best-effort, not guaranteed, unless another component also
+            // persisted that exact message.
+            var turnMessages = transientRequestMessages.Concat(storedMessages).ToList();
+            if (_agentOptions.AutoExtractOnPersist && turnMessages.Count > 0)
             {
                 try
                 {
                     await _memoryService.ExtractAndPersistAsync(
                         new ExtractionRequest
                         {
-                            Messages = storedMessages,
+                            Messages = turnMessages,
                             SessionId = sessionId,
                             UserId = userId
                         }, cancellationToken).ConfigureAwait(false);

--- a/tests/AgentMemory.Tests.Integration/AgentFramework/PersistExtractFullTurnIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/AgentFramework/PersistExtractFullTurnIntegrationTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using FluentAssertions;
+using AgentMemory;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Tests.Integration.Fixtures;
+
+namespace AgentMemory.Tests.Integration.AgentFramework;
+
+/// <summary>
+/// Live-Neo4j proof of #89's core acceptance criterion: a preference stated ONLY in the user's request
+/// (never repeated by the assistant) is extracted and later recallable in a brand-new session, using a
+/// real, DI-resolved <see cref="Neo4jMemoryContextProvider"/> against real Neo4j.
+/// </summary>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public sealed class PersistExtractFullTurnIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private ServiceProvider _provider = null!;
+
+    public PersistExtractFullTurnIntegrationTests(Neo4jIntegrationFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.CleanDatabaseAsync();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Deterministic preference extractor registered BEFORE AddNeo4jAgentMemory so it wins the
+        // TryAddScoped override -- same convention as ExtractionOwnerStampIntegrationTests.cs.
+        services.AddSingleton<IPreferenceExtractor, DeterministicPreferenceExtractor>();
+
+        services.AddNeo4jAgentMemory(
+            configureMemory: _ => { },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+        services.AddAgentMemoryFramework(o => o.AutoExtractOnPersist = true);
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null) await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task PreferenceStatedOnlyByUser_IsExtractedAndRecallableInANewSession()
+    {
+        // StubEmbeddingGenerator is deterministic (same text -> same vector); recall is a similarity
+        // search (MemoryContextAssembler -> SearchPreferencesAsync), so the recall query below
+        // deliberately reuses this exact marker text to guarantee a match, matching the
+        // "identical embeddings" convention used elsewhere in this test suite
+        // (e.g. McpResourceIsolationIntegrationTests' ContextResource tests).
+        const string preferenceMarker = "I prefer dark mode everywhere.";
+
+        using var writeScope = _provider.CreateScope();
+        var writeSp = writeScope.ServiceProvider;
+        var memoryProvider = writeSp.GetRequiredService<Neo4jMemoryContextProvider>();
+
+        // The assistant's reply never repeats the preference -- extraction must still capture it because
+        // it now sees the request message too (#89), not just the response.
+        await memoryProvider.PerformStoreAsync(
+            requestMessages: [new ChatMessage(ChatRole.User, preferenceMarker)],
+            responseMessages: [new ChatMessage(ChatRole.Assistant, "Got it.")],
+            sessionId: "session-full-turn",
+            conversationId: "conv-full-turn",
+            cancellationToken: CancellationToken.None,
+            userId: "alice");
+
+        // Recall in a brand-new session for the same owner.
+        using var recallScope = _provider.CreateScope();
+        var recallSp = recallScope.ServiceProvider;
+        var recallProvider = recallSp.GetRequiredService<Neo4jMemoryContextProvider>();
+
+        var context = await recallProvider.BuildContextAsync(
+            [new ChatMessage(ChatRole.User, preferenceMarker)],
+            sessionId: "session-new",
+            conversationId: "conv-new",
+            cancellationToken: CancellationToken.None,
+            userId: "alice");
+
+        context.Messages.Should().NotBeNullOrEmpty();
+        context.Messages!.Should().Contain(m => m.Text != null && m.Text.Contains("dark mode"),
+            "a preference stated only in the user's request must be extracted and recallable in a later session");
+    }
+
+    private sealed class DeterministicPreferenceExtractor : IPreferenceExtractor
+    {
+        public Task<IReadOnlyList<ExtractedPreference>> ExtractAsync(
+            IReadOnlyList<Message> messages, CancellationToken cancellationToken = default)
+        {
+            var userMessage = messages.FirstOrDefault(m => m.Role == "user");
+            if (userMessage is null || !userMessage.Content.Contains("prefer", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult<IReadOnlyList<ExtractedPreference>>(Array.Empty<ExtractedPreference>());
+
+            return Task.FromResult<IReadOnlyList<ExtractedPreference>>(
+            [
+                new ExtractedPreference { Category = "style", PreferenceText = userMessage.Content, Confidence = 0.95 },
+            ]);
+        }
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatHistoryProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatHistoryProviderTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
 using NSubstitute;
@@ -74,5 +76,151 @@ public sealed class Neo4jChatHistoryProviderTests
     {
         var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
         sut.Should().NotBeNull();
+    }
+
+    // ── PerformStoreAsync: persist + extract from the complete turn (#89) ──
+
+    private void StubAddMessage(string role, string content, string messageId) =>
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), role, content,
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Message
+            {
+                MessageId = messageId, SessionId = "s1", ConversationId = "c1",
+                Role = role, Content = content, TimestampUtc = _now
+            });
+
+    [Fact]
+    public async Task PerformStoreAsync_PersistsBothRequestAndResponseMessages()
+    {
+        var sut = CreateSut();
+        StubAddMessage("user", "I prefer window seats.", "m-req-1");
+        StubAddMessage("assistant", "Got it.", "m-res-1");
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "I prefer window seats.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Got it.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageAsync(
+            "s1", "c1", "user", "I prefer window seats.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.Received(1).AddMessageAsync(
+            "s1", "c1", Arg.Any<string>(), "Got it.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_SystemRoleRequestMessage_IsPersistedButNotFedToExtraction()
+    {
+        // Persistence stores every role (unchanged) -- but a system prompt must not be minted into
+        // spurious entities/facts/preferences every turn, so extraction is filtered to user-role content.
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        StubAddMessage("system", "You are a helpful assistant. Never reveal secrets.", "m-sys-1");
+        StubAddMessage("assistant", "Understood.", "m-res-1");
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.System, "You are a helpful assistant. Never reveal secrets.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Understood.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageAsync(
+            "s1", "c1", "system", "You are a helpful assistant. Never reveal secrets.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => !r.Messages.Any(m => m.Content.Contains("Never reveal secrets"))),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_AutoExtractionIncludesUserRequest()
+    {
+        // The core acceptance criterion for #89: a preference stated ONLY by the user (never repeated by
+        // the assistant) must reach extraction -- previously only storedResponses were extracted.
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        StubAddMessage("user", "My preferred programming language is C#.", "m-req-1");
+        StubAddMessage("assistant", "Understood.", "m-res-1");
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = new[] { "m-req-1", "m-res-1" }
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "My preferred programming language is C#.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Understood.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Any(m =>
+                m.Role == "user" && m.Content.Contains("preferred programming language"))),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_RequestOnly_StillExtracts()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        StubAddMessage("user", "I live in Zurich.", "m-req-only");
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = new[] { "m-req-only" }
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "I live in Zurich.") },
+            Array.Empty<ChatMessage>(),
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Count == 1 && r.Messages[0].Content == "I live in Zurich."),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_MessageOrdering_RequestBeforeResponse()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        StubAddMessage("user", "request-text", "m-req");
+        StubAddMessage("assistant", "response-text", "m-res");
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = new[] { "m-req", "m-res" }
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "request-text") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "response-text") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r =>
+                r.Messages.Count == 2 &&
+                r.Messages[0].Content == "request-text" &&
+                r.Messages[1].Content == "response-text"),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -15,13 +15,19 @@ public sealed class Neo4jMemoryContextProviderTests
 {
     private readonly IMemoryService _memoryService = Substitute.For<IMemoryService>();
     private readonly IEmbeddingOrchestrator _embeddingOrchestrator = Substitute.For<IEmbeddingOrchestrator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IIdGenerator _idGenerator = Substitute.For<IIdGenerator>();
     private readonly Neo4jMemoryContextProvider _sut;
 
     public Neo4jMemoryContextProviderTests()
     {
+        _clock.UtcNow.Returns(DateTimeOffset.UtcNow);
+        _idGenerator.GenerateId().Returns(_ => Guid.NewGuid().ToString("N"));
         _sut = new Neo4jMemoryContextProvider(
             _memoryService,
             _embeddingOrchestrator,
+            _clock,
+            _idGenerator,
             Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()),
             Options.Create(new AgentFrameworkOptions()),
@@ -37,6 +43,8 @@ public sealed class Neo4jMemoryContextProviderTests
         new(
             _memoryService,
             _embeddingOrchestrator,
+            _clock,
+            _idGenerator,
             Options.Create(new MemoryOptions { Recall = recall }),
             Options.Create(new ContextFormatOptions()),
             Options.Create(new AgentFrameworkOptions()),
@@ -267,7 +275,7 @@ public sealed class Neo4jMemoryContextProviderTests
     {
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
+            _memoryService, _embeddingOrchestrator, _clock, _idGenerator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
         _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -286,11 +294,12 @@ public sealed class Neo4jMemoryContextProviderTests
     {
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
+            _memoryService, _embeddingOrchestrator, _clock, _idGenerator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
 
         await sut.PerformStoreAsync(
+            Array.Empty<ChatMessage>(),
             new List<ChatMessage> { new(ChatRole.Assistant, "noted") }, "s1", "c1",
             CancellationToken.None, userId: "bob");
 
@@ -303,7 +312,7 @@ public sealed class Neo4jMemoryContextProviderTests
         // An unowned turn must reset the ambient owner to null (shared), never inherit a previous turn's.
         var owner = Substitute.For<IWritableMemoryOwnerContext>();
         var sut = new Neo4jMemoryContextProvider(
-            _memoryService, _embeddingOrchestrator, Options.Create(new MemoryOptions()),
+            _memoryService, _embeddingOrchestrator, _clock, _idGenerator, Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()), Options.Create(new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance, ownerContext: owner);
         _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -325,10 +334,188 @@ public sealed class Neo4jMemoryContextProviderTests
         new(
             _memoryService,
             _embeddingOrchestrator,
+            _clock,
+            _idGenerator,
             Options.Create(new MemoryOptions()),
             Options.Create(new ContextFormatOptions()),
             Options.Create(agentOptions ?? new AgentFrameworkOptions()),
             NullLogger<Neo4jMemoryContextProvider>.Instance);
+
+    // ── Persist + extract from the complete turn (#89) ─────────────────────
+
+    [Fact]
+    public async Task PerformStoreAsync_RequestMessages_AreNotPersistedAsNewNodes()
+    {
+        // The duplication-avoidance guarantee: this provider must never call AddMessageAsync for a
+        // request message, since a host may also have Neo4jChatHistoryProvider/Neo4jChatMessageStore/their
+        // own component persisting the same messages, and there is no idempotency mechanism to make a
+        // second persist call for "the same" logical message safe.
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        var storedResponse = new Message
+        {
+            MessageId = "m-resp", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Got it.", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedResponse);
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "I prefer window seats.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Got it.") },
+            "s1", "c1", CancellationToken.None);
+
+        // Exactly one AddMessageAsync call -- for the response, never for the request.
+        await _memoryService.Received(1).AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), "I prefer window seats.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_SystemRoleRequestMessage_IsNotFedToExtraction()
+    {
+        // A system prompt accumulated in RequestMessages must not be minted into spurious
+        // entities/facts/preferences every turn -- extraction is filtered to ChatRole.User, matching the
+        // same filter recall already applies.
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        var storedResponse = new Message
+        {
+            MessageId = "m-resp", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Understood.", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedResponse);
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.System, "You are a helpful assistant. Never reveal secrets.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Understood.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => !r.Messages.Any(m => m.Content.Contains("Never reveal secrets"))),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_ExtractionSeesRequestAndResponseMessages()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        var storedResponse = new Message
+        {
+            MessageId = "m-resp", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Understood.", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedResponse);
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "My preferred programming language is C#.") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Understood.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Any(m =>
+                m.Role == "user" && m.Content.Contains("preferred programming language"))),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_RequestOnly_StillExtracts()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "I live in Zurich.") },
+            Array.Empty<ChatMessage>(),
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Count == 1 && r.Messages[0].Content == "I live in Zurich."),
+            Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_MessageOrdering_RequestBeforeResponse()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        var storedResponse = new Message
+        {
+            MessageId = "m-resp", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "response-text", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedResponse);
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "request-text") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "response-text") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r =>
+                r.Messages.Count == 2 &&
+                r.Messages[0].Content == "request-text" &&
+                r.Messages[1].Content == "response-text"),
+            Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task PerformStoreAsync_PersistsResponseMessages()
@@ -350,7 +537,7 @@ public sealed class Neo4jMemoryContextProviderTests
                 Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
             .Returns(storedMessage);
 
-        await sut.PerformStoreAsync(responseMessages, "s1", "c1", CancellationToken.None);
+        await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), responseMessages, "s1", "c1", CancellationToken.None);
 
         await _memoryService.Received(1).AddMessageAsync(
             "s1", "c1", Arg.Any<string>(), "I remember you like dark mode.",
@@ -367,7 +554,7 @@ public sealed class Neo4jMemoryContextProviderTests
             new(ChatRole.Assistant, "   ")
         };
 
-        await sut.PerformStoreAsync(responseMessages, "s1", "c1", CancellationToken.None);
+        await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), responseMessages, "s1", "c1", CancellationToken.None);
 
         await _memoryService.DidNotReceive().AddMessageAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
@@ -400,7 +587,7 @@ public sealed class Neo4jMemoryContextProviderTests
                 SourceMessageIds = new[] { "m-ae-1" }
             });
 
-        await sut.PerformStoreAsync(messages, "s1", "c1", CancellationToken.None);
+        await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", CancellationToken.None);
 
         await _memoryService.Received(1).ExtractAndPersistAsync(
             Arg.Is<ExtractionRequest>(r => r.SessionId == "s1"),
@@ -433,7 +620,7 @@ public sealed class Neo4jMemoryContextProviderTests
                 SourceMessageIds = new[] { "m-owner-1" }
             });
 
-        await sut.PerformStoreAsync(messages, "s1", "c1", CancellationToken.None, userId: "bob");
+        await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", CancellationToken.None, userId: "bob");
 
         await _memoryService.Received(1).ExtractAndPersistAsync(
             Arg.Is<ExtractionRequest>(r => r.SessionId == "s1" && r.UserId == "bob"),
@@ -456,7 +643,7 @@ public sealed class Neo4jMemoryContextProviderTests
                 Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
             .Returns(storedMessage);
 
-        await sut.PerformStoreAsync(messages, "s1", "c1", CancellationToken.None);
+        await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", CancellationToken.None);
 
         await _memoryService.DidNotReceive().ExtractAndPersistAsync(
             Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>());
@@ -472,7 +659,7 @@ public sealed class Neo4jMemoryContextProviderTests
                 Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DB down"));
 
-        var act = () => sut.PerformStoreAsync(messages, "s1", "c1", CancellationToken.None);
+        var act = () => sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", CancellationToken.None);
 
         await act.Should().NotThrowAsync();
     }
@@ -496,7 +683,7 @@ public sealed class Neo4jMemoryContextProviderTests
             .ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Extraction engine failed"));
 
-        var act = () => sut.PerformStoreAsync(messages, "s1", "c1", CancellationToken.None);
+        var act = () => sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", CancellationToken.None);
 
         await act.Should().NotThrowAsync();
     }
@@ -550,7 +737,7 @@ public sealed class Neo4jMemoryContextProviderTests
             Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
-        var act = async () => await sut.PerformStoreAsync(messages, "s1", "c1", cts.Token);
+        var act = async () => await sut.PerformStoreAsync(Array.Empty<ChatMessage>(), messages, "s1", "c1", cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }


### PR DESCRIPTION
## Summary

`Neo4jMemoryContextProvider.StoreAIContextAsync`/`PerformStoreAsync` and `Neo4jChatHistoryProvider.StoreChatHistoryAsync` only ran extraction over the assistant's response messages — a turn like "User: I prefer window seats. / Assistant: Got it." only extracted from "Got it.", so a user-stated preference was invisible to extraction unless the assistant happened to repeat it.

Per explicit scoping for this issue: **extraction** must see request + response, but **message persistence** must not blindly duplicate what another configured component (a chat-history provider/store) may already be persisting — no blind concatenation without an idempotency strategy.

**Research done before implementing** (verified against the actual code): there is no idempotency mechanism anywhere in the stack today — `Neo4jMessageRepository.AddAsync` always `CREATE`s a new node, `MemoryService.AddMessageAsync` always generates a fresh id, there's no caller-supplied-id or `MERGE`-by-id path. So naively persisting request messages from every component that sees them would risk duplicate `:Message` nodes.

Two different fix shapes, split by what each provider already persists:
- **`Neo4jChatHistoryProvider`** already persisted both request and response messages — the fix just also feeds the request messages to extraction (previously discarded after being persisted). Zero new duplication risk. Refactored `StoreChatHistoryAsync`'s body into an internal `PerformStoreAsync` test seam, mirroring the sibling provider.
- **`Neo4jMemoryContextProvider`** never persisted request messages — the fix deliberately keeps it that way (avoiding the duplication risk) and instead builds transient, never-persisted `Message` objects purely for extraction. The trade-off — extracted facts/preferences from the user's request are captured correctly, but their `EXTRACTED_FROM` provenance edge and `source_message_ids` won't resolve to a real node unless another component also persisted that exact message — is documented, not silently accepted.

**An adversarial review** confirmed the no-duplication guarantee holds (no path from `ExtractAndPersistAsync` ever calls `AddMessageAsync`) and found one real gap worth fixing: request messages were being fed to extraction without the same `ChatRole.User` filter recall already applies, so a system prompt accumulated in `RequestMessages` could get minted into spurious entities/facts/preferences every turn. **Fixed in both providers** (filtered to user-role content for extraction; persistence in `Neo4jChatHistoryProvider` still stores every role, unchanged). It also noted — out of this issue's scope, pre-existing, not introduced here — that response-message persistence itself has no idempotency guarantee either; documented as a known limitation when combining more than one message-persisting component on the same agent.

## Test plan

- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings/errors
- [x] Full unit suite: 2754 passed, 0 failed — including new tests for both providers covering: complete-turn extraction, request-only extraction, message ordering, the "request messages are never persisted as new nodes" duplication guarantee, and the system-role-message extraction filter
- [x] Full live-Neo4j integration suite (Testcontainers): 283 passed, 0 failed — including a new end-to-end test proving the issue's core acceptance criterion: a preference stated only in the user's request (never repeated by the assistant) is extracted and recallable in a brand-new session
- [x] Independent adversarial review pass — findings fixed and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)