### PR TITLE
docs+build: fix stale/inaccurate docs and wire ShoppingAssistant into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           dotnet build samples/AgentMemory.Sample.MinimalAgent/AgentMemory.Sample.MinimalAgent.csproj -c Release --no-restore
           dotnet build samples/AgentMemory.Sample.BlendedAgent/AgentMemory.Sample.BlendedAgent.csproj -c Release --no-restore
           dotnet build samples/AgentMemory.Sample.McpHost/AgentMemory.Sample.McpHost.csproj -c Release --no-restore
+          dotnet build samples/AgentMemory.Sample.ShoppingAssistant/AgentMemory.Sample.ShoppingAssistant.csproj -c Release --no-restore
           dotnet build samples/AspireDemo/AspireDemo.AppHost/AspireDemo.AppHost.csproj -c Release --no-restore
           dotnet build samples/AspireDemo/AspireDemo.DemoApp/AspireDemo.DemoApp.csproj -c Release --no-restore
 

--- a/AgentMemory.slnx
+++ b/AgentMemory.slnx
@@ -9,6 +9,7 @@
     <Project Path="samples/AgentMemory.Sample.MinimalAgent/AgentMemory.Sample.MinimalAgent.csproj" />
     <Project Path="samples/AgentMemory.Sample.RealAgent/AgentMemory.Sample.RealAgent.csproj" />
     <Project Path="samples/AgentMemory.Sample.McpHost/AgentMemory.Sample.McpHost.csproj" />
+    <Project Path="samples/AgentMemory.Sample.ShoppingAssistant/AgentMemory.Sample.ShoppingAssistant.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/AgentMemory.Abstractions/AgentMemory.Abstractions.csproj" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing! This guide covers environment setup
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| [.NET SDK](https://dotnet.microsoft.com/download) | **9.0+** | Build and test |
+| [.NET SDK](https://dotnet.microsoft.com/download) | version pinned in `global.json` | Build and test |
 | [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Any recent | Testcontainers (integration tests start Neo4j 5.x automatically — no manual Neo4j install needed) |
 | Git | Any | Source control |
 
@@ -31,7 +31,8 @@ dotnet build AgentMemory.slnx
 ```
 
 The solution is configured via `Directory.Build.props`:
-- Target framework: **net9.0**
+- Target frameworks: publishable `src/` libraries multi-target **net8.0**, **net9.0**, and **net10.0**;
+  tests, samples, and tools build against whatever single framework their own `.csproj` specifies
 - Nullable reference types: **enabled**
 - `TreatWarningsAsErrors`: **true** for all `src/` projects (disabled for `tests/`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,9 @@ Agent Memory for .NET is a **native .NET implementation of graph-native persiste
 
 ### 2.2 Dependency Direction Rule
 
-**Dependencies flow strictly inward.** Adapters → Neo4j → Core → Abstractions. Never the reverse.
+**Dependencies flow strictly inward.** Adapters (MAF, SemanticKernel, Observability, MCP) depend directly
+on Core, never on Neo4j or on each other. Neo4j depends on Core and Abstractions as its own, separate
+branch. Core depends on Abstractions. Never the reverse. See the diagram below.
 
 ```mermaid
 graph TD

--- a/docs/neo4j-memory-ecosystem.md
+++ b/docs/neo4j-memory-ecosystem.md
@@ -72,9 +72,9 @@ on top of normal PR review and CI:
 - **API surface lockdown.** Ahead of the `1.0` cut, an eight-part review series audited the entire public
   API surface for implementation leakage, contract honesty, naming/enum consistency, and type safety, and
   locked the result under Semantic Versioning.
-- **Release gates.** Every release ships from a warning-free Release build with the full test suite green:
-  unit, Semantic Kernel, live-Neo4j integration, and performance smoke tests — currently **3000+ tests**
-  in total — plus an end-to-end soak of the flagship sample against a live Neo4j instance.
+- **Release gates.** Every release ships from a warning-free Release build with the full test suite green
+  across unit, Semantic Kernel, live-Neo4j integration, and performance smoke tests, plus an end-to-end
+  soak of the flagship sample against a live Neo4j instance.
 
 The review process treats a passing happy-path test as insufficient evidence: fixes are verified by a
 regression test that reproduces the original trigger (fails before the fix, passes after), and any


### PR DESCRIPTION
## Summary

Addresses external review feedback on recent work — 5 items assessed, 4 were real and fixed, 1 was verified as harmless already-resolved git history noise (not touched, since rewriting published main history would be destructive):

- `docs/architecture.md`'s dependency-direction prose said "Adapters → Neo4j → Core → Abstractions," contradicting both the mermaid diagram right below it and the actual `.csproj` files (adapters depend on Core directly, never Neo4j). Corrected.
- `CONTRIBUTING.md` said ".NET SDK 9.0+" / "Target framework: net9.0" — stale since `global.json` now pins `10.0.102` and publishable packages multi-target net8.0/9.0/10.0. Corrected.
- `docs/neo4j-memory-ecosystem.md` had a hardcoded "currently 3000+ tests" figure from the 1.0 release — dropped the number entirely so it can't go stale again.
- `AgentMemory.Sample.ShoppingAssistant` (added in #85) was never wired into `AgentMemory.slnx` or CI's sample-smoke build list — added both; full solution builds clean.
- (Verified, not fixed) A 4-commit sequence in README.md history added/reverted a link — diffed the pre- and post-churn README and confirmed identical content; no lingering artifact to fix, and rewriting published history isn't warranted here.

## Test plan
- [x] Full unit suite green (2767 tests)
- [x] Full solution builds clean (0 warnings/errors) including the newly-wired ShoppingAssistant sample
- [x] CI YAML validated

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>