### PR TITLE
fix: idempotent cross-component message persistence + non-text-content policy (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   user-stated preference was invisible unless the assistant repeated it. Extraction now considers the
   complete turn. `Neo4jChatHistoryProvider` (which already persisted both request and response messages)
   gained full-provenance extraction from both at no new risk. `Neo4jMemoryContextProvider` deliberately
-  does not start persisting request messages as new `:Message` nodes (there is no idempotency mechanism to
-  avoid duplicating what a chat-history provider/store may already persist) — captured facts/preferences
-  are correct, but their provenance link to the literal source message is best-effort in that path, not
+  does not start persisting request messages as new `:Message` nodes — request-message persistence
+  ownership intentionally stays solely with `Neo4jChatHistoryProvider` — so captured facts/preferences are
+  correct, but their provenance link to the literal source message is best-effort in that path, not
   guaranteed; documented, not silently accepted.
+- **Enabling more than one MAF message-persisting component could duplicate `:Message` nodes (#89).**
+  `Neo4jChatHistoryProvider` now narrows MAF's default request-message filter to
+  `AgentRequestMessageSourceType.External` only, so it no longer re-persists another configured
+  `AIContextProvider`'s (e.g. `Neo4jMemoryContextProvider`'s) injected recalled-memory messages as new
+  nodes every turn — a real, previously-undiscovered bug found while investigating this issue, not merely
+  one of its stated acceptance criteria. On the response side, message persistence is now idempotent by
+  id: `Neo4jMessageRepository`'s writes are `MERGE`-by-id instead of `CREATE` (a no-op, first-write-wins,
+  for a repeated id — safe because `message_id` already has a uniqueness constraint, and no existing
+  caller ever supplied a repeated id), and `Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider`/
+  `Neo4jChatMessageStore` now persist a response message under a deterministic id derived from the
+  underlying `ChatMessage.MessageId` when the `IChatClient` populates one — so two of these components
+  observing the same response converge on one node instead of duplicating it. When the client doesn't
+  populate `MessageId`, today's fresh-id behavior remains (no regression, but the gap remains for that
+  client) — a disclosed limitation, not a silent one; see `docs/agent-framework.md`. Also explicitly
+  documents the non-text-content policy for `Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider`: a
+  message carrying only function/tool calls, function/tool results, or reasoning content is excluded from
+  both persistence and extraction in those two providers (previously true as a side effect of the
+  empty-text filter, now an explicit, tested contract for them specifically — the lower-level
+  `Neo4jChatMessageStore`/`Neo4jMicrosoftMemoryFacade` path does not have this guard and persists every
+  message it's given). #89 is now fully closed.
 
 ## [1.0.3] - 2026-07-14
 

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -64,20 +64,36 @@ text isn't minted into spurious entities/facts/preferences every turn — so a p
 states is captured even if the assistant never repeats it back. `Neo4jChatHistoryProvider` persists both
 request and response messages as real `:Message` nodes (unchanged), so extraction there has full
 provenance. `Neo4jMemoryContextProvider` deliberately does **not** persist request messages as new nodes
-— only response messages are — because a host may already have `Neo4jChatHistoryProvider`,
-`Neo4jChatMessageStore`, or their own component persisting the same request messages on the same agent,
-and there is no idempotency mechanism (no caller-supplied message id, no upsert-by-content) that would let
-this provider safely avoid creating a duplicate `:Message` node for the same logical message. The
-practical effect: a fact/preference extracted from the user's own request is still created and recallable,
-but both its `EXTRACTED_FROM` provenance edge and its own `source_message_ids` property will reference a
-message id that was never persisted, unless another component also persisted that exact message.
+— only response messages are — because a caller-constructed request `ChatMessage` essentially never
+carries a stable identity that another persisting component would also see, so request-message persistence
+ownership intentionally stays solely with `Neo4jChatHistoryProvider`. The practical effect: a
+fact/preference extracted from the user's own request is still created and recallable, but both its
+`EXTRACTED_FROM` provenance edge and its own `source_message_ids` property will reference a message id that
+was never persisted, unless another component also persisted that exact message.
 
-**This asymmetry is deliberate for requests, but note it does not (yet) extend to responses**: both
-`Neo4jMemoryContextProvider` and `Neo4jChatHistoryProvider` persist response messages unconditionally, with
-the same lack of an idempotency mechanism — so combining both providers (or either with
-`Neo4jChatMessageStore`/a custom component) on the same agent can still duplicate **response** `:Message`
-nodes today. Avoid wiring more than one message-persisting component onto the same agent until a real
-cross-component idempotency mechanism exists.
+**Duplicate message persistence across components (#89)**: `Neo4jChatHistoryProvider` narrows MAF's
+default request-message filter to `AgentRequestMessageSourceType.External` only, so it never re-persists
+another configured `AIContextProvider`'s (e.g. `Neo4jMemoryContextProvider`'s) injected recalled-memory
+messages as new nodes every turn. On the **response** side, message persistence is idempotent by id:
+`Neo4jMemoryContextProvider`, `Neo4jChatHistoryProvider`, and `Neo4jChatMessageStore` all persist a response
+message under a deterministic id derived from the underlying `ChatMessage.MessageId` when the `IChatClient`
+populates one (true for many production clients, e.g. those backed by the OpenAI Responses API) — so if
+more than one of these components observes the same response message, they converge on the same
+`:Message` node instead of creating a duplicate. When the underlying client does **not** populate
+`MessageId`, each component still falls back to today's behavior (a fresh id per call), so combining more
+than one message-persisting component on the same agent can still duplicate that response message — this
+is a known, disclosed limitation of relying on provider-native identity rather than a cross-component
+idempotency protocol; there is no plan to add content-hash-based deduplication, since that would risk
+silently collapsing two genuinely distinct occurrences of identical text (e.g. the assistant saying
+"Understood." twice in different turns) into one node.
+
+**Non-text content policy**: a `ChatMessage` whose content is exclusively non-`TextContent` (e.g. a
+function/tool call, a function/tool result, or a reasoning trace) has an empty `.Text`, and `Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider` exclude it from both persistence and automatic
+extraction — not just "tool messages," but any message carrying no literal text for a human or the
+extraction pipeline to act on. This guard is specific to those two providers; the lower-level
+`Neo4jChatMessageStore`/`Neo4jMicrosoftMemoryFacade` path persists every message it's given regardless of
+text content, so a host driving that path directly is responsible for filtering non-text messages itself
+if it wants the same behavior.
 
 `Neo4jMicrosoftMemoryFacade` (the lower-level, manually-driven alternative to the context provider)
 does not yet wire configured `RecallOptions` into its own recall call — a known gap for a future pass, not

--- a/src/AgentMemory.Abstractions/Services/IMemoryIngestion.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryIngestion.cs
@@ -20,6 +20,28 @@ public interface IMemoryIngestion
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Adds a message to short-term memory with a caller-supplied, deterministic id. Calling this twice
+    /// with the same <paramref name="messageId"/> returns the pre-existing message unchanged (first-write-
+    /// wins) instead of creating a duplicate node -- lets independently-configured persisting components
+    /// (e.g. multiple MAF integration components observing the same underlying model response) converge on
+    /// one message node when they share a stable identity for it, instead of each minting a fresh one.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="messageId"/> and behaves exactly like
+    /// <see cref="AddMessageAsync(string,string,string,string,IReadOnlyDictionary{string,object}?,CancellationToken)"/>
+    /// (a fresh id every call) -- implementers of this interface are not required to override this member.
+    /// </remarks>
+    Task<Message> AddMessageWithIdAsync(
+        string sessionId,
+        string conversationId,
+        string role,
+        string content,
+        string messageId,
+        IReadOnlyDictionary<string, object>? metadata = null,
+        CancellationToken cancellationToken = default) =>
+        AddMessageAsync(sessionId, conversationId, role, content, metadata, cancellationToken);
+
+    /// <summary>
     /// Batch adds messages to short-term memory.
     /// </summary>
     Task<IReadOnlyList<Message>> AddMessagesAsync(

--- a/src/AgentMemory.AgentFramework/Mapping/MafTypeMapper.cs
+++ b/src/AgentMemory.AgentFramework/Mapping/MafTypeMapper.cs
@@ -39,6 +39,17 @@ internal static class MafTypeMapper
         => new(ToMafRole(message.Role), message.Content);
 
     /// <summary>
+    /// Derives a deterministic persistence id from a response <see cref="ChatMessage"/>'s provider-native
+    /// <see cref="ChatMessage.MessageId"/>, when the underlying <c>IChatClient</c> populates one (common
+    /// for clients backed by e.g. the OpenAI Responses API). Returns null when absent -- caller-constructed
+    /// messages (typically request/user messages) essentially never have one, so this only helps dedupe
+    /// response messages that independently-configured persisting components (Neo4jMemoryContextProvider,
+    /// Neo4jChatHistoryProvider, Neo4jChatMessageStore) might otherwise each persist as a separate node.
+    /// </summary>
+    public static string? TryGetProviderMessageId(ChatMessage message) =>
+        string.IsNullOrWhiteSpace(message.MessageId) ? null : $"maf:{message.MessageId}";
+
+    /// <summary>
     /// Converts a <see cref="MemoryContext"/> to a list of context <see cref="ChatMessage"/> instances.
     /// </summary>
     public static IReadOnlyList<ChatMessage> ToContextMessages(

--- a/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatHistoryProvider.cs
@@ -39,7 +39,17 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
         ILogger<Neo4jChatHistoryProvider> logger,
         IMemoryStoreContext? storeContext = null,
         IWritableMemoryOwnerContext? ownerContext = null)
-        : base(null, null, null)
+        // storeInputRequestMessageFilter narrows MAF's own default (which excludes only ChatHistory-sourced
+        // messages) down to External-only. Without this, when a host also configures an AIContextProvider
+        // (e.g. Neo4jMemoryContextProvider) on the same agent, that provider's injected messages (recalled
+        // memory, wrapped as system-role content) show up in RequestMessages here too and get persisted as
+        // brand-new :Message nodes every single turn (#89). Trade-off: a host using a DIFFERENT,
+        // legitimate AIContextProvider whose injected content they actually want captured as persisted
+        // history would now have it silently excluded too -- treating provider-injected context as
+        // ephemeral (not history) is the correct default for this library, but it is a real behavior
+        // change from MAF's own out-of-the-box default for that uncommon case.
+        : base(null, static msgs => msgs.Where(
+            m => m.GetAgentRequestMessageSourceType() == AgentRequestMessageSourceType.External), null)
     {
         _memoryService = memoryService ?? throw new ArgumentNullException(nameof(memoryService));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
@@ -140,18 +150,31 @@ public sealed class Neo4jChatHistoryProvider : ChatHistoryProvider
                 storedRequests.Add(stored);
             }
 
-            // Persist response messages
+            // Persist response messages. When the underlying IChatClient stamps a provider-native
+            // MessageId, persist under a deterministic id (#89) so another persisting component observing
+            // the same response (e.g. Neo4jMemoryContextProvider, Neo4jChatMessageStore) converges on the
+            // same :Message node instead of creating a duplicate. Falls back to today's fresh-id behavior
+            // when absent.
             var storedResponses = new List<Abstractions.Domain.Message>();
             foreach (var msg in responseMessages)
             {
                 if (string.IsNullOrWhiteSpace(msg.Text)) continue;
-                var stored = await _memoryService
-                    .AddMessageAsync(
-                        sessionId, conversationId,
-                        MafTypeMapper.ToInternalRole(msg.Role),
-                        msg.Text,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                var providerId = MafTypeMapper.TryGetProviderMessageId(msg);
+                var stored = providerId is not null
+                    ? await _memoryService
+                        .AddMessageWithIdAsync(
+                            sessionId, conversationId,
+                            MafTypeMapper.ToInternalRole(msg.Role),
+                            msg.Text, providerId,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false)
+                    : await _memoryService
+                        .AddMessageAsync(
+                            sessionId, conversationId,
+                            MafTypeMapper.ToInternalRole(msg.Role),
+                            msg.Text,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
                 storedResponses.Add(stored);
             }
 

--- a/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jChatMessageStore.cs
@@ -40,9 +40,18 @@ public sealed class Neo4jChatMessageStore
         try
         {
             var message = MafTypeMapper.ToInternalMessage(chatMessage, sessionId, conversationId, _clock, _idGenerator);
-            return await _memoryService
-                .AddMessageAsync(message.SessionId, message.ConversationId, message.Role, message.Content, message.Metadata, cancellationToken)
-                .ConfigureAwait(false);
+            // When the underlying IChatClient stamps a provider-native MessageId on this ChatMessage,
+            // persist under a deterministic id (#89) so another persisting component observing the same
+            // message (Neo4jMemoryContextProvider, Neo4jChatHistoryProvider) converges on the same
+            // :Message node instead of creating a duplicate.
+            var providerId = MafTypeMapper.TryGetProviderMessageId(chatMessage);
+            return providerId is not null
+                ? await _memoryService
+                    .AddMessageWithIdAsync(message.SessionId, message.ConversationId, message.Role, message.Content, providerId, message.Metadata, cancellationToken)
+                    .ConfigureAwait(false)
+                : await _memoryService
+                    .AddMessageAsync(message.SessionId, message.ConversationId, message.Role, message.Content, message.Metadata, cancellationToken)
+                    .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -197,15 +197,14 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         try
         {
             // Response messages are persisted as new :Message nodes, as before. Request messages are
-            // deliberately NOT persisted here (#89): a host may already have a Neo4jChatHistoryProvider,
-            // Neo4jChatMessageStore, or their own component persisting the same request messages on this
-            // agent, and there is no idempotency mechanism (no MERGE-by-id, no caller-supplied id) that
-            // would let this provider safely avoid creating a second, duplicate :Message node for the
-            // same logical message. Building transient (never-persisted) Message objects for extraction
-            // only avoids that risk entirely while still capturing what the user said. Filtered to
-            // ChatRole.User -- the same filter recall already applies (BuildContextAsync above) -- so a
-            // system prompt or other non-user content accumulated in RequestMessages doesn't get minted
-            // into spurious entities/facts/preferences every turn.
+            // deliberately NOT persisted here (#89): ChatMessage.MessageId (used below for response-side
+            // dedup) is essentially never populated on caller-constructed request messages, so it can't
+            // help there -- request-message persistence ownership intentionally stays solely with
+            // Neo4jChatHistoryProvider. Building transient (never-persisted) Message objects for extraction
+            // only captures what the user said without risking a duplicate node. Filtered to ChatRole.User
+            // -- the same filter recall already applies (BuildContextAsync above) -- so a system prompt or
+            // other non-user content accumulated in RequestMessages doesn't get minted into spurious
+            // entities/facts/preferences every turn.
             var transientRequestMessages = requestMessages
                 .Where(msg => msg.Role == ChatRole.User && !string.IsNullOrWhiteSpace(msg.Text))
                 .Select(msg => MafTypeMapper.ToInternalMessage(msg, sessionId, conversationId, _clock, _idGenerator))
@@ -216,13 +215,27 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
             {
                 if (string.IsNullOrWhiteSpace(msg.Text)) continue;
 
-                var stored = await _memoryService
-                    .AddMessageAsync(
-                        sessionId, conversationId,
-                        MafTypeMapper.ToInternalRole(msg.Role),
-                        msg.Text,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                // When the underlying IChatClient stamps a provider-native MessageId on this response
+                // message, persist it under a deterministic id (#89): if another persisting component
+                // (e.g. Neo4jChatHistoryProvider, Neo4jChatMessageStore) configured on the same agent
+                // observes the same response, it converges on this same :Message node instead of creating
+                // a duplicate. Falls back to today's fresh-id behavior when absent (no regression).
+                var providerId = MafTypeMapper.TryGetProviderMessageId(msg);
+                var stored = providerId is not null
+                    ? await _memoryService
+                        .AddMessageWithIdAsync(
+                            sessionId, conversationId,
+                            MafTypeMapper.ToInternalRole(msg.Role),
+                            msg.Text, providerId,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false)
+                    : await _memoryService
+                        .AddMessageAsync(
+                            sessionId, conversationId,
+                            MafTypeMapper.ToInternalRole(msg.Role),
+                            msg.Text,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
                 storedMessages.Add(stored);
             }
 

--- a/src/AgentMemory.Core/Services/MemoryService.cs
+++ b/src/AgentMemory.Core/Services/MemoryService.cs
@@ -191,6 +191,36 @@ internal sealed class MemoryService : IMemoryService
     }
 
     /// <inheritdoc/>
+    public async Task<Message> AddMessageWithIdAsync(
+        string sessionId,
+        string conversationId,
+        string role,
+        string content,
+        string messageId,
+        IReadOnlyDictionary<string, object>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+        ArgumentNullException.ThrowIfNull(content);
+
+        var message = new Message
+        {
+            MessageId = messageId,
+            SessionId = sessionId,
+            ConversationId = conversationId,
+            Role = role,
+            Content = content,
+            TimestampUtc = _clock.UtcNow,
+            Metadata = metadata ?? new Dictionary<string, object>()
+        };
+
+        return await _shortTerm.AddMessageAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public Task<IReadOnlyList<Message>> AddMessagesAsync(
         IEnumerable<Message> messages,
         CancellationToken cancellationToken = default)

--- a/src/AgentMemory.Neo4j/Queries/MessageQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/MessageQueries.cs
@@ -14,23 +14,29 @@ internal static class MessageQueries
     /// <summary>Create a message and link it to its conversation via HAS_MESSAGE. The conversation
     /// is MERGE-d so persisting a message never silently no-ops when the conversation was not
     /// explicitly created first (e.g. from the MAF context/history providers); a thin conversation
-    /// is created and later enriched by ConversationQueries.Upsert.</summary>
+    /// is created and later enriched by ConversationQueries.Upsert.
+    /// The message node itself is also MERGE-d by id (ON CREATE SET only, first-write-wins) rather than
+    /// CREATE-d, so callers that supply a deterministic id (see IMemoryIngestion.AddMessageWithIdAsync)
+    /// can safely persist "the same" message more than once -- a second call with the same id is a no-op
+    /// for content and never creates a duplicate node or a duplicate HAS_MESSAGE edge. Safe because
+    /// message_id has a uniqueness constraint (SchemaQueries), so MERGE uses the backing index. Every
+    /// existing caller is unaffected: nothing before this ever supplied a repeated id (fresh GUID each
+    /// call), so this is purely additive infrastructure.</summary>
     public const string Add = @"
             MERGE (conv:Conversation {id: $conversationId})
             ON CREATE SET conv.session_id = $sessionId,
                           conv.created_at = datetime($timestamp),
                           conv.updated_at = datetime($timestamp)
-            CREATE (m:Message {
-                id:              $id,
-                conversation_id: $conversationId,
-                session_id:      $sessionId,
-                role:            $role,
-                content:         $content,
-                timestamp:       datetime($timestamp),
-                tool_call_ids:   $toolCallIds,
-                metadata:        $metadata
-            })
-            CREATE (conv)-[:HAS_MESSAGE]->(m)
+            MERGE (m:Message {id: $id})
+            ON CREATE SET
+                m.conversation_id = $conversationId,
+                m.session_id      = $sessionId,
+                m.role            = $role,
+                m.content         = $content,
+                m.timestamp       = datetime($timestamp),
+                m.tool_call_ids   = $toolCallIds,
+                m.metadata        = $metadata
+            MERGE (conv)-[:HAS_MESSAGE]->(m)
             RETURN m";
 
     /// <summary>Link the first message in a conversation via FIRST_MESSAGE.</summary>
@@ -39,47 +45,62 @@ internal static class MessageQueries
                 WHERE NOT EXISTS { MATCH (conv)-[:FIRST_MESSAGE]->() }
                 MERGE (conv)-[:FIRST_MESSAGE]->(m)";
 
-    /// <summary>Establish NEXT_MESSAGE linked-list pointer from previous last message.</summary>
+    /// <summary>Establish NEXT_MESSAGE linked-list pointer from previous last message. MERGE (not CREATE)
+    /// so re-persisting a message with the same id never creates a second edge to the SAME prev/next pair.
+    /// NOTE: "prev" is re-selected fresh on every call (not carried from a prior call). This DOES happen in
+    /// the real cross-provider-in-one-turn scenario (#89): Neo4jChatHistoryProvider persists a request
+    /// message between the two providers' response-persist calls, so the second response-persist links a
+    /// NEW prev->response edge, forming an inert 2-cycle rather than a duplicate of the first edge. Harmless
+    /// because NEXT_MESSAGE (like FIRST_MESSAGE) is write-only -- nothing in this codebase reads or
+    /// traverses either relationship; ordering is always read via the `timestamp` property. Not guarded
+    /// against since there's nothing depending on it being a clean linked list.</summary>
     public const string LinkNextMessage = @"
             MATCH (conv:Conversation {id: $conversationId})-[:HAS_MESSAGE]->(prev:Message)
             WHERE prev.id <> $id
             WITH prev ORDER BY prev.timestamp DESC LIMIT 1
             MATCH (m:Message {id: $id})
-            CREATE (prev)-[:NEXT_MESSAGE]->(m)";
+            MERGE (prev)-[:NEXT_MESSAGE]->(m)";
 
     // ── AddBatchAsync ──────────────────────────────────────────────────
 
-    /// <summary>Batch create messages and link to conversations via UNWIND.</summary>
+    /// <summary>Batch create messages and link to conversations via UNWIND. MERGE-d by id (ON CREATE SET
+    /// only) for the same idempotency guarantee as <see cref="Add"/>; safe under UNWIND because message_id
+    /// is a uniqueness-constrained property (no eagerness-analysis duplicate-row hazard). NOTE: this API
+    /// is only ever fed fresh-GUID messages today (batch ingestion doesn't accept caller-supplied ids) --
+    /// if a caller ever passed two Message objects with the same id in one call, MERGE would collapse them
+    /// to one node and the returned list would have one fewer entry than the input, silently. Out of scope
+    /// to guard against since nothing does this.</summary>
     public const string AddBatch = @"
             UNWIND $messages AS msg
             MERGE (conv:Conversation {id: msg.conversation_id})
             ON CREATE SET conv.session_id = msg.session_id,
                           conv.created_at = datetime(msg.timestamp),
                           conv.updated_at = datetime(msg.timestamp)
-            CREATE (m:Message {
-                id:              msg.id,
-                conversation_id: msg.conversation_id,
-                session_id:      msg.session_id,
-                role:            msg.role,
-                content:         msg.content,
-                timestamp:       datetime(msg.timestamp),
-                tool_call_ids:   msg.tool_call_ids,
-                metadata:        msg.metadata
-            })
-            CREATE (conv)-[:HAS_MESSAGE]->(m)
+            MERGE (m:Message {id: msg.id})
+            ON CREATE SET
+                m.conversation_id = msg.conversation_id,
+                m.session_id      = msg.session_id,
+                m.role            = msg.role,
+                m.content         = msg.content,
+                m.timestamp       = datetime(msg.timestamp),
+                m.tool_call_ids   = msg.tool_call_ids,
+                m.metadata        = msg.metadata
+            MERGE (conv)-[:HAS_MESSAGE]->(m)
             RETURN m";
 
-    /// <summary>Create NEXT_MESSAGE link between two specific messages.</summary>
+    /// <summary>Create NEXT_MESSAGE link between two specific messages. MERGE (not CREATE) for the same
+    /// idempotency guarantee as <see cref="LinkNextMessage"/>.</summary>
     public const string CreateNextMessageLink =
-        "MATCH (prev:Message {id: $prevId}), (next:Message {id: $nextId}) CREATE (prev)-[:NEXT_MESSAGE]->(next)";
+        "MATCH (prev:Message {id: $prevId}), (next:Message {id: $nextId}) MERGE (prev)-[:NEXT_MESSAGE]->(next)";
 
-    /// <summary>Connect first batch message to the existing last message in the conversation.</summary>
+    /// <summary>Connect first batch message to the existing last message in the conversation. MERGE (not
+    /// CREATE) for the same idempotency guarantee as <see cref="LinkNextMessage"/>.</summary>
     public const string LinkBatchToExisting = @"
                     MATCH (conv:Conversation {id: $conversationId})-[:HAS_MESSAGE]->(prev:Message)
                     WHERE NOT prev.id IN $batchIds
                     WITH prev ORDER BY prev.timestamp DESC LIMIT 1
                     MATCH (first:Message {id: $firstId})
-                    CREATE (prev)-[:NEXT_MESSAGE]->(first)";
+                    MERGE (prev)-[:NEXT_MESSAGE]->(first)";
 
     /// <summary>Re-read all created messages by ids ordered by timestamp.</summary>
     public const string GetByIds =

--- a/src/AgentMemory.Neo4j/Queries/SharedFragments.cs
+++ b/src/AgentMemory.Neo4j/Queries/SharedFragments.cs
@@ -15,7 +15,11 @@ internal static class SharedFragments
     public const string SetFactEmbedding =
         "MATCH (f:Fact {id: $id}) SET f.embedding = $embedding";
 
-    /// <summary>Set embedding on a Message node by id.</summary>
+    /// <summary>Set embedding on a Message node by id. Runs unconditionally after Neo4jMessageRepository's
+    /// MERGE-by-id message write, whether that write created a new node or matched an existing one (a
+    /// duplicate-id persist call still overwrites the embedding) -- harmless assuming a deterministic
+    /// embedding for identical text, but not literally free: the embedding itself is generated upstream in
+    /// ShortTermMemoryService.AddMessageAsync before the repository is ever reached, on every call.</summary>
     public const string SetMessageEmbedding =
         "MATCH (m:Message {id: $id}) SET m.embedding = $embedding";
 

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -110,6 +110,40 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         }
     }
 
+    // Explicit override is mandatory, not optional polish: AddMessageWithIdAsync is a default interface
+    // method on IMemoryIngestion. Without this override, calls made through an IMemoryService-typed
+    // reference (which is how every consumer resolves this decorator) would silently execute the DIM's
+    // own default body -- which drops messageId and forwards to plain AddMessageAsync -- defeating the
+    // entire idempotent-persistence mechanism for any observability-enabled host, with no error or trace.
+    public async Task<Message> AddMessageWithIdAsync(
+        string sessionId,
+        string conversationId,
+        string role,
+        string content,
+        string messageId,
+        IReadOnlyDictionary<string, object>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = MemoryActivitySource.Instance.StartActivity("memory.add_message");
+        activity?.SetTag("memory.session_id", sessionId);
+        activity?.SetTag("memory.conversation_id", conversationId);
+        activity?.SetTag("memory.message.role", role);
+        activity?.SetTag("memory.message.id", messageId);
+
+        try
+        {
+            var result = await _inner.AddMessageWithIdAsync(
+                sessionId, conversationId, role, content, messageId, metadata, cancellationToken).ConfigureAwait(false);
+            _metrics.MessagesStored.Add(1);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+
     public async Task<IReadOnlyList<Message>> AddMessagesAsync(
         IEnumerable<Message> messages,
         CancellationToken cancellationToken = default)

--- a/tests/AgentMemory.Tests.Integration/AgentFramework/CrossProviderResponseMessageDedupIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/AgentFramework/CrossProviderResponseMessageDedupIntegrationTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using FluentAssertions;
+using AgentMemory;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Tests.Integration.Fixtures;
+
+namespace AgentMemory.Tests.Integration.AgentFramework;
+
+/// <summary>
+/// Live-Neo4j proof of #89's remaining acceptance criterion: enabling a chat-history provider alongside
+/// the memory context provider does not create duplicate persisted messages -- at least when the
+/// underlying IChatClient stamps a provider-native <see cref="ChatMessage.MessageId"/> on the response, as
+/// many production clients do. Simulates two independently-configured MAF integration components
+/// (<see cref="Neo4jMemoryContextProvider"/> and <see cref="Neo4jChatHistoryProvider"/>) both observing the
+/// same underlying model response for one turn.
+/// </summary>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public sealed class CrossProviderResponseMessageDedupIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+    private ServiceProvider _provider = null!;
+
+    public CrossProviderResponseMessageDedupIntegrationTests(Neo4jIntegrationFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.CleanDatabaseAsync();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddNeo4jAgentMemory(
+            configureMemory: _ => { },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+        services.AddAgentMemoryFramework(o => o.AutoExtractOnPersist = false);
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null) await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task TwoProvidersPersistingTheSameResponseMessage_ConvergeOnOneNode()
+    {
+        const string sessionId = "session-dedup";
+        const string conversationId = "conv-dedup";
+
+        // Both providers observe a response message carrying the SAME provider-native MessageId -- as they
+        // would if a host configured both on one agent and the underlying model call produced one real
+        // response, delivered to both InvokedContext callbacks for the same invocation. Deliberately
+        // DIFFERENT text per provider (a scenario that couldn't genuinely arise in production, since it's
+        // the same underlying response) so a regression back to CREATE-based persistence is caught hard:
+        // it would produce a second node carrying the second provider's text, not just an extra copy of
+        // identical content that a content-based assertion could miss.
+        var firstObserved = new ChatMessage(ChatRole.Assistant, "Got it.") { MessageId = "resp-shared-1" };
+        var secondObserved = new ChatMessage(ChatRole.Assistant, "a different second call must not overwrite this")
+        {
+            MessageId = "resp-shared-1"
+        };
+
+        using (var scope1 = _provider.CreateScope())
+        {
+            var contextProvider = scope1.ServiceProvider.GetRequiredService<Neo4jMemoryContextProvider>();
+            await contextProvider.PerformStoreAsync(
+                requestMessages: [new ChatMessage(ChatRole.User, "hello")],
+                responseMessages: [firstObserved],
+                sessionId: sessionId,
+                conversationId: conversationId,
+                cancellationToken: CancellationToken.None);
+        }
+
+        using (var scope2 = _provider.CreateScope())
+        {
+            var historyProvider = scope2.ServiceProvider.GetRequiredService<Neo4jChatHistoryProvider>();
+            await historyProvider.PerformStoreAsync(
+                requestMessages: [new ChatMessage(ChatRole.User, "hello")],
+                responseMessages: [secondObserved],
+                sessionId: sessionId,
+                conversationId: conversationId,
+                cancellationToken: CancellationToken.None);
+        }
+
+        using var readScope = _provider.CreateScope();
+        var memoryService = readScope.ServiceProvider.GetRequiredService<IMemoryService>();
+        var recallResult = await memoryService.RecallAsync(new Abstractions.Domain.RecallRequest
+        {
+            SessionId = sessionId,
+            Query = string.Empty,
+            Options = new Abstractions.Options.RecallOptions { MaxRecentMessages = 50 }
+        });
+
+        // Total messages: 1 request (persisted only by Neo4jChatHistoryProvider; Neo4jMemoryContextProvider
+        // deliberately never persists request messages) + 1 response. A regression back to CREATE-based
+        // response persistence would show 3 (two separate response nodes), not 2.
+        recallResult.Context.RecentMessages.Items.Should().HaveCount(2,
+            "both providers persisted a response message sharing the same provider-native MessageId, so " +
+            "they must converge on exactly one :Message node instead of each creating their own");
+
+        var responseNode = recallResult.Context.RecentMessages.Items.Should()
+            .ContainSingle(m => m.Role == "assistant").Subject;
+        responseNode.Content.Should().Be("Got it.",
+            "first-write-wins: the second provider's persist call must not overwrite the first provider's content");
+    }
+}

--- a/tests/AgentMemory.Tests.Integration/Repositories/MessageRepositoryIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/MessageRepositoryIntegrationTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Neo4j.Driver;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Neo4j.Repositories;
 using AgentMemory.Tests.Integration.Fixtures;
@@ -221,5 +222,81 @@ public class MessageRepositoryIntegrationTests : IAsyncLifetime
         var result = await _repo.GetByIdAsync("nonexistent-message-id");
 
         result.Should().BeNull();
+    }
+
+    // ── Idempotent-by-id persistence (#89): cross-component response-message dedup ──
+
+    [Fact]
+    public async Task AddAsync_CalledTwiceWithSameId_ProducesExactlyOneNodeAndNoDuplicateEdges()
+    {
+        var conv = await SeedConversationAsync();
+        var sharedId = $"msg-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        // A prior message so the shared-id message has a real predecessor to link NEXT_MESSAGE from.
+        var other = await _repo.AddAsync(new Message
+        {
+            MessageId = $"msg-{Guid.NewGuid():N}",
+            ConversationId = conv.ConversationId,
+            SessionId = conv.SessionId,
+            Role = "user",
+            Content = "unrelated message",
+            TimestampUtc = now
+        });
+
+        var first = await _repo.AddAsync(new Message
+        {
+            MessageId = sharedId,
+            ConversationId = conv.ConversationId,
+            SessionId = conv.SessionId,
+            Role = "assistant",
+            Content = "Got it.",
+            TimestampUtc = now.AddSeconds(1)
+        });
+
+        // Immediately persist the SAME id again (no unrelated message in between, so "prev" -- re-selected
+        // fresh each call -- resolves to the SAME node both times: "other") with DIFFERENT content,
+        // simulating a second MAF component independently observing the same response.
+        var second = await _repo.AddAsync(new Message
+        {
+            MessageId = sharedId,
+            ConversationId = conv.ConversationId,
+            SessionId = conv.SessionId,
+            Role = "assistant",
+            Content = "a different second call must not overwrite this",
+            TimestampUtc = now.AddSeconds(2)
+        });
+
+        // First-write-wins: the second call returns the ORIGINAL content, not its own.
+        second.Content.Should().Be("Got it.");
+        second.MessageId.Should().Be(first.MessageId);
+
+        var allMessages = await _repo.GetByConversationAsync(conv.ConversationId);
+        allMessages.Should().HaveCount(2, "the duplicate-id call must not create a second node");
+        allMessages.Should().ContainSingle(m => m.MessageId == sharedId && m.Content == "Got it.");
+        allMessages.Should().ContainSingle(m => m.MessageId == other.MessageId);
+
+        await using var session = _fixture.Driver.AsyncSession();
+        var hasMessageEdgeCount = await CountRelationshipsAsync(
+            session, "MATCH (:Conversation {id: $conversationId})-[r:HAS_MESSAGE]->(:Message {id: $id}) RETURN count(r) AS c",
+            new { conversationId = conv.ConversationId, id = sharedId });
+        hasMessageEdgeCount.Should().Be(1, "MERGE must not create a second HAS_MESSAGE edge to the same node");
+
+        // Both AddAsync calls for sharedId resolve "prev" to the SAME node ("other", the only other
+        // message), so this genuinely tests that MERGE doesn't duplicate the other->sharedId edge --
+        // unlike a variant where an unrelated message is inserted between the two calls, which would
+        // change "prev" the second time and always pass regardless of CREATE vs MERGE.
+        var nextMessageEdgeCount = await CountRelationshipsAsync(
+            session, "MATCH (:Message {id: $otherId})-[r:NEXT_MESSAGE]->(:Message {id: $id}) RETURN count(r) AS c",
+            new { otherId = other.MessageId, id = sharedId });
+        nextMessageEdgeCount.Should().Be(1, "MERGE must not create a second NEXT_MESSAGE edge for the same prev/next pair");
+    }
+
+    private static async Task<long> CountRelationshipsAsync(
+        IAsyncSession session, string cypher, object parameters)
+    {
+        var cursor = await session.RunAsync(cypher, parameters);
+        var record = await cursor.SingleAsync();
+        return global::Neo4j.Driver.ValueExtensions.As<long>(record["c"]);
     }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatHistoryProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatHistoryProviderTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using AgentMemory.Abstractions.Domain;
@@ -29,6 +31,33 @@ public sealed class Neo4jChatHistoryProviderTests
             _idGen,
             options ?? new AgentFrameworkOptions(),
             NullLogger<Neo4jChatHistoryProvider>.Instance);
+
+    // Minimal AIAgent/AgentSession doubles just to satisfy ChatHistoryProvider.InvokedContext's non-null
+    // constructor requirements -- these tests never actually invoke Run/session (de)serialization.
+    private sealed class NoopAgent : AIAgent
+    {
+        protected override Task<AgentResponse> RunCoreAsync(
+            IEnumerable<ChatMessage> messages, AgentSession? session, AgentRunOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        protected override IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+            IEnumerable<ChatMessage> messages, AgentSession? session, AgentRunOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(
+            JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(
+            AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TestAgentSession : AgentSession;
 
     [Fact]
     public void Constructor_NullMemoryService_Throws() =>
@@ -221,6 +250,128 @@ public sealed class Neo4jChatHistoryProviderTests
                 r.Messages.Count == 2 &&
                 r.Messages[0].Content == "request-text" &&
                 r.Messages[1].Content == "response-text"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Fix A (#89): don't re-persist another provider's injected request messages ──
+
+    [Fact]
+    public async Task InvokedAsync_ExcludesAIContextProviderSourcedRequestMessages()
+    {
+        // The base ChatHistoryProvider's default filter only excludes ChatHistory-sourced messages;
+        // Neo4jChatHistoryProvider narrows this to External-only (see its constructor) so it never
+        // re-persists e.g. Neo4jMemoryContextProvider's injected recalled-memory content every turn.
+        var sut = CreateSut();
+        StubAddMessage("user", "hello", "m-external");
+        StubAddMessage("assistant", "hi", "m-res");
+
+        var externalMessage = new ChatMessage(ChatRole.User, "hello");
+        var injectedMessage = new ChatMessage(ChatRole.System, "<recalled_memory>stuff</recalled_memory>")
+            .WithAgentRequestMessageSource(AgentRequestMessageSourceType.AIContextProvider, "Neo4jMemoryContextProvider");
+
+#pragma warning disable MAAI001
+        var context = new ChatHistoryProvider.InvokedContext(
+            new NoopAgent(),
+            new TestAgentSession(),
+            new[] { externalMessage, injectedMessage },
+            new[] { new ChatMessage(ChatRole.Assistant, "hi") });
+#pragma warning restore MAAI001
+
+        await sut.InvokedAsync(context, CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), "user", "hello",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Is<string>(c => c.Contains("recalled_memory")),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Fix B.4 (#89): dedupe response messages via a provider-native MessageId when present ──
+
+    private void StubAddMessageWithId(string role, string content, string messageId) =>
+        _memoryService
+            .AddMessageWithIdAsync(Arg.Any<string>(), Arg.Any<string>(), role, content, messageId,
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Message
+            {
+                MessageId = messageId, SessionId = "s1", ConversationId = "c1",
+                Role = role, Content = content, TimestampUtc = _now
+            });
+
+    [Fact]
+    public async Task PerformStoreAsync_ResponseMessageWithProviderMessageId_UsesAddMessageWithIdAsync()
+    {
+        var sut = CreateSut();
+        StubAddMessage("user", "hi", "m-req");
+        StubAddMessageWithId("assistant", "Got it.", "maf:resp-42");
+
+        var responseMessage = new ChatMessage(ChatRole.Assistant, "Got it.") { MessageId = "resp-42" };
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            new List<ChatMessage> { responseMessage },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageWithIdAsync(
+            "s1", "c1", "assistant", "Got it.", "maf:resp-42",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), "assistant", "Got it.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_ResponseMessageWithoutProviderMessageId_FallsBackToAddMessageAsync()
+    {
+        var sut = CreateSut();
+        StubAddMessage("user", "hi", "m-req");
+        StubAddMessage("assistant", "Got it.", "m-res");
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            new List<ChatMessage> { new(ChatRole.Assistant, "Got it.") },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageAsync(
+            "s1", "c1", "assistant", "Got it.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageWithIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Fix C (#89): non-text content (function calls/results, reasoning) is excluded, explicitly ──
+
+    [Fact]
+    public async Task PerformStoreAsync_FunctionCallOnlyResponseMessage_IsExcludedFromPersistenceAndExtraction()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        StubAddMessage("user", "hi", "m-req");
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        var functionCallMessage = new ChatMessage(
+            ChatRole.Assistant, new List<AIContent> { new FunctionCallContent("call-1", "search_memory") });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            new List<ChatMessage> { functionCallMessage },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), "assistant", Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Count == 1 && r.Messages[0].Role == "user"),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jChatMessageStoreTests.cs
@@ -69,6 +69,34 @@ public sealed class Neo4jChatMessageStoreTests
     }
 
     [Fact]
+    public async Task AddMessageAsync_ChatMessageWithProviderMessageId_UsesAddMessageWithIdAsync()
+    {
+        // #89: when the underlying IChatClient stamps a provider-native MessageId, persist under a
+        // deterministic id so another persisting component observing the same message converges on the
+        // same :Message node instead of creating a duplicate.
+        var expected = new Message
+        {
+            MessageId = "maf:resp-7", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Hi there", TimestampUtc = _now
+        };
+        _memoryService
+            .AddMessageWithIdAsync("s1", "c1", "assistant", "Hi there", "maf:resp-7",
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var chatMsg = new ChatMessage(ChatRole.Assistant, "Hi there") { MessageId = "resp-7" };
+        var result = await _sut.AddMessageAsync(chatMsg, "s1", "c1");
+
+        result.Should().Be(expected);
+        await _memoryService.Received(1).AddMessageWithIdAsync(
+            "s1", "c1", "assistant", "Hi there", "maf:resp-7",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task AddMessageAsync_ServiceThrows_PropagatesInsteadOfFabricatingSuccess()
     {
         // A persist failure must surface, not be hidden behind a fabricated "success" Message (which would

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -561,6 +561,94 @@ public sealed class Neo4jMemoryContextProviderTests
             Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
     }
 
+    // ── Fix B.4 (#89): dedupe response messages via a provider-native MessageId when present ──
+
+    [Fact]
+    public async Task PerformStoreAsync_ResponseMessageWithProviderMessageId_UsesAddMessageWithIdAsync()
+    {
+        var sut = CreateSut();
+        var responseMessage = new ChatMessage(ChatRole.Assistant, "Got it.") { MessageId = "resp-42" };
+        var storedMessage = new Message
+        {
+            MessageId = "maf:resp-42", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Got it.", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageWithIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedMessage);
+
+        await sut.PerformStoreAsync(
+            Array.Empty<ChatMessage>(), new List<ChatMessage> { responseMessage }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageWithIdAsync(
+            "s1", "c1", "assistant", "Got it.", "maf:resp-42",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PerformStoreAsync_ResponseMessageWithoutProviderMessageId_FallsBackToAddMessageAsync()
+    {
+        var sut = CreateSut();
+        var responseMessage = new ChatMessage(ChatRole.Assistant, "Got it.");
+        var storedMessage = new Message
+        {
+            MessageId = "m-store-1", SessionId = "s1", ConversationId = "c1",
+            Role = "assistant", Content = "Got it.", TimestampUtc = FixedTime
+        };
+        _memoryService
+            .AddMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>())
+            .Returns(storedMessage);
+
+        await sut.PerformStoreAsync(
+            Array.Empty<ChatMessage>(), new List<ChatMessage> { responseMessage }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).AddMessageAsync(
+            "s1", "c1", "assistant", "Got it.",
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageWithIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Fix C (#89): non-text content (function calls/results, reasoning) is excluded, explicitly ──
+
+    [Fact]
+    public async Task PerformStoreAsync_FunctionCallOnlyResponseMessage_IsExcludedFromPersistenceAndExtraction()
+    {
+        var sut = CreateSut(new AgentFrameworkOptions { AutoExtractOnPersist = true });
+        var functionCallMessage = new ChatMessage(
+            ChatRole.Assistant, new List<AIContent> { new FunctionCallContent("call-1", "search_memory") });
+        _memoryService.ExtractAndPersistAsync(Arg.Any<ExtractionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Entities = Array.Empty<ExtractedEntity>(),
+                Facts = Array.Empty<ExtractedFact>(),
+                Preferences = Array.Empty<ExtractedPreference>(),
+                Relationships = Array.Empty<ExtractedRelationship>(),
+                SourceMessageIds = Array.Empty<string>()
+            });
+
+        await sut.PerformStoreAsync(
+            new List<ChatMessage> { new(ChatRole.User, "search for my preferences") },
+            new List<ChatMessage> { functionCallMessage },
+            "s1", "c1", CancellationToken.None);
+
+        await _memoryService.DidNotReceive().AddMessageAsync(
+            Arg.Any<string>(), Arg.Any<string>(), "assistant", Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.DidNotReceive().AddMessageWithIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), "assistant", Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<CancellationToken>());
+        await _memoryService.Received(1).ExtractAndPersistAsync(
+            Arg.Is<ExtractionRequest>(r => r.Messages.Count == 1 && r.Messages[0].Role == "user"),
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task PerformStoreAsync_AutoExtractEnabled_CallsExtractAndPersistAsync()
     {

--- a/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
@@ -144,6 +144,30 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task AddMessageWithIdAsync_DelegatesToInnerAndCreatesActivity()
+    {
+        // AddMessageWithIdAsync is a default interface method on IMemoryIngestion (#89) -- this decorator
+        // MUST explicitly override it, or calls made through the IMemoryService-typed reference (how every
+        // consumer resolves it) would silently execute the DIM's own default body, dropping the id and
+        // defeating the idempotent-persistence mechanism entirely, with no error or trace.
+        var message = CreateMessage("maf:resp-1", "s1");
+        _inner.AddMessageWithIdAsync("s1", "c1", "assistant", "hello", "maf:resp-1", null, Arg.Any<CancellationToken>())
+            .Returns(message);
+
+        var result = await _sut.AddMessageWithIdAsync("s1", "c1", "assistant", "hello", "maf:resp-1");
+
+        result.Should().Be(message);
+        await _inner.Received(1).AddMessageWithIdAsync(
+            "s1", "c1", "assistant", "hello", "maf:resp-1", null, Arg.Any<CancellationToken>());
+        var activity = _capturedActivities.Should().ContainSingle(
+            a => a.OperationName == "memory.add_message").Subject;
+        activity.GetTagItem("memory.session_id").Should().Be("s1");
+        activity.GetTagItem("memory.conversation_id").Should().Be("c1");
+        activity.GetTagItem("memory.message.role").Should().Be("assistant");
+        activity.GetTagItem("memory.message.id").Should().Be("maf:resp-1");
+    }
+
+    [Fact]
     public async Task ExtractAndPersist_RecordsExtractionDuration()
     {
         var request = new ExtractionRequest

--- a/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
+++ b/tests/AgentMemory.Tests.Unit/Queries/CypherQuerySnapshot.snap
@@ -358,17 +358,16 @@ MERGE (conv:Conversation {id: $conversationId})
             ON CREATE SET conv.session_id = $sessionId,
                           conv.created_at = datetime($timestamp),
                           conv.updated_at = datetime($timestamp)
-            CREATE (m:Message {
-                id:              $id,
-                conversation_id: $conversationId,
-                session_id:      $sessionId,
-                role:            $role,
-                content:         $content,
-                timestamp:       datetime($timestamp),
-                tool_call_ids:   $toolCallIds,
-                metadata:        $metadata
-            })
-            CREATE (conv)-[:HAS_MESSAGE]->(m)
+            MERGE (m:Message {id: $id})
+            ON CREATE SET
+                m.conversation_id = $conversationId,
+                m.session_id      = $sessionId,
+                m.role            = $role,
+                m.content         = $content,
+                m.timestamp       = datetime($timestamp),
+                m.tool_call_ids   = $toolCallIds,
+                m.metadata        = $metadata
+            MERGE (conv)-[:HAS_MESSAGE]->(m)
             RETURN m
 
 ## MessageQueries.AddBatch
@@ -377,17 +376,16 @@ UNWIND $messages AS msg
             ON CREATE SET conv.session_id = msg.session_id,
                           conv.created_at = datetime(msg.timestamp),
                           conv.updated_at = datetime(msg.timestamp)
-            CREATE (m:Message {
-                id:              msg.id,
-                conversation_id: msg.conversation_id,
-                session_id:      msg.session_id,
-                role:            msg.role,
-                content:         msg.content,
-                timestamp:       datetime(msg.timestamp),
-                tool_call_ids:   msg.tool_call_ids,
-                metadata:        msg.metadata
-            })
-            CREATE (conv)-[:HAS_MESSAGE]->(m)
+            MERGE (m:Message {id: msg.id})
+            ON CREATE SET
+                m.conversation_id = msg.conversation_id,
+                m.session_id      = msg.session_id,
+                m.role            = msg.role,
+                m.content         = msg.content,
+                m.timestamp       = datetime(msg.timestamp),
+                m.tool_call_ids   = msg.tool_call_ids,
+                m.metadata        = msg.metadata
+            MERGE (conv)-[:HAS_MESSAGE]->(m)
             RETURN m
 
 ## MessageQueries.CreateFirstMessageLink
@@ -396,7 +394,7 @@ MATCH (conv:Conversation {id: $conversationId}), (m:Message {id: $id})
                 MERGE (conv)-[:FIRST_MESSAGE]->(m)
 
 ## MessageQueries.CreateNextMessageLink
-MATCH (prev:Message {id: $prevId}), (next:Message {id: $nextId}) CREATE (prev)-[:NEXT_MESSAGE]->(next)
+MATCH (prev:Message {id: $prevId}), (next:Message {id: $nextId}) MERGE (prev)-[:NEXT_MESSAGE]->(next)
 
 ## MessageQueries.DeleteBySession
 MATCH (m:Message {session_id: $sessionId}) DETACH DELETE m
@@ -438,14 +436,14 @@ MATCH (conv:Conversation {id: $conversationId})-[:HAS_MESSAGE]->(prev:Message)
                     WHERE NOT prev.id IN $batchIds
                     WITH prev ORDER BY prev.timestamp DESC LIMIT 1
                     MATCH (first:Message {id: $firstId})
-                    CREATE (prev)-[:NEXT_MESSAGE]->(first)
+                    MERGE (prev)-[:NEXT_MESSAGE]->(first)
 
 ## MessageQueries.LinkNextMessage
 MATCH (conv:Conversation {id: $conversationId})-[:HAS_MESSAGE]->(prev:Message)
             WHERE prev.id <> $id
             WITH prev ORDER BY prev.timestamp DESC LIMIT 1
             MATCH (m:Message {id: $id})
-            CREATE (prev)-[:NEXT_MESSAGE]->(m)
+            MERGE (prev)-[:NEXT_MESSAGE]->(m)
 
 ## PreferenceQueries.CreateAboutRelationship
 MATCH (p:Preference {id: $preferenceId}), (e:Entity {id: $entityId})


### PR DESCRIPTION
## Summary

Closes the two remaining #89 acceptance criteria, plus a related bug found while investigating them.

- **Enabling more than one MAF message-persisting component could duplicate `:Message` nodes.**
  - `Neo4jChatHistoryProvider` now narrows MAF's default request-message filter to `AgentRequestMessageSourceType.External` only, so it no longer re-persists another configured `AIContextProvider`'s (e.g. `Neo4jMemoryContextProvider`'s) injected recalled-memory messages as new nodes every turn. This is a real, previously-undiscovered bug found while investigating #89 — not one of its originally stated criteria.
  - Response-message persistence is now idempotent by id: `Neo4jMessageRepository` writes `MERGE`-by-id instead of `CREATE` (safe no-op for a repeated id, backed by the existing `message_id` uniqueness constraint — no existing caller ever supplied a repeated id, so this is purely additive). `Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider`/`Neo4jChatMessageStore` now persist a response message under a deterministic id derived from the underlying `ChatMessage.MessageId` when the `IChatClient` populates one (true for many production clients), so components observing the same response converge on one node instead of duplicating it. When the client doesn't populate `MessageId`, today's behavior remains (disclosed limitation, not a silent one).
  - `IMemoryIngestion.AddMessageWithIdAsync` is added as a **default interface method** to stay backward-compatible (this ships in a minor version). `InstrumentedMemoryService` gets a **mandatory** explicit override — without it, calls through this decorator would silently execute the DIM's default body and drop the id, defeating the mechanism for any observability-enabled host.
- **Tool messages are handled according to an explicitly documented policy.** Documented (and now tested) that a message carrying only function/tool calls, function/tool results, or reasoning content — not just "tool messages" narrowly — is excluded from both persistence and extraction in `Neo4jMemoryContextProvider`/`Neo4jChatHistoryProvider`. Explicitly scoped: the lower-level `Neo4jChatMessageStore`/`Neo4jMicrosoftMemoryFacade` path does not have this guard and persists everything it's given.

Adversarially reviewed (Opus) before opening this PR — one real doc-overclaim finding fixed (narrowed the non-text-content policy claim to the two providers that actually have the guard), plus several test-hardening fixes (a couple of the original tests could have passed without actually proving the fix; strengthened both to genuinely detect a regression).

## Test plan
- [x] Full unit suite green (2767 tests)
- [x] Full live-Neo4j integration suite green (285 tests)
- [x] New/updated unit tests: `Neo4jChatHistoryProviderTests`, `Neo4jMemoryContextProviderTests`, `Neo4jChatMessageStoreTests`, `InstrumentedMemoryServiceTests`
- [x] New/updated integration tests: `MessageRepositoryIntegrationTests` (idempotent-by-id proof), new `CrossProviderResponseMessageDedupIntegrationTests` (two independently-configured providers converge on one node)
- [x] `docs/agent-framework.md` and `CHANGELOG.md` updated

Closes #89.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>