### PR TITLE
feat: structured ingestion outcomes for partial extraction/persistence failures (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Structured ingestion outcomes for partial extraction/persistence failures (#101).** `ExtractionResult`
+  gains `Status` (`IngestionStatus`: `Succeeded` / `PartiallySucceeded` / `Failed`) and `Outcomes`
+  (`IReadOnlyList<IngestionItemOutcome>`), so a caller can finally distinguish "everything persisted" from
+  "3 facts succeeded, 1 entity failed, 2 provenance edges didn't." Best-effort ingestion (continue past
+  per-item failures) remains the default via the new `ExtractionOptions.FailureMode` (`IngestionFailureMode.BestEffort`);
+  set it to `FailFast` to instead throw `MemoryIngestionException` (carrying every outcome completed
+  before the failure) at the first non-recoverable item. Covers extractor failures, entity
+  validation/resolution failures, persistence failures, and provenance failures — the last two now
+  distinctly staged, since a node can persist successfully while its `EXTRACTED_FROM` edge fails.
+  Routine confidence-threshold filtering is deliberately not recorded as an outcome. New
+  `memory.ingestion.operations`/`memory.ingestion.items.succeeded`/`memory.ingestion.items.failed`
+  metrics (tagged by status/failure-mode/item-kind/stage only — never owner IDs or memory content).
+  Fully additive: existing `ExtractionResult` properties and default behavior are unchanged.
+
 ## [1.2.0] - 2026-07-15
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ graph TD
 | **Purpose** | Domain contracts — all models, interfaces, and configuration types shared across the system |
 | **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.5.1 (approved, D-AR2-1) — .NET BCL otherwise (multi-targets net8.0/net9.0/net10.0) |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK, any MCP SDK, any NuGet package **except** Microsoft.Extensions.AI.Abstractions |
-| **Key types** | 48 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, etc.), 39 service interfaces (incl. `IMemoryIsolationPolicy`, #100), 11 repository interfaces, 16 configuration types (incl. `MemoryRankingOptions`, `MemoryIsolationOptions`), 18 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`, `MemoryNodeKind`, `MemoryOperationAccess`, `MemoryIsolationMode`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
+| **Key types** | 49 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, IngestionItemOutcome, etc.), 39 service interfaces (incl. `IMemoryIsolationPolicy`, #100), 11 repository interfaces, 16 configuration types (incl. `MemoryRankingOptions`, `MemoryIsolationOptions`), 23 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`, `MemoryNodeKind`, `MemoryOperationAccess`, `MemoryIsolationMode`, `IngestionStatus`, `IngestionStage`, `IngestionItemStatus`, `MemoryItemKind`, `IngestionFailureMode`) (see the catalogs in `design.md §5/§6` for the authoritative, per-type list) |
 
 **Namespace structure:**
 ```
@@ -160,6 +160,37 @@ AgentMemory.Abstractions.Options       — configuration records
 | **Dependencies** | Abstractions (project ref), Microsoft.Extensions.AI.Abstractions 10.5.1, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5, FuzzySharp |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK |
 | **Key types** | SystemClock, GuidIdGenerator, StubEmbeddingGenerator, EmbeddingOrchestrator, StubExtractionPipeline, StubEntityExtractor, StubFactExtractor, StubPreferenceExtractor, StubRelationshipExtractor, StubEntityResolver |
+
+#### 3.2.1 Ingestion outcomes (#101)
+
+`ExtractAndPersistAsync`/`IMemoryExtractionPipeline.ExtractAsync` extract and persist independent
+items (entities, facts, preferences, relationships) from a batch of messages. Individual items can
+fail at any stage — an extractor throws, an entity fails validation or resolution, a node fails to
+persist, or its `EXTRACTED_FROM` provenance edge fails after the node itself succeeded — and by
+default (`IngestionFailureMode.BestEffort`) the pipeline keeps going: one bad item must not discard
+several good ones. `ExtractionResult` makes that visible instead of only logging it:
+
+- `Status` (`IngestionStatus`: `Succeeded` / `PartiallySucceeded` / `Failed`) — derived from
+  `Outcomes`: any `Failed` item outcome makes it at least `PartiallySucceeded`; `Failed` overall only
+  when *nothing* succeeded. Nothing to ingest is `Succeeded`, not `Failed`.
+- `Outcomes` (`IReadOnlyList<IngestionItemOutcome>`) — one entry per meaningful event (a success, a
+  validation/resolution skip, or a failure), each carrying `Kind` (entity/fact/preference/
+  relationship), `Stage` (extraction/validation/resolution/persistence/provenance/relationship-
+  persistence), a stable `ErrorCode` (`MemoryErrorCodes`, all `MEMORY_`-prefixed), and `Retryable`.
+  Routine confidence-threshold filtering is deliberately **not** recorded — it's expected pipeline
+  behavior, not a failure or a meaningful skip.
+
+Set `ExtractionOptions.FailureMode = IngestionFailureMode.FailFast` to instead stop at the first
+failure and throw `MemoryIngestionException`, which carries every `IngestionItemOutcome` completed
+before the failure (`CompletedOutcomes`) so a caller can see exactly how far ingestion got. The four
+extractor categories (entity/fact/preference/relationship) run concurrently and can't be pre-empted
+mid-flight, so fail-fast takes effect at the next stoppable point: once all four finish, or inside
+the sequential per-item resolution/persistence loops. `OperationCanceledException` always propagates
+as itself — under either mode — never converted into a partial or failed outcome.
+
+Item-level transactionality (e.g. a fact and its provenance edges committing atomically) is an
+explicit non-goal of #101 — Neo4j write ordering here is still best-effort, not atomic, and nothing
+in the API claims otherwise.
 
 ### 3.3 AgentMemory.Neo4j
 

--- a/src/AgentMemory.Abstractions/Domain/Extraction/ExtractionResult.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/ExtractionResult.cs
@@ -37,4 +37,19 @@ public sealed record ExtractionResult
     /// </summary>
     public IReadOnlyDictionary<string, object> Metadata { get; init; } =
         new Dictionary<string, object>();
+
+    /// <summary>
+    /// Overall ingestion outcome (#101). Defaults to <see cref="IngestionStatus.Succeeded"/> so existing
+    /// callers that only read the item collections above see unchanged behavior.
+    /// </summary>
+    public IngestionStatus Status { get; init; } = IngestionStatus.Succeeded;
+
+    /// <summary>
+    /// Per-item outcomes recorded across the extraction and persistence stages (#101): failures,
+    /// meaningful skips, and successes. Empty by default. See <see cref="IngestionItemOutcome"/>.
+    /// </summary>
+    public IReadOnlyList<IngestionItemOutcome> Outcomes { get; init; } = Array.Empty<IngestionItemOutcome>();
+
+    /// <summary>Convenience accessor: <see langword="true"/> when <see cref="Status"/> is <see cref="IngestionStatus.PartiallySucceeded"/>.</summary>
+    public bool IsPartial => Status == IngestionStatus.PartiallySucceeded;
 }

--- a/src/AgentMemory.Abstractions/Domain/Extraction/IngestionItemOutcome.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/IngestionItemOutcome.cs
@@ -1,0 +1,40 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>
+/// Machine-readable outcome of one memory item at one ingestion stage (#101). A single logical item
+/// (e.g. one fact) may have more than one outcome across the pipeline -- e.g. a
+/// <see cref="IngestionStage.Persistence"/> success followed by a <see cref="IngestionStage.Provenance"/>
+/// failure -- since each stage's result is independently meaningful for retries and auditing.
+/// </summary>
+public sealed record IngestionItemOutcome
+{
+    /// <summary>The kind of item this outcome describes.</summary>
+    public required MemoryItemKind Kind { get; init; }
+
+    /// <summary>The pipeline stage this outcome was recorded at.</summary>
+    public required IngestionStage Stage { get; init; }
+
+    /// <summary>Whether the item succeeded, was skipped, or failed at this stage.</summary>
+    public required IngestionItemStatus Status { get; init; }
+
+    /// <summary>
+    /// A human-readable identifier for the item, for correlating this outcome back to the source data
+    /// (e.g. an entity name, or "Subject Predicate Object" for a fact). Not a persisted identifier.
+    /// </summary>
+    public string? SourceKey { get; init; }
+
+    /// <summary>The persisted node/edge id, when the item reached persistence successfully.</summary>
+    public string? PersistedId { get; init; }
+
+    /// <summary>A stable, machine-readable error code (see <c>MemoryErrorCodes</c>), when <see cref="Status"/> is not <see cref="IngestionItemStatus.Succeeded"/>.</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>
+    /// A diagnostic message, when applicable. Must not include prompts, complete memory contents,
+    /// secrets, connection strings, or provider credentials.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Whether retrying this item (e.g. via fail-fast + re-submission) is expected to be safe/useful.</summary>
+    public bool Retryable { get; init; }
+}

--- a/src/AgentMemory.Abstractions/Domain/Extraction/IngestionItemStatus.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/IngestionItemStatus.cs
@@ -1,0 +1,15 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>Per-item outcome status recorded in an <see cref="IngestionItemOutcome"/> (#101).</summary>
+public enum IngestionItemStatus
+{
+    /// <summary>The item completed this stage successfully.</summary>
+    Succeeded,
+
+    /// <summary>The item was deliberately not processed further (e.g. failed validation, or a
+    /// relationship whose endpoint was never resolved/persisted) -- not an error, but worth surfacing.</summary>
+    Skipped,
+
+    /// <summary>The item failed this stage.</summary>
+    Failed
+}

--- a/src/AgentMemory.Abstractions/Domain/Extraction/IngestionStage.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/IngestionStage.cs
@@ -1,0 +1,26 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>Pipeline stage at which an <see cref="IngestionItemOutcome"/> was recorded (#101).</summary>
+public enum IngestionStage
+{
+    /// <summary>An extractor (entity/fact/preference/relationship) ran.</summary>
+    Extraction,
+
+    /// <summary>Entity validation (<c>EntityValidator</c>) ran against an extracted candidate.</summary>
+    Validation,
+
+    /// <summary>Entity resolution (matching/deduplication against existing graph entities) ran.</summary>
+    Resolution,
+
+    /// <summary>Embedding generation for a persisted item ran.</summary>
+    Embedding,
+
+    /// <summary>The item's node was upserted to its repository.</summary>
+    Persistence,
+
+    /// <summary>An <c>EXTRACTED_FROM</c> provenance edge was created for a persisted item.</summary>
+    Provenance,
+
+    /// <summary>A relationship's endpoints were checked against already-persisted entities.</summary>
+    RelationshipPersistence
+}

--- a/src/AgentMemory.Abstractions/Domain/Extraction/IngestionStatus.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/IngestionStatus.cs
@@ -1,0 +1,17 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>
+/// Overall outcome of an ingestion (extraction + persistence) operation. See
+/// <see cref="ExtractionResult.Status"/> (#101).
+/// </summary>
+public enum IngestionStatus
+{
+    /// <summary>Every attempted item succeeded (including the trivial case of nothing to ingest).</summary>
+    Succeeded,
+
+    /// <summary>At least one item succeeded and at least one item failed.</summary>
+    PartiallySucceeded,
+
+    /// <summary>At least one item was attempted and none succeeded.</summary>
+    Failed
+}

--- a/src/AgentMemory.Abstractions/Domain/Extraction/MemoryItemKind.cs
+++ b/src/AgentMemory.Abstractions/Domain/Extraction/MemoryItemKind.cs
@@ -1,0 +1,22 @@
+namespace AgentMemory.Abstractions.Domain;
+
+/// <summary>
+/// The kind of memory item an <see cref="IngestionItemOutcome"/> describes (#101). Deliberately
+/// separate from <see cref="MemoryNodeKind"/> (which enumerates persisted graph node labels only,
+/// scoped to embedding-batch regeneration): ingestion outcomes also need to describe
+/// <see cref="Relationship"/> items, which are graph edges, not nodes.
+/// </summary>
+public enum MemoryItemKind
+{
+    /// <summary>An extracted/persisted entity.</summary>
+    Entity,
+
+    /// <summary>An extracted/persisted fact.</summary>
+    Fact,
+
+    /// <summary>An extracted/persisted preference.</summary>
+    Preference,
+
+    /// <summary>An extracted/persisted relationship.</summary>
+    Relationship
+}

--- a/src/AgentMemory.Abstractions/Exceptions/MemoryErrorCodes.cs
+++ b/src/AgentMemory.Abstractions/Exceptions/MemoryErrorCodes.cs
@@ -53,4 +53,48 @@ public static class MemoryErrorCodes
 
     /// <summary>Persisting one or more memory items to the graph failed.</summary>
     public const string PersistenceFailed       = "MEMORY_PERSISTENCE_FAILED";
+
+    // ── Ingestion outcome codes (#101) — used as IngestionItemOutcome.ErrorCode ──
+
+    /// <summary>An entity extractor threw.</summary>
+    public const string EntityExtractionFailed       = "MEMORY_ENTITY_EXTRACTION_FAILED";
+
+    /// <summary>A fact extractor threw.</summary>
+    public const string FactExtractionFailed         = "MEMORY_FACT_EXTRACTION_FAILED";
+
+    /// <summary>A preference extractor threw.</summary>
+    public const string PreferenceExtractionFailed   = "MEMORY_PREFERENCE_EXTRACTION_FAILED";
+
+    /// <summary>A relationship extractor threw.</summary>
+    public const string RelationshipExtractionFailed = "MEMORY_RELATIONSHIP_EXTRACTION_FAILED";
+
+    /// <summary>An extracted entity candidate failed <c>EntityValidator</c> validation.</summary>
+    public const string EntityValidationFailed       = "MEMORY_ENTITY_VALIDATION_FAILED";
+
+    /// <summary>Entity resolution (matching/deduplication) threw for one candidate.</summary>
+    public const string EntityResolutionFailed       = "MEMORY_ENTITY_RESOLUTION_FAILED";
+
+    /// <summary>A relationship's source or target entity was never resolved during extraction.</summary>
+    public const string RelationshipEndpointUnresolved = "MEMORY_RELATIONSHIP_ENDPOINT_UNRESOLVED";
+
+    /// <summary>Generating an embedding for an item to persist failed.</summary>
+    public const string EmbeddingGenerationFailed    = "MEMORY_EMBEDDING_GENERATION_FAILED";
+
+    /// <summary>Persisting an entity node failed.</summary>
+    public const string EntityPersistenceFailed       = "MEMORY_ENTITY_PERSISTENCE_FAILED";
+
+    /// <summary>Persisting a fact node failed.</summary>
+    public const string FactPersistenceFailed         = "MEMORY_FACT_PERSISTENCE_FAILED";
+
+    /// <summary>Persisting a preference node failed.</summary>
+    public const string PreferencePersistenceFailed   = "MEMORY_PREFERENCE_PERSISTENCE_FAILED";
+
+    /// <summary>Persisting a relationship edge failed.</summary>
+    public const string RelationshipPersistenceFailed = "MEMORY_RELATIONSHIP_PERSISTENCE_FAILED";
+
+    /// <summary>A relationship's source or target entity was never persisted.</summary>
+    public const string RelationshipEndpointNotPersisted = "MEMORY_RELATIONSHIP_ENDPOINT_NOT_PERSISTED";
+
+    /// <summary>Creating an <c>EXTRACTED_FROM</c> provenance edge failed for an otherwise-persisted item.</summary>
+    public const string ProvenancePersistenceFailed   = "MEMORY_PROVENANCE_PERSISTENCE_FAILED";
 }

--- a/src/AgentMemory.Abstractions/Exceptions/MemoryIngestionException.cs
+++ b/src/AgentMemory.Abstractions/Exceptions/MemoryIngestionException.cs
@@ -1,0 +1,40 @@
+using AgentMemory.Abstractions.Domain;
+
+namespace AgentMemory.Abstractions.Exceptions;
+
+/// <summary>
+/// Thrown by the extraction/persistence pipeline when <c>IngestionFailureMode.FailFast</c> is
+/// configured and an item fails (#101). Carries every <see cref="IngestionItemOutcome"/> completed
+/// before the failure, so a caller can inspect exactly how far ingestion got.
+/// </summary>
+public sealed class MemoryIngestionException : MemoryException
+{
+    /// <summary>Every item outcome recorded before the failure that triggered this exception.</summary>
+    public IReadOnlyList<IngestionItemOutcome> CompletedOutcomes { get; }
+
+    /// <summary>
+    /// Initializes a new instance carrying the outcomes completed before the failure. Use this overload
+    /// when fail-fast was triggered by a <see cref="IngestionItemStatus.Skipped"/> outcome (e.g. an
+    /// unresolved relationship endpoint) rather than a thrown exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="completedOutcomes">Every item outcome recorded before the failure.</param>
+    public MemoryIngestionException(string message, IReadOnlyList<IngestionItemOutcome> completedOutcomes)
+        : base(message)
+    {
+        CompletedOutcomes = completedOutcomes;
+    }
+
+    /// <summary>Initializes a new instance carrying the outcomes completed before the failure.</summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="completedOutcomes">Every item outcome recorded before the failure.</param>
+    /// <param name="innerException">The exception that triggered fail-fast.</param>
+    public MemoryIngestionException(
+        string message,
+        IReadOnlyList<IngestionItemOutcome> completedOutcomes,
+        Exception innerException)
+        : base(message, innerException)
+    {
+        CompletedOutcomes = completedOutcomes;
+    }
+}

--- a/src/AgentMemory.Abstractions/Options/ExtractionOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/ExtractionOptions.cs
@@ -23,6 +23,11 @@ public sealed class ExtractionOptions
     public double StrongPatternConfidence { get; set; } = 0.95;
     /// <summary>Confidence assigned to standard regex matches in PatternBasedPreferenceDetector.</summary>
     public double RegexMatchConfidence { get; set; } = 0.85;
+    /// <summary>
+    /// How the pipeline reacts to a per-item ingestion failure (#101). Defaults to
+    /// <see cref="IngestionFailureMode.BestEffort"/> -- today's behavior, unchanged.
+    /// </summary>
+    public IngestionFailureMode FailureMode { get; set; } = IngestionFailureMode.BestEffort;
 }
 
 /// <summary>Controls which matching strategies are used for entity resolution.</summary>

--- a/src/AgentMemory.Abstractions/Options/IngestionFailureMode.cs
+++ b/src/AgentMemory.Abstractions/Options/IngestionFailureMode.cs
@@ -1,0 +1,20 @@
+namespace AgentMemory.Abstractions.Options;
+
+/// <summary>
+/// Controls how the extraction/persistence pipeline reacts to a per-item ingestion failure (#101).
+/// </summary>
+public enum IngestionFailureMode
+{
+    /// <summary>
+    /// Continue processing independent items after a failure, collecting structured outcomes for
+    /// each. The default -- appropriate for best-effort conversational memory, where one malformed
+    /// item should not discard several otherwise-valid ones.
+    /// </summary>
+    BestEffort,
+
+    /// <summary>
+    /// Stop at the first non-recoverable ingestion failure and throw <c>MemoryIngestionException</c>,
+    /// carrying every <c>IngestionItemOutcome</c> completed before the failure.
+    /// </summary>
+    FailFast
+}

--- a/src/AgentMemory.Abstractions/Services/IMemoryExtractionPipeline.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryExtractionPipeline.cs
@@ -8,7 +8,12 @@ namespace AgentMemory.Abstractions.Services;
 public interface IMemoryExtractionPipeline
 {
     /// <summary>
-    /// Extracts structured memory from messages.
+    /// Extracts structured memory from messages. The returned <see cref="ExtractionResult"/> carries
+    /// structured per-item outcomes and an overall <see cref="IngestionStatus"/> (#101). Under the default
+    /// <c>ExtractionOptions.FailureMode</c> (<c>IngestionFailureMode.BestEffort</c>) this never throws for
+    /// a per-item failure; under <c>IngestionFailureMode.FailFast</c> it throws
+    /// <see cref="AgentMemory.Abstractions.Exceptions.MemoryIngestionException"/> at the first one,
+    /// carrying every outcome completed before the failure.
     /// </summary>
     Task<ExtractionResult> ExtractAsync(
         ExtractionRequest request,

--- a/src/AgentMemory.Abstractions/Services/IMemoryIngestion.cs
+++ b/src/AgentMemory.Abstractions/Services/IMemoryIngestion.cs
@@ -49,7 +49,12 @@ public interface IMemoryIngestion
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Extracts and persists long-term memory from messages.
+    /// Extracts and persists long-term memory from messages. The returned <see cref="ExtractionResult"/>
+    /// carries structured per-item outcomes and an overall <see cref="IngestionStatus"/> (#101). Under the
+    /// default <c>ExtractionOptions.FailureMode</c> (<c>IngestionFailureMode.BestEffort</c>) this never
+    /// throws for a per-item failure; under <c>IngestionFailureMode.FailFast</c> it throws
+    /// <see cref="AgentMemory.Abstractions.Exceptions.MemoryIngestionException"/> at the first one,
+    /// carrying every outcome completed before the failure.
     /// </summary>
     Task<ExtractionResult> ExtractAndPersistAsync(
         ExtractionRequest request,
@@ -59,7 +64,10 @@ public interface IMemoryIngestion
     /// Retroactively runs the extraction pipeline on all messages in a session and persists the
     /// resulting entities, facts, preferences, and relationships. When <paramref name="userId"/> is
     /// supplied (R1) the extracted nodes are owner-stamped and resolution is owner-scoped; null ⇒ the
-    /// nodes are stored as shared/global (the prior single-tenant behavior).
+    /// nodes are stored as shared/global (the prior single-tenant behavior). Under
+    /// <c>IngestionFailureMode.FailFast</c> (#101) can throw
+    /// <see cref="AgentMemory.Abstractions.Exceptions.MemoryIngestionException"/>; this method's <c>void</c>
+    /// return means the per-item outcomes are only observable via that exception, not on success.
     /// </summary>
     Task ExtractFromSessionAsync(
         string sessionId,
@@ -69,7 +77,10 @@ public interface IMemoryIngestion
     /// <summary>
     /// Retroactively runs the extraction pipeline on all messages in a conversation and persists the
     /// results. When <paramref name="userId"/> is supplied (R1) the extracted nodes are owner-stamped
-    /// and resolution is owner-scoped; null ⇒ stored as shared/global.
+    /// and resolution is owner-scoped; null ⇒ stored as shared/global. Under
+    /// <c>IngestionFailureMode.FailFast</c> (#101) can throw
+    /// <see cref="AgentMemory.Abstractions.Exceptions.MemoryIngestionException"/>; this method's <c>void</c>
+    /// return means the per-item outcomes are only observable via that exception, not on success.
     /// </summary>
     Task ExtractFromConversationAsync(
         string conversationId,

--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Core.Extraction.MergeStrategies;
@@ -49,6 +50,7 @@ internal sealed class ExtractionStage : IExtractionStage
     {
         var sourceMessageIds = messages.Select(m => m.MessageId).ToList();
         var strategy = _options.MergeStrategy;
+        var failFast = _options.FailureMode == IngestionFailureMode.FailFast;
 
         _logger.LogDebug(
             "ExtractionStage starting. Extractors: {E} entity, {F} fact, {P} preference, {R} relationship. Strategy: {Strategy}.",
@@ -56,37 +58,60 @@ internal sealed class ExtractionStage : IExtractionStage
             _preferenceExtractors.Count, _relationshipExtractors.Count, strategy);
 
         // 1. Run all enabled extractor types in parallel.
-        var entityTask = typesToExtract.HasFlag(ExtractionTypes.Entities)
+        var entityRun = typesToExtract.HasFlag(ExtractionTypes.Entities)
             ? RunExtractorsAsync(_entityExtractors, e => e.ExtractAsync(messages, cancellationToken),
-                strategy, MergeStrategyFactory.CreateEntityStrategy, "entity", cancellationToken)
-            : Task.FromResult<IReadOnlyList<ExtractedEntity>>(Array.Empty<ExtractedEntity>());
+                strategy, MergeStrategyFactory.CreateEntityStrategy, "entity",
+                MemoryItemKind.Entity, MemoryErrorCodes.EntityExtractionFailed, cancellationToken)
+            : EmptyRun<ExtractedEntity>();
 
-        var factTask = typesToExtract.HasFlag(ExtractionTypes.Facts)
+        var factRun = typesToExtract.HasFlag(ExtractionTypes.Facts)
             ? RunExtractorsAsync(_factExtractors, f => f.ExtractAsync(messages, cancellationToken),
-                strategy, MergeStrategyFactory.CreateFactStrategy, "fact", cancellationToken)
-            : Task.FromResult<IReadOnlyList<ExtractedFact>>(Array.Empty<ExtractedFact>());
+                strategy, MergeStrategyFactory.CreateFactStrategy, "fact",
+                MemoryItemKind.Fact, MemoryErrorCodes.FactExtractionFailed, cancellationToken)
+            : EmptyRun<ExtractedFact>();
 
-        var prefTask = typesToExtract.HasFlag(ExtractionTypes.Preferences)
+        var prefRun = typesToExtract.HasFlag(ExtractionTypes.Preferences)
             ? RunExtractorsAsync(_preferenceExtractors, p => p.ExtractAsync(messages, cancellationToken),
-                strategy, MergeStrategyFactory.CreatePreferenceStrategy, "preference", cancellationToken)
-            : Task.FromResult<IReadOnlyList<ExtractedPreference>>(Array.Empty<ExtractedPreference>());
+                strategy, MergeStrategyFactory.CreatePreferenceStrategy, "preference",
+                MemoryItemKind.Preference, MemoryErrorCodes.PreferenceExtractionFailed, cancellationToken)
+            : EmptyRun<ExtractedPreference>();
 
-        var relTask = typesToExtract.HasFlag(ExtractionTypes.Relationships)
+        var relRun = typesToExtract.HasFlag(ExtractionTypes.Relationships)
             ? RunExtractorsAsync(_relationshipExtractors, r => r.ExtractAsync(messages, cancellationToken),
-                strategy, MergeStrategyFactory.CreateRelationshipStrategy, "relationship", cancellationToken)
-            : Task.FromResult<IReadOnlyList<ExtractedRelationship>>(Array.Empty<ExtractedRelationship>());
+                strategy, MergeStrategyFactory.CreateRelationshipStrategy, "relationship",
+                MemoryItemKind.Relationship, MemoryErrorCodes.RelationshipExtractionFailed, cancellationToken)
+            : EmptyRun<ExtractedRelationship>();
 
-        await Task.WhenAll(entityTask, factTask, prefTask, relTask).ConfigureAwait(false);
+        await Task.WhenAll(entityRun, factRun, prefRun, relRun).ConfigureAwait(false);
 
-        var rawEntities = await entityTask.ConfigureAwait(false);
-        var rawFacts = await factTask.ConfigureAwait(false);
-        var rawPreferences = await prefTask.ConfigureAwait(false);
-        var rawRelationships = await relTask.ConfigureAwait(false);
+        var (rawEntities, entityOutcomes) = await entityRun.ConfigureAwait(false);
+        var (rawFacts, factOutcomes) = await factRun.ConfigureAwait(false);
+        var (rawPreferences, prefOutcomes) = await prefRun.ConfigureAwait(false);
+        var (rawRelationships, relOutcomes) = await relRun.ConfigureAwait(false);
+
+        var outcomes = new List<IngestionItemOutcome>();
+        outcomes.AddRange(entityOutcomes);
+        outcomes.AddRange(factOutcomes);
+        outcomes.AddRange(prefOutcomes);
+        outcomes.AddRange(relOutcomes);
+
+        // FailFast (#101): the four extractor categories above already ran concurrently to completion --
+        // in-flight extractor tasks can't be pre-empted -- so "stop at the first failure" is honored at
+        // the first point after that where sequential, stoppable work begins: here, and again inside the
+        // per-entity resolution loop below.
+        if (failFast && outcomes.Any(o => o.Status == IngestionItemStatus.Failed))
+        {
+            throw new MemoryIngestionException(
+                "Ingestion failed fast: one or more extractors threw.", outcomes);
+        }
 
         // 2. Filter + validate + resolve entities; build name→Entity map for relationship resolution.
         var resolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase);
         foreach (var extracted in rawEntities)
         {
+            // Confidence-threshold filtering is routine, expected pipeline behavior, not a failure or a
+            // meaningful skip -- deliberately NOT recorded as an outcome (#101 acceptance: "important
+            // skips", not every filtered candidate).
             if (extracted.Confidence < _options.MinConfidenceThreshold)
             {
                 _logger.LogDebug(
@@ -98,6 +123,15 @@ internal sealed class ExtractionStage : IExtractionStage
             if (!EntityValidator.IsValid(extracted, _options.Validation))
             {
                 _logger.LogWarning("Skipping entity '{Name}' — failed validation.", extracted.Name);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Entity,
+                    Stage = IngestionStage.Validation,
+                    Status = IngestionItemStatus.Skipped,
+                    SourceKey = extracted.Name,
+                    ErrorCode = MemoryErrorCodes.EntityValidationFailed,
+                    ErrorMessage = "Entity candidate failed validation rules.",
+                });
                 continue;
             }
 
@@ -115,6 +149,22 @@ internal sealed class ExtractionStage : IExtractionStage
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error resolving entity '{Name}'.", extracted.Name);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Entity,
+                    Stage = IngestionStage.Resolution,
+                    Status = IngestionItemStatus.Failed,
+                    SourceKey = extracted.Name,
+                    ErrorCode = MemoryErrorCodes.EntityResolutionFailed,
+                    ErrorMessage = ex.Message,
+                    Retryable = true,
+                });
+
+                if (failFast)
+                {
+                    throw new MemoryIngestionException(
+                        $"Ingestion failed fast: entity resolution failed for '{extracted.Name}'.", outcomes, ex);
+                }
             }
         }
 
@@ -159,6 +209,15 @@ internal sealed class ExtractionStage : IExtractionStage
                 _logger.LogWarning(
                     "Skipping relationship — source entity '{Source}' not resolved.",
                     extracted.SourceEntity);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Relationship,
+                    Stage = IngestionStage.Resolution,
+                    Status = IngestionItemStatus.Skipped,
+                    SourceKey = $"{extracted.SourceEntity}->{extracted.TargetEntity}",
+                    ErrorCode = MemoryErrorCodes.RelationshipEndpointUnresolved,
+                    ErrorMessage = $"Source entity '{extracted.SourceEntity}' was not resolved.",
+                });
                 continue;
             }
 
@@ -167,6 +226,15 @@ internal sealed class ExtractionStage : IExtractionStage
                 _logger.LogWarning(
                     "Skipping relationship — target entity '{Target}' not resolved.",
                     extracted.TargetEntity);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Relationship,
+                    Stage = IngestionStage.Resolution,
+                    Status = IngestionItemStatus.Skipped,
+                    SourceKey = $"{extracted.SourceEntity}->{extracted.TargetEntity}",
+                    ErrorCode = MemoryErrorCodes.RelationshipEndpointUnresolved,
+                    ErrorMessage = $"Target entity '{extracted.TargetEntity}' was not resolved.",
+                });
                 continue;
             }
 
@@ -192,34 +260,47 @@ internal sealed class ExtractionStage : IExtractionStage
             EntityExtractorCount = _entityExtractors.Count,
             FactExtractorCount = _factExtractors.Count,
             PreferenceExtractorCount = _preferenceExtractors.Count,
-            RelationshipExtractorCount = _relationshipExtractors.Count
+            RelationshipExtractorCount = _relationshipExtractors.Count,
+            Outcomes = outcomes
         };
     }
 
     // ── Multi-extractor runner (ported from MultiExtractorPipeline) ──
 
-    private async Task<IReadOnlyList<T>> RunExtractorsAsync<TExtractor, T>(
+    private static Task<(IReadOnlyList<T> Items, IReadOnlyList<IngestionItemOutcome> Outcomes)> EmptyRun<T>() where T : class =>
+        Task.FromResult<(IReadOnlyList<T>, IReadOnlyList<IngestionItemOutcome>)>(
+            (Array.Empty<T>(), Array.Empty<IngestionItemOutcome>()));
+
+    private async Task<(IReadOnlyList<T> Items, IReadOnlyList<IngestionItemOutcome> Outcomes)> RunExtractorsAsync<TExtractor, T>(
         IReadOnlyList<TExtractor> extractors,
         Func<TExtractor, Task<IReadOnlyList<T>>> extractFn,
         MergeStrategyType strategyType,
         Func<MergeStrategyType, IMergeStrategy<T>> strategyFactory,
         string extractorTypeName,
+        MemoryItemKind kind,
+        string failureErrorCode,
         CancellationToken cancellationToken) where T : class
     {
         if (extractors.Count == 0)
-            return Array.Empty<T>();
+            return (Array.Empty<T>(), Array.Empty<IngestionItemOutcome>());
 
         if (extractors.Count == 1)
-            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName, cancellationToken).ConfigureAwait(false);
+            return await ExtractSafeAsync(() => extractFn(extractors[0]), extractorTypeName, kind, failureErrorCode, cancellationToken)
+                .ConfigureAwait(false);
 
         var tasks = extractors
-            .Select(e => ExtractSafeAsync(() => extractFn(e), extractorTypeName, cancellationToken))
+            .Select(e => ExtractSafeAsync(() => extractFn(e), extractorTypeName, kind, failureErrorCode, cancellationToken))
             .ToList();
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         var allResults = new List<IReadOnlyList<T>>(tasks.Count);
+        var allOutcomes = new List<IngestionItemOutcome>();
         foreach (var task in tasks)
-            allResults.Add(await task.ConfigureAwait(false));
+        {
+            var (items, outcomes) = await task.ConfigureAwait(false);
+            allResults.Add(items);
+            allOutcomes.AddRange(outcomes);
+        }
 
         var mergeStrategy = strategyFactory(strategyType);
         var merged = mergeStrategy.Merge(allResults);
@@ -228,17 +309,20 @@ internal sealed class ExtractionStage : IExtractionStage
             "Merged {Count} {Type} extractor results ({Strategy}): {Result} items.",
             allResults.Count, extractorTypeName, strategyType, merged.Count);
 
-        return merged;
+        return (merged, allOutcomes);
     }
 
-    private async Task<IReadOnlyList<T>> ExtractSafeAsync<T>(
+    private async Task<(IReadOnlyList<T> Items, IReadOnlyList<IngestionItemOutcome> Outcomes)> ExtractSafeAsync<T>(
         Func<Task<IReadOnlyList<T>>> extractor,
         string extractorTypeName,
+        MemoryItemKind kind,
+        string failureErrorCode,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await extractor().ConfigureAwait(false);
+            var items = await extractor().ConfigureAwait(false);
+            return (items, Array.Empty<IngestionItemOutcome>());
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -249,7 +333,17 @@ internal sealed class ExtractionStage : IExtractionStage
             _logger.LogError(ex,
                 "Extractor for {ExtractorType} threw — continuing with empty list.",
                 extractorTypeName);
-            return Array.Empty<T>();
+            var outcome = new IngestionItemOutcome
+            {
+                Kind = kind,
+                Stage = IngestionStage.Extraction,
+                Status = IngestionItemStatus.Failed,
+                SourceKey = extractorTypeName,
+                ErrorCode = failureErrorCode,
+                ErrorMessage = ex.Message,
+                Retryable = true,
+            };
+            return (Array.Empty<T>(), new[] { outcome });
         }
     }
 }

--- a/src/AgentMemory.Core/Extraction/ExtractionStageResult.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStageResult.cs
@@ -46,4 +46,11 @@ internal sealed record ExtractionStageResult
     public int FactExtractorCount { get; init; }
     public int PreferenceExtractorCount { get; init; }
     public int RelationshipExtractorCount { get; init; }
+
+    /// <summary>
+    /// Item outcomes recorded during this stage (extractor failures, validation/resolution
+    /// failures and skips) -- see <see cref="IngestionItemOutcome"/> (#101). Carried forward and
+    /// appended to by <see cref="IPersistenceStage"/>.
+    /// </summary>
+    public IReadOnlyList<IngestionItemOutcome> Outcomes { get; init; } = Array.Empty<IngestionItemOutcome>();
 }

--- a/src/AgentMemory.Core/Extraction/IPersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/IPersistenceStage.cs
@@ -1,3 +1,5 @@
+using AgentMemory.Abstractions.Domain;
+
 namespace AgentMemory.Core.Extraction;
 
 /// <summary>
@@ -8,7 +10,9 @@ internal interface IPersistenceStage
     /// <summary>
     /// Embeds entities, facts, and preferences, upserts them to their repositories,
     /// and wires EXTRACTED_FROM provenance relationships. The optional <c>ownerId</c> is stamped on
-    /// every persisted entity/fact/preference (null = shared/global; see MemoryScope, R1).
+    /// every persisted entity/fact/preference (null = shared/global; see MemoryScope, R1). Honors the
+    /// configured <c>ExtractionOptions.FailureMode</c> (#101): under <c>FailFast</c>, throws
+    /// <c>MemoryIngestionException</c> at the first item that fails at this stage.
     /// </summary>
     Task<PersistenceResult> PersistAsync(
         ExtractionStageResult extraction,
@@ -25,4 +29,10 @@ internal sealed record PersistenceResult
     public int FactCount { get; init; }
     public int PreferenceCount { get; init; }
     public int RelationshipCount { get; init; }
+
+    /// <summary>
+    /// The complete outcome list: every outcome carried in from the extraction stage, plus every
+    /// outcome (success, skip, or failure) recorded during this stage (#101).
+    /// </summary>
+    public IReadOnlyList<IngestionItemOutcome> Outcomes { get; init; } = Array.Empty<IngestionItemOutcome>();
 }

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 
@@ -18,6 +21,7 @@ internal sealed class PersistenceStage : IPersistenceStage
     private readonly IRelationshipRepository _relationshipRepository;
     private readonly IClock _clock;
     private readonly IIdGenerator _idGenerator;
+    private readonly ExtractionOptions _options;
     private readonly ILogger<PersistenceStage> _logger;
 
     public PersistenceStage(
@@ -28,7 +32,8 @@ internal sealed class PersistenceStage : IPersistenceStage
         IRelationshipRepository relationshipRepository,
         IClock clock,
         IIdGenerator idGenerator,
-        ILogger<PersistenceStage> logger)
+        ILogger<PersistenceStage> logger,
+        IOptions<ExtractionOptions>? extractionOptions = null)
     {
         _embeddingOrchestrator = embeddingOrchestrator;
         _entityRepository = entityRepository;
@@ -38,6 +43,7 @@ internal sealed class PersistenceStage : IPersistenceStage
         _clock = clock;
         _idGenerator = idGenerator;
         _logger = logger;
+        _options = extractionOptions?.Value ?? new ExtractionOptions();
     }
 
     public async Task<PersistenceResult> PersistAsync(
@@ -46,23 +52,39 @@ internal sealed class PersistenceStage : IPersistenceStage
         CancellationToken cancellationToken = default)
     {
         var sourceMessageIds = extraction.SourceMessageIds;
+        var failFast = _options.FailureMode == IngestionFailureMode.FailFast;
+        var outcomes = new List<IngestionItemOutcome>(extraction.Outcomes);
 
         // 1. Embed + upsert entities; build a name→persisted Entity map for relationship resolution.
         var persistedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase);
         foreach (var (name, entity) in extraction.ResolvedEntityMap)
         {
-            try
+            var entityToSave = entity with { OwnerId = ownerId };
+
+            if (entityToSave.Embedding is null)
             {
-                var entityToSave = entity with { OwnerId = ownerId };
-                if (entityToSave.Embedding is null)
+                try
                 {
                     var embedding = await _embeddingOrchestrator.EmbedEntityAsync(
                         entityToSave.Name, cancellationToken).ConfigureAwait(false);
                     entityToSave = entityToSave with { Embedding = embedding };
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error generating embedding for entity '{Name}'.", name);
+                    RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Entity, IngestionStage.Embedding,
+                        MemoryErrorCodes.EmbeddingGenerationFailed, name, null, ex,
+                        $"Ingestion failed fast: embedding generation failed for entity '{name}'.");
+                    continue; // no embedding — nothing to persist for this entity
+                }
+            }
 
+            try
+            {
                 entityToSave = await _entityRepository.UpsertAsync(entityToSave, cancellationToken).ConfigureAwait(false);
                 persistedEntityMap[name] = entityToSave;
+                RecordSuccess(outcomes, MemoryItemKind.Entity, name, entityToSave.EntityId);
 
                 foreach (var msgId in sourceMessageIds)
                 {
@@ -77,15 +99,22 @@ internal sealed class PersistenceStage : IPersistenceStage
                         _logger.LogWarning(ex,
                             "Failed to create EXTRACTED_FROM for entity '{Id}' → message '{MsgId}'.",
                             entityToSave.EntityId, msgId);
+                        RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Entity, IngestionStage.Provenance,
+                            MemoryErrorCodes.ProvenancePersistenceFailed, name, entityToSave.EntityId, ex,
+                            $"Ingestion failed fast: provenance failed for entity '{name}'.");
                     }
                 }
 
                 _logger.LogDebug("Persisted entity '{Name}' (id={Id}).", entityToSave.Name, entityToSave.EntityId);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (MemoryIngestionException) { throw; } // already recorded + wrapped above — propagate as-is
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error persisting entity '{Name}'.", name);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Entity, IngestionStage.Persistence,
+                    MemoryErrorCodes.EntityPersistenceFailed, name, null, ex,
+                    $"Ingestion failed fast: persistence failed for entity '{name}'.");
             }
         }
 
@@ -93,11 +122,26 @@ internal sealed class PersistenceStage : IPersistenceStage
         var persistedFactCount = 0;
         foreach (var extracted in extraction.FilteredFacts)
         {
+            var factSourceKey = $"{extracted.Subject} {extracted.Predicate} {extracted.Object}";
+
+            float[] factEmbedding;
             try
             {
-                var factEmbedding = await _embeddingOrchestrator.EmbedFactAsync(
+                factEmbedding = await _embeddingOrchestrator.EmbedFactAsync(
                     extracted.Subject, extracted.Predicate, extracted.Object, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating embedding for fact '{Key}'.", factSourceKey);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Fact, IngestionStage.Embedding,
+                    MemoryErrorCodes.EmbeddingGenerationFailed, factSourceKey, null, ex,
+                    $"Ingestion failed fast: embedding generation failed for fact '{factSourceKey}'.");
+                continue;
+            }
 
+            try
+            {
                 var fact = new Fact
                 {
                     FactId = _idGenerator.GenerateId(),
@@ -114,6 +158,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                 };
 
                 await _factRepository.UpsertAsync(fact, cancellationToken).ConfigureAwait(false);
+                RecordSuccess(outcomes, MemoryItemKind.Fact, factSourceKey, fact.FactId);
 
                 foreach (var msgId in sourceMessageIds)
                 {
@@ -128,6 +173,9 @@ internal sealed class PersistenceStage : IPersistenceStage
                         _logger.LogWarning(ex,
                             "Failed to create EXTRACTED_FROM for fact '{Id}' → message '{MsgId}'.",
                             fact.FactId, msgId);
+                        RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Fact, IngestionStage.Provenance,
+                            MemoryErrorCodes.ProvenancePersistenceFailed, factSourceKey, fact.FactId, ex,
+                            $"Ingestion failed fast: provenance failed for fact '{factSourceKey}'.");
                     }
                 }
 
@@ -135,11 +183,13 @@ internal sealed class PersistenceStage : IPersistenceStage
                 _logger.LogDebug("Persisted fact '{S} {P} {O}'.", fact.Subject, fact.Predicate, fact.Object);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (MemoryIngestionException) { throw; }
             catch (Exception ex)
             {
-                _logger.LogError(ex,
-                    "Error persisting fact '{S} {P} {O}'.",
-                    extracted.Subject, extracted.Predicate, extracted.Object);
+                _logger.LogError(ex, "Error persisting fact '{Key}'.", factSourceKey);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Fact, IngestionStage.Persistence,
+                    MemoryErrorCodes.FactPersistenceFailed, factSourceKey, null, ex,
+                    $"Ingestion failed fast: persistence failed for fact '{factSourceKey}'.");
             }
         }
 
@@ -147,11 +197,24 @@ internal sealed class PersistenceStage : IPersistenceStage
         var persistedPrefCount = 0;
         foreach (var extracted in extraction.FilteredPreferences)
         {
+            float[] prefEmbedding;
             try
             {
-                var prefEmbedding = await _embeddingOrchestrator.EmbedPreferenceAsync(
+                prefEmbedding = await _embeddingOrchestrator.EmbedPreferenceAsync(
                     extracted.PreferenceText, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating embedding for preference '{Text}'.", extracted.PreferenceText);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Preference, IngestionStage.Embedding,
+                    MemoryErrorCodes.EmbeddingGenerationFailed, extracted.PreferenceText, null, ex,
+                    "Ingestion failed fast: embedding generation failed for a preference.");
+                continue;
+            }
 
+            try
+            {
                 var preference = new Preference
                 {
                     PreferenceId = _idGenerator.GenerateId(),
@@ -166,6 +229,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                 };
 
                 await _preferenceRepository.UpsertAsync(preference, cancellationToken).ConfigureAwait(false);
+                RecordSuccess(outcomes, MemoryItemKind.Preference, extracted.PreferenceText, preference.PreferenceId);
 
                 foreach (var msgId in sourceMessageIds)
                 {
@@ -180,6 +244,9 @@ internal sealed class PersistenceStage : IPersistenceStage
                         _logger.LogWarning(ex,
                             "Failed to create EXTRACTED_FROM for preference '{Id}' → message '{MsgId}'.",
                             preference.PreferenceId, msgId);
+                        RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Preference, IngestionStage.Provenance,
+                            MemoryErrorCodes.ProvenancePersistenceFailed, extracted.PreferenceText, preference.PreferenceId, ex,
+                            "Ingestion failed fast: provenance failed for a preference.");
                     }
                 }
 
@@ -187,9 +254,13 @@ internal sealed class PersistenceStage : IPersistenceStage
                 _logger.LogDebug("Persisted preference in category '{Category}'.", preference.Category);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (MemoryIngestionException) { throw; }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error persisting preference '{Text}'.", extracted.PreferenceText);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Preference, IngestionStage.Persistence,
+                    MemoryErrorCodes.PreferencePersistenceFailed, extracted.PreferenceText, null, ex,
+                    "Ingestion failed fast: persistence failed for a preference.");
             }
         }
 
@@ -197,11 +268,22 @@ internal sealed class PersistenceStage : IPersistenceStage
         var persistedRelCount = 0;
         foreach (var extracted in extraction.FilteredRelationships)
         {
+            var relSourceKey = $"{extracted.SourceEntity}-{extracted.RelationshipType}->{extracted.TargetEntity}";
+
             if (!persistedEntityMap.TryGetValue(extracted.SourceEntity, out var sourceEntity))
             {
                 _logger.LogWarning(
                     "Skipping relationship — source entity '{Source}' was not persisted.",
                     extracted.SourceEntity);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Relationship,
+                    Stage = IngestionStage.RelationshipPersistence,
+                    Status = IngestionItemStatus.Skipped,
+                    SourceKey = relSourceKey,
+                    ErrorCode = MemoryErrorCodes.RelationshipEndpointNotPersisted,
+                    ErrorMessage = $"Source entity '{extracted.SourceEntity}' was not persisted.",
+                });
                 continue;
             }
 
@@ -210,6 +292,15 @@ internal sealed class PersistenceStage : IPersistenceStage
                 _logger.LogWarning(
                     "Skipping relationship — target entity '{Target}' was not persisted.",
                     extracted.TargetEntity);
+                outcomes.Add(new IngestionItemOutcome
+                {
+                    Kind = MemoryItemKind.Relationship,
+                    Stage = IngestionStage.RelationshipPersistence,
+                    Status = IngestionItemStatus.Skipped,
+                    SourceKey = relSourceKey,
+                    ErrorCode = MemoryErrorCodes.RelationshipEndpointNotPersisted,
+                    ErrorMessage = $"Target entity '{extracted.TargetEntity}' was not persisted.",
+                });
                 continue;
             }
 
@@ -231,17 +322,22 @@ internal sealed class PersistenceStage : IPersistenceStage
 
                 await _relationshipRepository.UpsertAsync(relationship, cancellationToken).ConfigureAwait(false);
                 persistedRelCount++;
+                RecordSuccess(outcomes, MemoryItemKind.Relationship, relSourceKey, relationship.RelationshipId);
 
                 _logger.LogDebug(
                     "Persisted relationship '{Src}-{Type}->{Tgt}'.",
                     extracted.SourceEntity, extracted.RelationshipType, extracted.TargetEntity);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+            catch (MemoryIngestionException) { throw; } // consistent with the other item kinds (#101 review)
             catch (Exception ex)
             {
                 _logger.LogError(ex,
                     "Error persisting relationship '{Src}->{Tgt}'.",
                     extracted.SourceEntity, extracted.TargetEntity);
+                RecordFailureAndMaybeThrow(outcomes, failFast, MemoryItemKind.Relationship, IngestionStage.Persistence,
+                    MemoryErrorCodes.RelationshipPersistenceFailed, relSourceKey, null, ex,
+                    $"Ingestion failed fast: persistence failed for relationship '{relSourceKey}'.");
             }
         }
 
@@ -250,7 +346,55 @@ internal sealed class PersistenceStage : IPersistenceStage
             EntityCount = persistedEntityMap.Count,
             FactCount = persistedFactCount,
             PreferenceCount = persistedPrefCount,
-            RelationshipCount = persistedRelCount
+            RelationshipCount = persistedRelCount,
+            Outcomes = outcomes
         };
+    }
+
+    /// <summary>Appends a <see cref="IngestionItemStatus.Succeeded"/> outcome (#101).</summary>
+    private static void RecordSuccess(
+        List<IngestionItemOutcome> outcomes, MemoryItemKind kind, string? sourceKey, string? persistedId) =>
+        outcomes.Add(new IngestionItemOutcome
+        {
+            Kind = kind,
+            Stage = IngestionStage.Persistence,
+            Status = IngestionItemStatus.Succeeded,
+            SourceKey = sourceKey,
+            PersistedId = persistedId,
+        });
+
+    /// <summary>
+    /// Appends a <see cref="IngestionItemStatus.Failed"/> outcome and, under
+    /// <see cref="IngestionFailureMode.FailFast"/>, throws <see cref="MemoryIngestionException"/>
+    /// carrying every outcome recorded so far (#101). Centralizing this in one helper — rather than
+    /// repeating "add outcome, then maybe throw" at each of the ~10 call sites across four item kinds —
+    /// is what guarantees every one of them gets the same fail-fast behavior; hand-copying it previously
+    /// let the relationship block silently miss the failure-mode check entirely (caught in review).
+    /// </summary>
+    private static void RecordFailureAndMaybeThrow(
+        List<IngestionItemOutcome> outcomes,
+        bool failFast,
+        MemoryItemKind kind,
+        IngestionStage stage,
+        string errorCode,
+        string? sourceKey,
+        string? persistedId,
+        Exception ex,
+        string failFastMessage)
+    {
+        outcomes.Add(new IngestionItemOutcome
+        {
+            Kind = kind,
+            Stage = stage,
+            Status = IngestionItemStatus.Failed,
+            SourceKey = sourceKey,
+            PersistedId = persistedId,
+            ErrorCode = errorCode,
+            ErrorMessage = ex.Message,
+            Retryable = true,
+        });
+
+        if (failFast)
+            throw new MemoryIngestionException(failFastMessage, outcomes, ex);
     }
 }

--- a/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
+++ b/src/AgentMemory.Core/Services/MemoryExtractionPipeline.cs
@@ -74,6 +74,8 @@ internal sealed class MemoryExtractionPipeline : IMemoryExtractionPipeline
             Preferences = staged.RawPreferences,
             Relationships = staged.RawRelationships,
             SourceMessageIds = staged.SourceMessageIds,
+            Status = ComputeStatus(persisted.Outcomes),
+            Outcomes = persisted.Outcomes,
             Metadata = new Dictionary<string, object>
             {
                 ["sessionId"] = request.SessionId,
@@ -84,5 +86,24 @@ internal sealed class MemoryExtractionPipeline : IMemoryExtractionPipeline
                 ["relationshipCount"] = persisted.RelationshipCount
             }
         };
+    }
+
+    /// <summary>
+    /// Derives the overall <see cref="IngestionStatus"/> (#101) from item outcomes: any failure makes
+    /// it at best partial; a total loss (failures present, nothing succeeded) is Failed; no failures at
+    /// all — including the trivial case of nothing to ingest — is Succeeded.
+    /// </summary>
+    private static IngestionStatus ComputeStatus(IReadOnlyList<IngestionItemOutcome> outcomes)
+    {
+        var failed = 0;
+        var succeeded = 0;
+        foreach (var outcome in outcomes)
+        {
+            if (outcome.Status == IngestionItemStatus.Failed) failed++;
+            else if (outcome.Status == IngestionItemStatus.Succeeded) succeeded++;
+        }
+
+        if (failed == 0) return IngestionStatus.Succeeded;
+        return succeeded > 0 ? IngestionStatus.PartiallySucceeded : IngestionStatus.Failed;
     }
 }

--- a/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
+++ b/src/AgentMemory.McpServer/Tools/AdvancedMemoryTools.cs
@@ -206,13 +206,20 @@ internal sealed class AdvancedMemoryTools
         {
             sessionId = sid,
             sourceMessageId = message.MessageId,
+            // #101: surface structured ingestion outcomes so a caller can tell "everything persisted"
+            // from "some items failed" rather than only inferring it from the item counts below.
+            status = result.Status.ToString(),
+            isPartial = result.IsPartial,
             entityCount = result.Entities.Count,
             factCount = result.Facts.Count,
             preferenceCount = result.Preferences.Count,
             relationshipCount = result.Relationships.Count,
             entities = result.Entities.Select(e => new { e.Name, e.Type, e.Confidence }),
             facts = result.Facts.Select(f => new { f.Subject, f.Predicate, f.Object, f.Confidence }),
-            preferences = result.Preferences.Select(p => new { p.Category, p.PreferenceText, p.Confidence })
+            preferences = result.Preferences.Select(p => new { p.Category, p.PreferenceText, p.Confidence }),
+            failedOutcomes = result.Outcomes
+                .Where(o => o.Status == IngestionItemStatus.Failed)
+                .Select(o => new { kind = o.Kind.ToString(), stage = o.Stage.ToString(), o.ErrorCode, o.Retryable })
         });
     }
 

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 
 namespace AgentMemory.Observability;
@@ -11,11 +14,14 @@ internal sealed class InstrumentedMemoryService : IMemoryService
 {
     private readonly IMemoryService _inner;
     private readonly MemoryMetrics _metrics;
+    private readonly IngestionFailureMode _failureMode;
 
-    public InstrumentedMemoryService(IMemoryService inner, MemoryMetrics metrics)
+    public InstrumentedMemoryService(
+        IMemoryService inner, MemoryMetrics metrics, IOptions<ExtractionOptions>? extractionOptions = null)
     {
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _failureMode = extractionOptions?.Value.FailureMode ?? IngestionFailureMode.BestEffort;
     }
 
     public async Task<RecallResult> RecallAsync(
@@ -181,7 +187,19 @@ internal sealed class InstrumentedMemoryService : IMemoryService
             activity?.SetTag("memory.extraction.entity_count", result.Entities.Count);
             activity?.SetTag("memory.extraction.fact_count", result.Facts.Count);
             activity?.SetTag("memory.extraction.preference_count", result.Preferences.Count);
+            RecordIngestionOutcome(result, activity);
             return result;
+        }
+        catch (MemoryIngestionException ex)
+        {
+            // Fail-fast (#101): still surfaces the completed-outcomes item counters, then re-throws.
+            RecordItemOutcomes(ex.CompletedOutcomes);
+            _metrics.IngestionOperations.Add(1,
+                new KeyValuePair<string, object?>("status", nameof(IngestionStatus.Failed)),
+                new KeyValuePair<string, object?>("failure_mode", _failureMode.ToString()));
+            _metrics.ExtractionErrors.Add(1);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
         }
         catch (Exception ex)
         {
@@ -192,6 +210,34 @@ internal sealed class InstrumentedMemoryService : IMemoryService
         finally
         {
             _metrics.ExtractionDurationMs.Record(sw.Elapsed.TotalMilliseconds);
+        }
+    }
+
+    /// <summary>Emits ingestion metrics/tags for a completed (non-throwing) ingestion (#101).</summary>
+    private void RecordIngestionOutcome(ExtractionResult result, Activity? activity)
+    {
+        activity?.SetTag("memory.ingestion.status", result.Status.ToString());
+        _metrics.IngestionOperations.Add(1,
+            new KeyValuePair<string, object?>("status", result.Status.ToString()),
+            new KeyValuePair<string, object?>("failure_mode", _failureMode.ToString()));
+        RecordItemOutcomes(result.Outcomes);
+    }
+
+    /// <summary>Emits per-item succeeded/failed counters, tagged by kind and stage only (#101) —
+    /// never owner IDs, memory text, or exception messages.</summary>
+    private void RecordItemOutcomes(IReadOnlyList<IngestionItemOutcome> outcomes)
+    {
+        foreach (var outcome in outcomes)
+        {
+            var tags = new[]
+            {
+                new KeyValuePair<string, object?>("item.kind", outcome.Kind.ToString()),
+                new KeyValuePair<string, object?>("stage", outcome.Stage.ToString()),
+            };
+            if (outcome.Status == IngestionItemStatus.Succeeded)
+                _metrics.IngestionItemsSucceeded.Add(1, tags);
+            else if (outcome.Status == IngestionItemStatus.Failed)
+                _metrics.IngestionItemsFailed.Add(1, tags);
         }
     }
 

--- a/src/AgentMemory.Observability/MemoryMetrics.cs
+++ b/src/AgentMemory.Observability/MemoryMetrics.cs
@@ -110,6 +110,20 @@ public sealed class MemoryMetrics : IDisposable
             "memory.enrichment.duration",
             unit: "ms",
             description: "Duration of enrichment operations in milliseconds");
+
+        // #101: structured ingestion outcomes. Dimensions (status, failure_mode, item.kind, stage) are
+        // all low-cardinality enum values -- never owner IDs, memory text, or arbitrary exception text.
+        IngestionOperations = _meter.CreateCounter<long>(
+            "memory.ingestion.operations",
+            description: "Number of ingestion (extract+persist) operations, tagged by overall status and failure mode");
+
+        IngestionItemsSucceeded = _meter.CreateCounter<long>(
+            "memory.ingestion.items.succeeded",
+            description: "Number of ingestion items that succeeded, tagged by item kind and stage");
+
+        IngestionItemsFailed = _meter.CreateCounter<long>(
+            "memory.ingestion.items.failed",
+            description: "Number of ingestion items that failed, tagged by item kind and stage");
     }
 
     /// <summary>
@@ -180,4 +194,13 @@ public sealed class MemoryMetrics : IDisposable
 
     /// <summary>Duration of enrichment operations in milliseconds.</summary>
     internal Histogram<double> EnrichmentDurationMs { get; }
+
+    /// <summary>Number of ingestion operations, tagged by overall status and failure mode (#101).</summary>
+    internal Counter<long> IngestionOperations { get; }
+
+    /// <summary>Number of ingestion items that succeeded, tagged by item kind and stage (#101).</summary>
+    internal Counter<long> IngestionItemsSucceeded { get; }
+
+    /// <summary>Number of ingestion items that failed, tagged by item kind and stage (#101).</summary>
+    internal Counter<long> IngestionItemsFailed { get; }
 }

--- a/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
@@ -49,7 +49,8 @@ public static class ServiceCollectionExtensions
             {
                 var inner = CreateInstance<IMemoryService>(provider, descriptor);
                 var metrics = provider.GetRequiredService<MemoryMetrics>();
-                return new InstrumentedMemoryService(inner, metrics);
+                var extractionOptions = provider.GetService<Microsoft.Extensions.Options.IOptions<Abstractions.Options.ExtractionOptions>>();
+                return new InstrumentedMemoryService(inner, metrics, extractionOptions);
             },
             descriptor.Lifetime));
     }

--- a/tests/AgentMemory.Tests.Unit/Extraction/ExtractionStageTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/ExtractionStageTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Core.Extraction;
@@ -678,5 +679,180 @@ public sealed class ExtractionStageTests
         result.RawPreferences.Should().HaveCount(2);
         result.FilteredPreferences.Should().ContainSingle()
             .Which.PreferenceText.Should().Be("espresso");
+    }
+
+    // ── #101: structured ingestion outcomes ─────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_ExtractorThrows_RecordsFailedExtractionOutcome()
+    {
+        var failing = Substitute.For<IEntityExtractor>();
+        failing.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+
+        var sut = CreateSut(entityExtractors: new[] { failing });
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Extraction &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.EntityExtractionFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EntityFailsValidation_RecordsSkippedOutcome()
+    {
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("the", 0.9) }); // stopword — fails validation
+
+        var sut = CreateSut(entityExtractors: new[] { ext });
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Validation &&
+            o.Status == IngestionItemStatus.Skipped &&
+            o.SourceKey == "the" &&
+            o.ErrorCode == MemoryErrorCodes.EntityValidationFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LowConfidenceEntity_DoesNotRecordAnOutcome()
+    {
+        // Confidence-threshold filtering is routine, expected behavior, not a failure or meaningful
+        // skip — deliberately not tracked (#101 scope decision).
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("Alice", 0.1) });
+
+        var sut = CreateSut(
+            entityExtractors: new[] { ext },
+            options: new ExtractionOptions { MinConfidenceThreshold = 0.5 });
+
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        result.Outcomes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EntityResolutionFails_RecordsFailedOutcome()
+    {
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("BadEntity") });
+
+        var sut = CreateSut(entityExtractors: new[] { ext });
+        _resolver
+            .ResolveEntityAsync(Arg.Is<ExtractedEntity>(e => e.Name == "BadEntity"),
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("resolution failed"));
+
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Resolution &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.SourceKey == "BadEntity" &&
+            o.ErrorCode == MemoryErrorCodes.EntityResolutionFailed &&
+            o.Retryable);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_RelationshipEndpointUnresolved_RecordsSkippedOutcome()
+    {
+        var relExt = Substitute.For<IRelationshipExtractor>();
+        relExt.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new ExtractedRelationship { SourceEntity = "Ghost", TargetEntity = "Nobody", RelationshipType = "KNOWS", Confidence = 0.9 }
+            });
+
+        var sut = CreateSut(relExtractors: new[] { relExt });
+        var result = await sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Relationship &&
+            o.Stage == IngestionStage.Resolution &&
+            o.Status == IngestionItemStatus.Skipped &&
+            o.ErrorCode == MemoryErrorCodes.RelationshipEndpointUnresolved);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_FailFast_ExtractorThrows_ThrowsMemoryIngestionExceptionWithOutcomes()
+    {
+        var failing = Substitute.For<IEntityExtractor>();
+        failing.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = CreateSut(
+            entityExtractors: new[] { failing },
+            options: new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+
+        var act = () => sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        var ex = await act.Should().ThrowAsync<MemoryIngestionException>();
+        ex.Which.CompletedOutcomes.Should().ContainSingle(o =>
+            o.Status == IngestionItemStatus.Failed && o.ErrorCode == MemoryErrorCodes.EntityExtractionFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_FailFast_ResolutionFails_ThrowsMemoryIngestionExceptionWithOutcomes()
+    {
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("BadEntity") });
+
+        var sut = CreateSut(
+            entityExtractors: new[] { ext },
+            options: new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+        _resolver
+            .ResolveEntityAsync(Arg.Is<ExtractedEntity>(e => e.Name == "BadEntity"),
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("resolution failed"));
+
+        var act = () => sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        var ex = await act.Should().ThrowAsync<MemoryIngestionException>();
+        ex.Which.CompletedOutcomes.Should().ContainSingle(o =>
+            o.Stage == IngestionStage.Resolution && o.Status == IngestionItemStatus.Failed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_BestEffortIsDefault_FailFastNotConfigured_DoesNotThrow()
+    {
+        var failing = Substitute.For<IEntityExtractor>();
+        failing.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = CreateSut(entityExtractors: new[] { failing }); // default options — BestEffort
+
+        var act = () => sut.ExtractAsync(TestMessages, ExtractionTypes.All);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ResolutionCancelled_DoesNotThrowMemoryIngestionException()
+    {
+        // Cancellation must propagate as OperationCanceledException, never be reinterpreted as a
+        // fail-fast ingestion failure — even under FailFast (#101 acceptance criterion).
+        using var cts = new CancellationTokenSource();
+        var ext = Substitute.For<IEntityExtractor>();
+        ext.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeEntity("Alice") });
+        var sut = CreateSut(
+            entityExtractors: new[] { ext },
+            options: new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+
+        _resolver
+            .ResolveEntityAsync(Arg.Any<ExtractedEntity>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Entity>>(_ => { cts.Cancel(); throw new OperationCanceledException(cts.Token); });
+
+        var act = () => sut.ExtractAsync(TestMessages, ExtractionTypes.All, scope: null, cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
+using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Core.Extraction;
@@ -46,9 +49,9 @@ public sealed class PersistenceStageTests
             .Returns(ci => Task.FromResult(ci.Arg<Relationship>()));
     }
 
-    private PersistenceStage CreateSut() =>
+    private PersistenceStage CreateSut(ExtractionOptions? options = null) =>
         new(_orchestrator, _entityRepo, _factRepo, _prefRepo, _relRepo, _clock, _idGen,
-            NullLogger<PersistenceStage>.Instance);
+            NullLogger<PersistenceStage>.Instance, Options.Create(options ?? new ExtractionOptions()));
 
     private static ExtractionStageResult EmptyResult(IReadOnlyList<string>? sourceIds = null) =>
         new()
@@ -500,5 +503,330 @@ public sealed class PersistenceStageTests
         result.FactCount.Should().Be(1);
         result.PreferenceCount.Should().Be(1);
         result.RelationshipCount.Should().Be(1);
+    }
+
+    // ── #101: structured ingestion outcomes ─────────────────────────────────
+
+    [Fact]
+    public async Task PersistAsync_EntitySucceeds_RecordsSucceededOutcome()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Succeeded &&
+            o.SourceKey == "Alice" &&
+            o.PersistedId == "e-1");
+    }
+
+    [Fact]
+    public async Task PersistAsync_EntityEmbeddingFails_RecordsFailedOutcomeAtEmbeddingStage_NotPersistence()
+    {
+        // #101 review: embedding failures must be distinguishable from graph-write failures — a caller
+        // building retry/alerting logic on Stage/ErrorCode needs to tell "the embedding provider is down"
+        // apart from "the Neo4j write failed".
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _orchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<float[]>(new InvalidOperationException("embedding provider down")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Embedding &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.EmbeddingGenerationFailed);
+        await _entityRepo.DidNotReceive().UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_FactEmbeddingFails_RecordsFailedOutcomeAtEmbeddingStage_NotPersistence()
+    {
+        _orchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<float[]>(new InvalidOperationException("embedding provider down")));
+
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "A", Predicate = "b", Object = "c", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Fact &&
+            o.Stage == IngestionStage.Embedding &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.EmbeddingGenerationFailed);
+        await _factRepo.DidNotReceive().UpsertAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_FailFast_EmbeddingFails_ThrowsMemoryIngestionException()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _orchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<float[]>(new InvalidOperationException("embedding provider down")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut(new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+        var act = () => sut.PersistAsync(extraction);
+
+        var ex = await act.Should().ThrowAsync<MemoryIngestionException>();
+        ex.Which.CompletedOutcomes.Should().ContainSingle(o => o.Stage == IngestionStage.Embedding);
+    }
+
+    [Fact]
+    public async Task PersistAsync_EntityUpsertFails_RecordsFailedOutcome()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _entityRepo.UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Entity>(new InvalidOperationException("DB error")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Entity &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.EntityPersistenceFailed &&
+            o.Retryable);
+    }
+
+    [Fact]
+    public async Task PersistAsync_ExtractedFromFails_RecordsProvenanceFailure_SeparateFromPersistenceSuccess()
+    {
+        // Required behavior from #101: a fact/entity node can persist successfully while its
+        // provenance edge fails — both outcomes must be visible, distinctly staged.
+        var entity = new Entity { EntityId = "e-1", Name = "Bob", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _entityRepo.CreateExtractedFromRelationshipAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<double?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new Exception("DB connection failed")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Bob"] = entity }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().Contain(o =>
+            o.Kind == MemoryItemKind.Entity && o.Stage == IngestionStage.Persistence && o.Status == IngestionItemStatus.Succeeded);
+        result.Outcomes.Should().Contain(o =>
+            o.Kind == MemoryItemKind.Entity && o.Stage == IngestionStage.Provenance && o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.ProvenancePersistenceFailed);
+    }
+
+    [Fact]
+    public async Task PersistAsync_FactSucceeds_RecordsSucceededOutcome()
+    {
+        _idGen.GenerateId().Returns("fact-1");
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "Alice", Predicate = "likes", Object = "coffee", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Fact &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Succeeded &&
+            o.PersistedId == "fact-1");
+    }
+
+    [Fact]
+    public async Task PersistAsync_FactUpsertFails_RecordsFailedOutcome()
+    {
+        _factRepo.UpsertAsync(Arg.Any<Fact>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Fact>(new InvalidOperationException("DB error")));
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "A", Predicate = "b", Object = "c", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Fact &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.FactPersistenceFailed);
+    }
+
+    [Fact]
+    public async Task PersistAsync_PreferenceUpsertFails_RecordsFailedOutcome()
+    {
+        _prefRepo.UpsertAsync(Arg.Any<Preference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Preference>(new InvalidOperationException("DB error")));
+        var extraction = EmptyResult() with
+        {
+            FilteredPreferences = new[] { new ExtractedPreference { Category = "a", PreferenceText = "text1", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Preference &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.PreferencePersistenceFailed);
+    }
+
+    [Fact]
+    public async Task PersistAsync_RelationshipEndpointNotPersisted_RecordsSkippedOutcome()
+    {
+        var extraction = EmptyResult() with
+        {
+            FilteredRelationships = new[]
+            {
+                new ExtractedRelationship { SourceEntity = "Ghost", TargetEntity = "Nobody", RelationshipType = "KNOWS", Confidence = 0.9 }
+            }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Relationship &&
+            o.Stage == IngestionStage.RelationshipPersistence &&
+            o.Status == IngestionItemStatus.Skipped &&
+            o.ErrorCode == MemoryErrorCodes.RelationshipEndpointNotPersisted);
+    }
+
+    [Fact]
+    public async Task PersistAsync_RelationshipUpsertFails_RecordsFailedOutcome()
+    {
+        var alice = new Entity { EntityId = "e-alice", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        var bob = new Entity { EntityId = "e-bob", Name = "Bob", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _relRepo.UpsertAsync(Arg.Any<Relationship>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Relationship>(new InvalidOperationException("DB error")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = alice, ["Bob"] = bob },
+            FilteredRelationships = new[]
+            {
+                new ExtractedRelationship { SourceEntity = "Alice", TargetEntity = "Bob", RelationshipType = "KNOWS", Confidence = 0.9 }
+            }
+        };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().ContainSingle(o =>
+            o.Kind == MemoryItemKind.Relationship &&
+            o.Stage == IngestionStage.Persistence &&
+            o.Status == IngestionItemStatus.Failed &&
+            o.ErrorCode == MemoryErrorCodes.RelationshipPersistenceFailed);
+    }
+
+    [Fact]
+    public async Task PersistAsync_PriorOutcomesFromExtractionStage_ArePreservedInResult()
+    {
+        var priorOutcome = new IngestionItemOutcome
+        {
+            Kind = MemoryItemKind.Entity,
+            Stage = IngestionStage.Extraction,
+            Status = IngestionItemStatus.Failed,
+            SourceKey = "some-extractor",
+            ErrorCode = MemoryErrorCodes.EntityExtractionFailed,
+        };
+        var extraction = EmptyResult() with { Outcomes = new[] { priorOutcome } };
+
+        var sut = CreateSut();
+        var result = await sut.PersistAsync(extraction);
+
+        result.Outcomes.Should().Contain(priorOutcome);
+    }
+
+    [Fact]
+    public async Task PersistAsync_FailFast_EntityPersistenceFails_ThrowsMemoryIngestionException()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _entityRepo.UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Entity>(new InvalidOperationException("DB error")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut(new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+        var act = () => sut.PersistAsync(extraction);
+
+        var ex = await act.Should().ThrowAsync<MemoryIngestionException>();
+        ex.Which.CompletedOutcomes.Should().ContainSingle(o =>
+            o.Status == IngestionItemStatus.Failed && o.ErrorCode == MemoryErrorCodes.EntityPersistenceFailed);
+    }
+
+    [Fact]
+    public async Task PersistAsync_FailFast_ProvenanceFails_ThrowsMemoryIngestionException()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Bob", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _entityRepo.CreateExtractedFromRelationshipAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<double?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new Exception("DB connection failed")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Bob"] = entity }
+        };
+
+        var sut = CreateSut(new ExtractionOptions { FailureMode = IngestionFailureMode.FailFast });
+        var act = () => sut.PersistAsync(extraction);
+
+        var ex = await act.Should().ThrowAsync<MemoryIngestionException>();
+        ex.Which.CompletedOutcomes.Should().Contain(o =>
+            o.Stage == IngestionStage.Provenance && o.Status == IngestionItemStatus.Failed);
+        // The entity's own persistence success must still be visible even though provenance failed fast.
+        ex.Which.CompletedOutcomes.Should().Contain(o =>
+            o.Stage == IngestionStage.Persistence && o.Status == IngestionItemStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task PersistAsync_BestEffortIsDefault_DoesNotThrowOnPersistenceFailure()
+    {
+        var entity = new Entity { EntityId = "e-1", Name = "Alice", Type = "Person", Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UtcNow };
+        _entityRepo.UpsertAsync(Arg.Any<Entity>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Entity>(new InvalidOperationException("DB error")));
+
+        var extraction = EmptyResult() with
+        {
+            ResolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase) { ["Alice"] = entity }
+        };
+
+        var sut = CreateSut(); // default options — BestEffort
+        var act = () => sut.PersistAsync(extraction);
+
+        await act.Should().NotThrowAsync();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
@@ -18,8 +18,8 @@ public sealed class AbstractionsContractGuardTests
     // Counts mirrored in docs/architecture.md §3.1 and docs/design.md §5/§6.
     private const int DocumentedServiceInterfaces = 39; // R1b store + IC8 owner contexts, +IConsolidationService (PR#113), +IConflictDetectionService, +IMemoryRankingContext/+IWritable (D3), +IMemoryIsolationPolicy (#100)
     private const int DocumentedRepositoryInterfaces = 11;
-    private const int DocumentedDomainRecords = 48; // +ToolCallStats (PR2 — IToolCallRepository.GetStatsAsync)
-    private const int DocumentedEnums = 18; // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType, +MemoryNodeKind, +MemoryOperationAccess, +MemoryIsolationMode (#100)
+    private const int DocumentedDomainRecords = 49; // +ToolCallStats (PR2), +IngestionItemOutcome (#101)
+    private const int DocumentedEnums = 23; // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType, +MemoryNodeKind, +MemoryOperationAccess, +MemoryIsolationMode (#100); +IngestionStatus, +IngestionStage, +IngestionItemStatus, +MemoryItemKind, +IngestionFailureMode (#101)
 
     private static IEnumerable<Type> PublicTypes() =>
         Abstractions.GetTypes().Where(t => t.IsPublic);

--- a/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using FluentAssertions;
 using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Observability;
 using NSubstitute;
@@ -415,6 +416,139 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
         await _inner.Received(1).AddMessagesAsync(messages, Arg.Any<CancellationToken>());
         await _inner.Received(1).ExtractAndPersistAsync(extractRequest, Arg.Any<CancellationToken>());
         await _inner.Received(1).ClearSessionAsync("s1", Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── #101: ingestion outcome metrics/tags ────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAndPersist_TagsActivityWithIngestionStatus()
+    {
+        var request = new ExtractionRequest { SessionId = "s1", Messages = new[] { CreateMessage("msg-1", "s1") } };
+        _inner.ExtractAndPersistAsync(request, Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult { Status = IngestionStatus.PartiallySucceeded });
+
+        await _sut.ExtractAndPersistAsync(request);
+
+        var activity = _capturedActivities.Should().ContainSingle(
+            a => a.OperationName == "memory.extract_and_persist").Subject;
+        activity.GetTagItem("memory.ingestion.status").Should().Be("PartiallySucceeded");
+    }
+
+    [Fact]
+    public async Task ExtractAndPersist_RecordsIngestionOperationsAndItemCounters()
+    {
+        var request = new ExtractionRequest { SessionId = "s1", Messages = new[] { CreateMessage("msg-1", "s1") } };
+        _inner.ExtractAndPersistAsync(request, Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult
+            {
+                Status = IngestionStatus.PartiallySucceeded,
+                Outcomes = new IngestionItemOutcome[]
+                {
+                    new() { Kind = MemoryItemKind.Fact, Stage = IngestionStage.Persistence, Status = IngestionItemStatus.Succeeded },
+                    new() { Kind = MemoryItemKind.Entity, Stage = IngestionStage.Persistence, Status = IngestionItemStatus.Failed },
+                }
+            });
+
+        long operations = 0, succeeded = 0, failed = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MemoryMetrics.MeterName) l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            switch (instrument.Name)
+            {
+                case "memory.ingestion.operations": Interlocked.Add(ref operations, value); break;
+                case "memory.ingestion.items.succeeded": Interlocked.Add(ref succeeded, value); break;
+                case "memory.ingestion.items.failed": Interlocked.Add(ref failed, value); break;
+            }
+        });
+        listener.Start();
+
+        await _sut.ExtractAndPersistAsync(request);
+        listener.Dispose();
+
+        operations.Should().Be(1);
+        succeeded.Should().Be(1);
+        failed.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExtractAndPersist_ConfiguredFailFast_TagsSuccessfulRunWithActualFailureMode()
+    {
+        // #101 review: the success-path metric previously hardcoded failure_mode="BestEffort" regardless
+        // of the actual configured mode, so a FailFast host's successful runs were misreported.
+        var request = new ExtractionRequest { SessionId = "s1", Messages = new[] { CreateMessage("msg-1", "s1") } };
+        _inner.ExtractAndPersistAsync(request, Arg.Any<CancellationToken>())
+            .Returns(new ExtractionResult { Status = IngestionStatus.Succeeded });
+
+        var options = Microsoft.Extensions.Options.Options.Create(
+            new AgentMemory.Abstractions.Options.ExtractionOptions
+            {
+                FailureMode = AgentMemory.Abstractions.Options.IngestionFailureMode.FailFast
+            });
+        var sut = new InstrumentedMemoryService(_inner, _metrics, options);
+
+        string? failureMode = null;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MemoryMetrics.MeterName) l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+        {
+            if (instrument.Name != "memory.ingestion.operations") return;
+            foreach (var tag in tags)
+                if (tag.Key == "failure_mode") failureMode = tag.Value?.ToString();
+        });
+        listener.Start();
+
+        await sut.ExtractAndPersistAsync(request);
+        listener.Dispose();
+
+        failureMode.Should().Be("FailFast");
+    }
+
+    [Fact]
+    public async Task ExtractAndPersist_FailFast_RecordsCompletedOutcomesBeforeRethrowing()
+    {
+        var request = new ExtractionRequest { SessionId = "s1", Messages = new[] { CreateMessage("msg-1", "s1") } };
+        var completedOutcomes = new IngestionItemOutcome[]
+        {
+            new() { Kind = MemoryItemKind.Entity, Stage = IngestionStage.Persistence, Status = IngestionItemStatus.Failed }
+        };
+        _inner.ExtractAndPersistAsync(request, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MemoryIngestionException("failed fast", completedOutcomes));
+
+        long failed = 0, operations = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MemoryMetrics.MeterName) l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+        {
+            switch (instrument.Name)
+            {
+                case "memory.ingestion.items.failed": Interlocked.Add(ref failed, value); break;
+                case "memory.ingestion.operations": Interlocked.Add(ref operations, value); break;
+            }
+        });
+        listener.Start();
+
+        var act = () => _sut.ExtractAndPersistAsync(request);
+        await act.Should().ThrowAsync<MemoryIngestionException>();
+        listener.Dispose();
+
+        failed.Should().Be(1);
+        operations.Should().Be(1);
     }
 
     // ---- Helpers ----

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryExtractionPipelineTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryExtractionPipelineTests.cs
@@ -177,6 +177,116 @@ public sealed class MemoryExtractionPipelineTests
             Arg.Any<CancellationToken>());
     }
 
+    // ── #101: overall IngestionStatus derivation ────────────────────────────
+
+    private static IngestionItemOutcome MakeOutcome(IngestionItemStatus status) => new()
+    {
+        Kind = MemoryItemKind.Fact,
+        Stage = IngestionStage.Persistence,
+        Status = status,
+    };
+
+    [Fact]
+    public async Task ExtractAsync_NoOutcomes_StatusIsSucceeded()
+    {
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult());
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Status.Should().Be(IngestionStatus.Succeeded);
+        result.IsPartial.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AllOutcomesSucceeded_StatusIsSucceeded()
+    {
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult() with
+            {
+                Outcomes = new[] { MakeOutcome(IngestionItemStatus.Succeeded), MakeOutcome(IngestionItemStatus.Succeeded) }
+            });
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Status.Should().Be(IngestionStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_SomeSucceededSomeFailed_StatusIsPartiallySucceeded()
+    {
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult() with
+            {
+                Outcomes = new[] { MakeOutcome(IngestionItemStatus.Succeeded), MakeOutcome(IngestionItemStatus.Failed) }
+            });
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Status.Should().Be(IngestionStatus.PartiallySucceeded);
+        result.IsPartial.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AllOutcomesFailed_NoneSucceeded_StatusIsFailed()
+    {
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult() with
+            {
+                Outcomes = new[] { MakeOutcome(IngestionItemStatus.Failed), MakeOutcome(IngestionItemStatus.Failed) }
+            });
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Status.Should().Be(IngestionStatus.Failed);
+        result.IsPartial.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_SkippedOutcomesOnly_DoNotAffectStatus()
+    {
+        // Skipped items are neither success nor failure for overall-status purposes.
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult() with
+            {
+                Outcomes = new[] { MakeOutcome(IngestionItemStatus.Skipped) }
+            });
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Status.Should().Be(IngestionStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ReturnsOutcomesFromPersistenceStage()
+    {
+        var outcome = MakeOutcome(IngestionItemStatus.Succeeded);
+        _extractionStage.ExtractAsync(Arg.Any<IReadOnlyList<Message>>(), Arg.Any<ExtractionTypes>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeStageResult());
+        _persistenceStage.PersistAsync(Arg.Any<ExtractionStageResult>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(MakePersistenceResult() with { Outcomes = new[] { outcome } });
+
+        var sut = CreateSut();
+        var result = await sut.ExtractAsync(MakeRequest());
+
+        result.Outcomes.Should().ContainSingle().Which.Should().Be(outcome);
+    }
+
     [Fact]
     public async Task ExtractAsync_SourceMessageIdsFromStage()
     {


### PR DESCRIPTION
## Summary

Closes #101.

Extraction/persistence failures were previously best-effort with only log output — a caller had no way to distinguish "everything persisted" from "3 facts succeeded, 1 entity failed, 2 provenance edges didn't." This PR makes partial failure a first-class, observable outcome instead of a silently-swallowed log line.

- `ExtractionResult` gains `Status` (`IngestionStatus`: `Succeeded` / `PartiallySucceeded` / `Failed`) and `Outcomes` (`IReadOnlyList<IngestionItemOutcome>`), one entry per meaningful event (success, validation/resolution skip, or failure) — each carrying `Kind`, `Stage`, a stable `MEMORY_`-prefixed `ErrorCode`, and `Retryable`.
- New `ExtractionOptions.FailureMode` (`IngestionFailureMode`): default `BestEffort` preserves today's behavior (keep going past per-item failures); `FailFast` throws `MemoryIngestionException` at the first failure, carrying every outcome completed before it (`CompletedOutcomes`).
- Embedding-generation failures are now correctly staged as `IngestionStage.Embedding` (previously misclassified as `Persistence`) — a node's embed step and its upsert are now separate try/catch blocks per item kind.
- New `memory.ingestion.operations` / `memory.ingestion.items.succeeded` / `memory.ingestion.items.failed` metrics (tagged by status/failure-mode/item-kind/stage only — never owner IDs or memory content). `InstrumentedMemoryService`'s `failure_mode` tag now reflects the actually-configured mode instead of a hardcoded `BestEffort`.
- MCP `extract_and_persist` tool surfaces the new `status`/`isPartial`/`failedOutcomes` fields.
- Fully additive: existing `ExtractionResult` properties and default (`BestEffort`) behavior are unchanged.

Design notes and non-goals (item-level transactionality, routine confidence filtering not being an outcome, all-Skipped ⇒ `Succeeded`) are documented in `docs/architecture.md` §3.2.1.

## Self-review

Copilot PR review is unavailable (out of credits), so this was reviewed via a 4-angle finder pass + verification, done directly against this diff before opening the PR. Confirmed findings, all fixed:
- Relationship-persistence catch block was missing the `catch (MemoryIngestionException) { throw; }` re-throw guard present on the other three item kinds — fixed by refactoring all four onto shared `RecordSuccess`/`RecordFailureAndMaybeThrow` helpers (also eliminated ~150 lines of hand-copied duplication that caused the gap in the first place).
- `InstrumentedMemoryService` hardcoded `failure_mode="BestEffort"` in the success-path metric regardless of actual config — fixed by injecting `IOptions<ExtractionOptions>`.
- Embedding failures misclassified under `IngestionStage.Persistence` — fixed by separating embed/upsert try/catch blocks.
- MCP `extract_and_persist` not surfacing the new fields — fixed.
- `IMemoryIngestion`/`IMemoryExtractionPipeline` docs not mentioning `MemoryIngestionException` — fixed.

## Test plan

- [x] Full unit suite: 2833/2833 passed
- [x] Full integration suite (live Neo4j via Testcontainers): 296/296 passed
- [x] New regression tests added locking in each review fix (embedding-stage separation ×3, failure_mode tag ×1, plus ~30 more across `ExtractionStageTests`, `PersistenceStageTests`, `MemoryExtractionPipelineTests`, `InstrumentedMemoryServiceTests`)
- [x] `AbstractionsContractGuardTests` updated for the new domain-record/enum counts (49/23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)