### PR TITLE
feat: pluggable task-aware automatic recall policy for the MAF adapter (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metrics (tagged by status/failure-mode/item-kind/stage only — never owner IDs or memory content).
   Fully additive: existing `ExtractionResult` properties and default behavior are unchanged.
 
+- **Pluggable, task-aware automatic recall policy for the Microsoft Agent Framework adapter (#88).**
+  `Neo4jMemoryContextProvider` previously ran the same configured `RecallOptions` for every turn with user
+  text. The new `IAutomaticRecallPolicy` (`AgentMemory.AgentFramework.Recall`) decides, before anything is
+  queried, whether to recall at all, which memory categories to query, and which ranking intent to use.
+  `ConfiguredAutomaticRecallPolicy` (the default, registered by `AddAgentMemoryFramework`) reproduces the
+  prior behavior exactly. `HeuristicAutomaticRecallPolicy` is a lightweight, deterministic, model-call-free
+  alternative — skips recall for a greeting/acknowledgement-only turn, uses `RankingIntent.Latest` for
+  recency-oriented phrasing, `RankingIntent.Analog` plus reasoning traces for precedent-oriented phrasing,
+  and includes reasoning traces for task/troubleshooting phrasing — opt in via
+  `services.AddScoped<IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy>()`, or supply a fully custom
+  policy the same way. It never excludes GraphRAG (no rule about it is defined, so a host's independently
+  configured `EnableGraphRag`/`MaxGraphRagItems`/`BlendMode` is always preserved), and its greeting/
+  acknowledgement detection is a linear-time tokenizer rather than a regex, to avoid catastrophic
+  backtracking on adversarial input. Excluding a category now also skips its `MemoryContextAssembler`
+  repository call entirely (both the live and bitemporal recall paths) instead of issuing a zero-result
+  query; `AssembleContextAsync` additionally warns if `RetrievalBlendMode.GraphRagOnly` is requested and
+  the effective `MaxGraphRagItems<=0`, since that combination would otherwise silently return a completely
+  empty context every turn. Fully additive and behavior-preserving by default.
+
 ## [1.2.0] - 2026-07-15
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,7 +210,7 @@ in the API claims otherwise.
 | **Purpose** | Thin adapter layer exposing memory capabilities to Microsoft Agent Framework |
 | **Dependencies** | Abstractions (project ref), Core (project ref), Neo4j (project ref), Microsoft.Agents.AI.Abstractions 1.9.0, Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5, Microsoft.Extensions.Logging.Abstractions 10.0.5, Microsoft.Extensions.Options 10.0.5 |
 | **MUST NOT reference** | Business logic — act only as a type mapper and adapter |
-| **Key types** | `Neo4jMemoryContextProvider` (extends `AIContextProvider`), `Neo4jChatMessageStore`, `Neo4jMicrosoftMemoryFacade`, `MafTypeMapper` (bidirectional `ChatMessage` ↔ `Message` mapping), `MemoryToolFactory` (6 tools), `AgentTraceRecorder` |
+| **Key types** | `Neo4jMemoryContextProvider` (extends `AIContextProvider`), `Neo4jChatMessageStore`, `Neo4jMicrosoftMemoryFacade`, `MafTypeMapper` (bidirectional `ChatMessage` ↔ `Message` mapping), `MemoryToolFactory` (6 tools), `AgentTraceRecorder`, `IAutomaticRecallPolicy` (#88) and its `ConfiguredAutomaticRecallPolicy`/`HeuristicAutomaticRecallPolicy` implementations |
 | **Core responsibility** | Bridge between Microsoft Agent Framework lifecycle (`ProvideAIContextAsync`, `StoreAIContextAsync`) and Neo4j memory persistence |
 
 **Key Patterns:**
@@ -226,6 +226,7 @@ in the API claims otherwise.
    - `search_knowledge` — search entities and facts
    - `find_similar_tasks` — retrieve similar prior executions
 5. **Trace Capture** — `AgentTraceRecorder` records agent reasoning steps and tool calls to Neo4j for future analysis
+6. **Task-aware Automatic Recall (#88)** — `IAutomaticRecallPolicy.DecideAsync` runs inside `BuildContextAsync`, before the `RecallRequest` is built, and decides whether to recall at all, which memory categories to query, and which ranking intent to use — see §3.4.1.1
 
 **Namespace structure:**
 ```
@@ -233,7 +234,50 @@ AgentMemory.AgentFramework.Integration     — context provider, message store, 
 AgentMemory.AgentFramework.Tools            — memory tool definitions and factory
 AgentMemory.AgentFramework.Mapping          — MAF type mapping
 AgentMemory.AgentFramework.Tracing          — reasoning trace recording
+AgentMemory.AgentFramework.Recall           — task-aware automatic recall policy (#88)
 ```
+
+#### 3.4.1.1 Task-aware automatic recall policy (#88)
+
+`Neo4jMemoryContextProvider` previously ran the same configured `RecallOptions` for every turn with user
+text, regardless of whether the turn actually needed long-term memory. `IAutomaticRecallPolicy` makes that
+decision pluggable, running deterministically inside `BuildContextAsync` before anything is queried:
+
+- `IAutomaticRecallPolicy.DecideAsync(AutomaticRecallContext, CancellationToken)` returns an
+  `AutomaticRecallDecision` with `ShouldRecall`, `Categories` (an `AutomaticRecallCategories` flags enum:
+  `RecentMessages`/`RelevantMessages`/`Entities`/`Facts`/`Preferences`/`ReasoningTraces`/`GraphRag`),
+  an optional `Intent` override (D3's `RankingIntent`), and an optional full `RecallOptions` override.
+- `ConfiguredAutomaticRecallPolicy` (the default, registered by `AddAgentMemoryFramework`) always returns
+  `Categories = AutomaticRecallCategories.All` with no `Intent`/`RecallOptions` override — this reproduces
+  the pre-#88 behavior exactly, deferring entirely to whatever the host already configured.
+- `HeuristicAutomaticRecallPolicy` is a lightweight, deterministic, model-call-free policy: skips recall
+  for an empty or greeting/acknowledgement-only turn (a linear-time tokenizer, not a regex — an earlier
+  regex-based version of this check exhibited catastrophic backtracking on adversarial input), applies
+  `RankingIntent.Latest` for recency-oriented phrasing, applies `RankingIntent.Analog` plus reasoning
+  traces for precedent-oriented phrasing ("similar case", "how did we solve this before"), and includes
+  reasoning traces for task/troubleshooting phrasing. It has no rule about GraphRAG at all, so its baseline
+  always retains the `GraphRag` category on top of `AutomaticRecallCategories.Default` — it must never
+  silently disable a host's independently configured `EnableGraphRag`/`MaxGraphRagItems`/`BlendMode`.
+  A host opts in via `services.AddScoped<IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy>()` (after
+  `AddAgentMemoryFramework`, or a custom policy the same way) — plain `AddScoped` wins over the `TryAdd`-
+  registered default regardless of call order.
+- Excluding a category from the decision zeroes its `RecallOptions.MaxX` limit. `MemoryContextAssembler`
+  (Core) skips that category's repository call entirely instead of issuing a `LIMIT`/`TopK` 0 query — for
+  every category except GraphRag that query's result is always empty anyway, so this is a pure efficiency
+  win; for GraphRag specifically, `Neo4jGraphRagContextSource` treats `TopK<=0` as "use the configured
+  default TopK" (a pre-existing, unrelated quirk, not "return nothing"), so skipping the call here is what
+  makes `MaxGraphRagItems=0` actually mean "no GraphRAG" for the first time. This applies uniformly to both
+  `AssembleContextAsync` and the bitemporal `AssembleContextAsOfAsync`. Because `RetrievalBlendMode.GraphRagOnly`
+  retrieves nothing else, `AssembleContextAsync` logs a Warning if that blend mode is requested and the
+  effective `MaxGraphRagItems<=0` (in addition to the pre-existing warning for GraphRAG being unavailable)
+  — otherwise a host combining `GraphRagOnly` with a policy that excludes `GraphRag` would get a completely
+  empty context every turn with nothing to explain why.
+- Whichever branch produces the effective `RecallOptions`, `Scope` is always cleared afterwards — scope is
+  always resolved from the invocation's authenticated `userId` (#100's isolation policy), never from a
+  statically configured or policy-supplied value, unchanged from before #88.
+- The decision is logged at Debug level (policy type, `ShouldRecall`, `Categories`, `Intent`) for
+  observability. Automatic recall complements, and never replaces, the model-invokable memory tools
+  (`Tools.MemoryToolFactory`).
 
 #### 3.4.2 GraphRAG Retrieval — built into AgentMemory.Neo4j (Phase 4 ✅ COMPLETE)
 

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -6,6 +6,7 @@ using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework.Mapping;
+using AgentMemory.AgentFramework.Recall;
 using AgentMemory.AgentFramework.Tools;
 
 namespace AgentMemory.AgentFramework;
@@ -25,6 +26,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     private readonly IMemoryStoreContext? _storeContext;
     private readonly IWritableMemoryOwnerContext? _ownerContext;
     private readonly MemoryToolFactory? _toolFactory;
+    private readonly IAutomaticRecallPolicy _recallPolicy;
     private readonly ILogger<Neo4jMemoryContextProvider> _logger;
 
     public Neo4jMemoryContextProvider(
@@ -38,7 +40,8 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         ILogger<Neo4jMemoryContextProvider> logger,
         IMemoryStoreContext? storeContext = null,
         IWritableMemoryOwnerContext? ownerContext = null,
-        MemoryToolFactory? toolFactory = null)
+        MemoryToolFactory? toolFactory = null,
+        IAutomaticRecallPolicy? recallPolicy = null)
         // AIContextProvider(IServiceProvider? sp, ILogger? logger, string? stateKey)
         // All three are passed as null: we supply our own ILogger via constructor injection,
         // we don't need the base-class IServiceProvider, and StateKey is exposed as our own property.
@@ -54,6 +57,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         _storeContext = storeContext;
         _ownerContext = ownerContext;
         _toolFactory = toolFactory;
+        _recallPolicy = recallPolicy ?? new ConfiguredAutomaticRecallPolicy();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -99,6 +103,33 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
 
             var queryText = string.Join("\n", userMessages.Select(m => m.Text));
 
+            // Task-aware automatic recall (#88): let the policy decide, before anything is queried,
+            // whether this turn needs recall at all and which categories/intent are relevant. The default
+            // ConfiguredAutomaticRecallPolicy always returns Categories=All + Intent=null, which
+            // ResolveEffectiveOptions below turns into a complete no-op -- so the pre-#88 behavior is
+            // preserved exactly unless a host opts into a different policy.
+            var decision = await _recallPolicy
+                .DecideAsync(
+                    new AutomaticRecallContext
+                    {
+                        Messages = userMessages,
+                        SessionId = sessionId,
+                        ConversationId = conversationId,
+                        UserId = userId
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogDebug(
+                "Automatic recall decision for session {SessionId}: policy={Policy} recall={ShouldRecall} " +
+                "categories={Categories} intent={Intent}",
+                sessionId, _recallPolicy.GetType().Name, decision.ShouldRecall, decision.Categories, decision.Intent);
+
+            if (!decision.ShouldRecall)
+                return BuildResult();
+
+            var effectiveOptions = ResolveEffectiveOptions(decision);
+
             float[]? queryEmbedding = null;
             try
             {
@@ -121,13 +152,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
                 UserId = userId,
                 Query = queryText,
                 QueryEmbedding = queryEmbedding,
-                // Retrieval tuning (limits, MinSimilarityScore, BlendMode, Intent) comes from the
-                // configured RecallOptions (#87) -- but Scope is explicitly cleared: scope must always be
-                // resolved from this invocation's authenticated userId (via #100's isolation policy),
-                // never from a statically configured value. A host who ever sets
-                // MemoryOptions.Recall.Scope globally must not have it silently override the real,
-                // per-invocation owner here.
-                Options = _recallOptions with { Scope = null }
+                Options = effectiveOptions
             };
 
             RecallResult recallResult;
@@ -177,6 +202,33 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
             ? _toolFactory?.CreateAIFunctions()
             : null,
     };
+
+    /// <summary>
+    /// Resolves the effective <see cref="RecallOptions"/> for this turn from the policy's decision (#88).
+    /// An explicit <see cref="AutomaticRecallDecision.RecallOptions"/> is used verbatim; otherwise the
+    /// configured base <see cref="RecallOptions"/> is used, with the per-category limit zeroed for every
+    /// <see cref="AutomaticRecallCategories"/> flag the decision excludes (so <c>MemoryContextAssembler</c>
+    /// skips that category's retrieval entirely instead of querying and discarding it) and
+    /// <see cref="AutomaticRecallDecision.Intent"/> applied when set. Either way, <c>Scope</c> is always
+    /// cleared afterwards: scope must always be resolved from this invocation's authenticated userId (via
+    /// #100's isolation policy), never from a statically configured or policy-supplied value.
+    /// </summary>
+    private RecallOptions ResolveEffectiveOptions(AutomaticRecallDecision decision)
+    {
+        var effective = decision.RecallOptions ?? _recallOptions with
+        {
+            MaxRecentMessages = decision.Categories.HasFlag(AutomaticRecallCategories.RecentMessages) ? _recallOptions.MaxRecentMessages : 0,
+            MaxRelevantMessages = decision.Categories.HasFlag(AutomaticRecallCategories.RelevantMessages) ? _recallOptions.MaxRelevantMessages : 0,
+            MaxEntities = decision.Categories.HasFlag(AutomaticRecallCategories.Entities) ? _recallOptions.MaxEntities : 0,
+            MaxFacts = decision.Categories.HasFlag(AutomaticRecallCategories.Facts) ? _recallOptions.MaxFacts : 0,
+            MaxPreferences = decision.Categories.HasFlag(AutomaticRecallCategories.Preferences) ? _recallOptions.MaxPreferences : 0,
+            MaxTraces = decision.Categories.HasFlag(AutomaticRecallCategories.ReasoningTraces) ? _recallOptions.MaxTraces : 0,
+            MaxGraphRagItems = decision.Categories.HasFlag(AutomaticRecallCategories.GraphRag) ? _recallOptions.MaxGraphRagItems : 0,
+            Intent = decision.Intent ?? _recallOptions.Intent
+        };
+
+        return effective with { Scope = null };
+    }
 
     /// <summary>
     /// Post-run hook: persists response messages and optionally triggers extraction.

--- a/src/AgentMemory.AgentFramework/Recall/AutomaticRecallCategories.cs
+++ b/src/AgentMemory.AgentFramework/Recall/AutomaticRecallCategories.cs
@@ -1,0 +1,49 @@
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// Selects which memory categories an <see cref="IAutomaticRecallPolicy"/> wants queried for the current
+/// turn (#88). Excluding a category from <see cref="AutomaticRecallDecision.Categories"/> zeroes its
+/// corresponding <c>RecallOptions.MaxX</c> limit, so <c>MemoryContextAssembler</c> skips that category's
+/// retrieval entirely instead of querying it and discarding the result.
+/// </summary>
+[Flags]
+public enum AutomaticRecallCategories
+{
+    /// <summary>No automatic recall category is queried.</summary>
+    None = 0,
+
+    /// <summary>Recent short-term messages for this session.</summary>
+    RecentMessages = 1 << 0,
+
+    /// <summary>Semantically relevant short-term messages for this session.</summary>
+    RelevantMessages = 1 << 1,
+
+    /// <summary>Long-term entity nodes.</summary>
+    Entities = 1 << 2,
+
+    /// <summary>Long-term fact nodes.</summary>
+    Facts = 1 << 3,
+
+    /// <summary>Long-term preference nodes.</summary>
+    Preferences = 1 << 4,
+
+    /// <summary>Reasoning-trace nodes. Excluded from <see cref="Default"/> -- opt in explicitly.</summary>
+    ReasoningTraces = 1 << 5,
+
+    /// <summary>GraphRAG context. Excluded from <see cref="Default"/> -- opt in explicitly.</summary>
+    GraphRag = 1 << 6,
+
+    /// <summary>
+    /// A sensible baseline for a policy that wants "the usual" categories without reasoning traces or
+    /// GraphRAG: <see cref="RecentMessages"/> | <see cref="RelevantMessages"/> | <see cref="Entities"/> |
+    /// <see cref="Facts"/> | <see cref="Preferences"/>.
+    /// </summary>
+    Default = RecentMessages | RelevantMessages | Entities | Facts | Preferences,
+
+    /// <summary>
+    /// Every category. This is <see cref="AutomaticRecallDecision"/>'s own default -- it reproduces the
+    /// complete configured recall exactly as before #88, deferring entirely to whatever the host already
+    /// configured for reasoning traces / GraphRAG rather than silently disabling them.
+    /// </summary>
+    All = RecentMessages | RelevantMessages | Entities | Facts | Preferences | ReasoningTraces | GraphRag
+}

--- a/src/AgentMemory.AgentFramework/Recall/AutomaticRecallContext.cs
+++ b/src/AgentMemory.AgentFramework/Recall/AutomaticRecallContext.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.AI;
+
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// Input to <see cref="IAutomaticRecallPolicy.DecideAsync"/>: everything about the current turn a policy
+/// needs in order to decide whether/what to recall, before <c>Neo4jMemoryContextProvider</c> builds the
+/// <c>RecallRequest</c> (#88).
+/// </summary>
+public sealed record AutomaticRecallContext
+{
+    /// <summary>
+    /// This turn's user messages (already filtered to <c>ChatRole.User</c> with non-blank text) -- the
+    /// same set <c>Neo4jMemoryContextProvider</c> joins into the recall query text.
+    /// </summary>
+    public required IReadOnlyList<ChatMessage> Messages { get; init; }
+
+    /// <summary>The session this turn belongs to.</summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>The conversation this turn belongs to.</summary>
+    public required string ConversationId { get; init; }
+
+    /// <summary>
+    /// The authenticated owner for this turn, when R1 multi-user isolation is in use. Null for a
+    /// shared/global (unowned) turn.
+    /// </summary>
+    public string? UserId { get; init; }
+}

--- a/src/AgentMemory.AgentFramework/Recall/AutomaticRecallDecision.cs
+++ b/src/AgentMemory.AgentFramework/Recall/AutomaticRecallDecision.cs
@@ -1,0 +1,42 @@
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// The outcome of <see cref="IAutomaticRecallPolicy.DecideAsync"/> (#88).
+/// </summary>
+public sealed record AutomaticRecallDecision
+{
+    /// <summary>When <see langword="false"/>, no recall is performed and this turn injects no memory context.</summary>
+    public bool ShouldRecall { get; init; } = true;
+
+    /// <summary>
+    /// Which memory categories to query. Default (<see cref="AutomaticRecallCategories.All"/>) queries
+    /// every category the host has configured a nonzero limit for -- i.e. it changes nothing versus the
+    /// pre-#88 behavior. Excluding a category zeroes its <c>RecallOptions.MaxX</c> limit so it is not
+    /// queried at all, unless <see cref="RecallOptions"/> is also set (which takes precedence).
+    /// </summary>
+    public AutomaticRecallCategories Categories { get; init; } = AutomaticRecallCategories.All;
+
+    /// <summary>
+    /// Per-turn ranking-intent override (D3). Null leaves the host's configured
+    /// <c>RecallOptions.Intent</c> untouched; a non-null value overrides it for this turn only, unless
+    /// <see cref="RecallOptions"/> is also set (which takes precedence).
+    /// </summary>
+    public RankingIntent? Intent { get; init; }
+
+    /// <summary>
+    /// An explicit, complete override of the effective <see cref="Abstractions.Options.RecallOptions"/> for
+    /// this turn. When set, <see cref="Categories"/> and <see cref="Intent"/> above are ignored -- this
+    /// value is used verbatim (its <c>Scope</c> is still always cleared, the same invariant as before #88).
+    /// Null (default) derives the effective options from the host's configured <c>RecallOptions</c> plus
+    /// <see cref="Categories"/>/<see cref="Intent"/> instead.
+    /// </summary>
+    public RecallOptions? RecallOptions { get; init; }
+
+    /// <summary>Recall everything the host has configured, unchanged (the pre-#88 behavior).</summary>
+    public static AutomaticRecallDecision Recall { get; } = new();
+
+    /// <summary>Skip automatic recall entirely for this turn.</summary>
+    public static AutomaticRecallDecision Skip { get; } = new() { ShouldRecall = false };
+}

--- a/src/AgentMemory.AgentFramework/Recall/ConfiguredAutomaticRecallPolicy.cs
+++ b/src/AgentMemory.AgentFramework/Recall/ConfiguredAutomaticRecallPolicy.cs
@@ -1,0 +1,16 @@
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// The default <see cref="IAutomaticRecallPolicy"/> (#88): always recalls, using every category the host
+/// has configured a nonzero limit for -- reproducing the deterministic, task-agnostic behavior that
+/// predates #88 exactly. Registered by <c>AddAgentMemoryFramework</c>; a host replaces it by registering
+/// its own <see cref="IAutomaticRecallPolicy"/> (e.g. <see cref="HeuristicAutomaticRecallPolicy"/> or a
+/// custom implementation) after calling <c>AddAgentMemoryFramework</c>.
+/// </summary>
+public sealed class ConfiguredAutomaticRecallPolicy : IAutomaticRecallPolicy
+{
+    /// <inheritdoc/>
+    public ValueTask<AutomaticRecallDecision> DecideAsync(
+        AutomaticRecallContext context, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(AutomaticRecallDecision.Recall);
+}

--- a/src/AgentMemory.AgentFramework/Recall/HeuristicAutomaticRecallPolicy.cs
+++ b/src/AgentMemory.AgentFramework/Recall/HeuristicAutomaticRecallPolicy.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+using AgentMemory.Abstractions.Options;
+
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// A lightweight, deterministic <see cref="IAutomaticRecallPolicy"/> that adapts automatic recall to the
+/// shape of the current turn without any additional model call (#88):
+/// <list type="bullet">
+/// <item>Skips recall entirely for an empty or greeting/acknowledgement-only turn.</item>
+/// <item>Favours <see cref="RankingIntent.Latest"/> for recency-oriented phrasing ("latest", "current").</item>
+/// <item>Favours <see cref="RankingIntent.Analog"/> and includes reasoning traces for precedent-oriented
+/// phrasing ("similar case", "how did we solve this before").</item>
+/// <item>Includes reasoning traces for task/troubleshooting-oriented phrasing.</item>
+/// <item>Otherwise falls back to <see cref="AutomaticRecallCategories.Default"/> with no intent override.</item>
+/// </list>
+/// GraphRAG is never excluded by this policy -- it only ever reasons about reasoning traces/intent, so a
+/// host's independently configured <c>EnableGraphRag</c>/<c>MaxGraphRagItems</c>/<c>BlendMode</c> continue
+/// to govern GraphRAG exactly as before, unaffected by opting into this policy.
+/// Not required reading for a host that only wants the default behavior -- opt in explicitly via
+/// <c>services.AddScoped&lt;IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy&gt;()</c>.
+/// </summary>
+public sealed class HeuristicAutomaticRecallPolicy : IAutomaticRecallPolicy
+{
+    // Baseline always retains GraphRag (unlike AutomaticRecallCategories.Default) -- this policy has no
+    // rule for GraphRAG at all, so it must never silently disable a host's independently configured
+    // GraphRAG retrieval.
+    private const AutomaticRecallCategories BaselineCategories =
+        AutomaticRecallCategories.Default | AutomaticRecallCategories.GraphRag;
+
+    private static readonly HashSet<string> GreetingPhrases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "hi", "hello", "hey", "thanks", "thank you", "ok", "okay", "sure", "got it",
+        "yes", "no", "yep", "nope", "sounds good", "great", "cool", "noted", "understood"
+    };
+
+    private static readonly char[] WordSeparators = { ' ', '\t', '\r', '\n', '.', ',', '!', '?' };
+
+    private static readonly Regex RecencyOriented = new(
+        @"\b(latest|current|most recent|right now|these days|nowadays)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex PrecedentOriented = new(
+        @"\b(similar (case|incident|problem|issue)|previous (incident|issue|case)|precedent|find a similar|how did we (solve|handle|fix) this before)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex TaskOriented = new(
+        @"\b(debug|troubleshoot|workflow|steps to|how do i|walk me through|implement|error|bug|incident|root cause)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <inheritdoc/>
+    public ValueTask<AutomaticRecallDecision> DecideAsync(
+        AutomaticRecallContext context, CancellationToken cancellationToken = default)
+    {
+        var query = string.Join(" ", context.Messages.Select(m => m.Text ?? string.Empty)).Trim();
+
+        if (string.IsNullOrWhiteSpace(query) || IsGreetingOrAcknowledgementOnly(query))
+            return ValueTask.FromResult(AutomaticRecallDecision.Skip);
+
+        var categories = BaselineCategories;
+        RankingIntent? intent = null;
+
+        if (PrecedentOriented.IsMatch(query))
+        {
+            intent = RankingIntent.Analog;
+            categories |= AutomaticRecallCategories.ReasoningTraces;
+        }
+        else if (RecencyOriented.IsMatch(query))
+        {
+            intent = RankingIntent.Latest;
+        }
+
+        if (TaskOriented.IsMatch(query))
+            categories |= AutomaticRecallCategories.ReasoningTraces;
+
+        return ValueTask.FromResult(new AutomaticRecallDecision
+        {
+            ShouldRecall = true,
+            Categories = categories,
+            Intent = intent
+        });
+    }
+
+    /// <summary>
+    /// Whether every word/short-phrase in <paramref name="text"/> is a greeting or acknowledgement, e.g.
+    /// "hi", "ok, got it.", "sounds good". Deliberately NOT regex-based: an earlier version used a single
+    /// repeating-group pattern (<c>^(\s*(hi|...)\s*)+$</c>) that exhibited catastrophic backtracking --
+    /// verified experimentally, a string of ~30 repeated short fragments blocked the calling thread for
+    /// multiple seconds. Plain tokenization is linear time and has no such failure mode.
+    /// </summary>
+    private static bool IsGreetingOrAcknowledgementOnly(string text)
+    {
+        var words = text.ToLowerInvariant().Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+            return true;
+
+        var i = 0;
+        while (i < words.Length)
+        {
+            if (i + 1 < words.Length && GreetingPhrases.Contains($"{words[i]} {words[i + 1]}"))
+            {
+                i += 2;
+                continue;
+            }
+
+            if (!GreetingPhrases.Contains(words[i]))
+                return false;
+
+            i++;
+        }
+
+        return true;
+    }
+}

--- a/src/AgentMemory.AgentFramework/Recall/IAutomaticRecallPolicy.cs
+++ b/src/AgentMemory.AgentFramework/Recall/IAutomaticRecallPolicy.cs
@@ -1,0 +1,19 @@
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// Pluggable, task-aware policy that decides -- before <c>Neo4jMemoryContextProvider</c> queries any
+/// repository -- whether automatic recall is useful for the current turn, and if so, which memory
+/// categories, retrieval limits, and ranking intent to use (#88). Runs deterministically inside
+/// <c>ProvideAIContextAsync</c>/<c>BuildContextAsync</c>, before the <c>RecallRequest</c> is constructed.
+/// Complements, and never replaces, the model-invokable memory tools (<c>Tools.MemoryToolFactory</c>).
+/// </summary>
+public interface IAutomaticRecallPolicy
+{
+    /// <summary>
+    /// Decides the recall behavior for the current turn. Implementations must not require an additional
+    /// model call -- an LLM-backed policy can be implemented externally for hosts that want that tradeoff.
+    /// </summary>
+    ValueTask<AutomaticRecallDecision> DecideAsync(
+        AutomaticRecallContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AgentMemory.AgentFramework/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.AgentFramework/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework.Recall;
 using AgentMemory.Core.Services;
 
 namespace AgentMemory.AgentFramework;
@@ -36,6 +37,10 @@ public static class ServiceCollectionExtensions
             })
             .Validate(o => o.MaxChatHistoryMessages >= 0, "ContextFormatOptions.MaxChatHistoryMessages must be non-negative.")
             .ValidateOnStart();
+
+        // Task-aware automatic recall policy (#88). TryAdd: a host registering its own
+        // IAutomaticRecallPolicy either before or after this call always wins over this default.
+        services.TryAddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
 
         services.TryAddScoped<Neo4jMemoryContextProvider>();
         services.TryAddScoped<Neo4jChatMessageStore>();

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -122,7 +122,12 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         //   others       → both sources (Blended / MemoryThenGraphRag / GraphRagThenMemory).
         bool includeMemory = blendMode != RetrievalBlendMode.GraphRagOnly;
         bool graphRagAvailable = _graphRag != null && _options.EnableGraphRag;
-        bool includeGraphRag = blendMode != RetrievalBlendMode.MemoryOnly && graphRagAvailable;
+        // #88: a task-aware recall policy that excludes GraphRag from its decision zeroes MaxGraphRagItems
+        // -- skip the (potentially expensive) GraphRAG round-trip entirely rather than call into it with
+        // TopK=0 (which Neo4jGraphRagContextSource treats as "use the configured default TopK", NOT "return
+        // nothing" -- an existing, unrelated quirk this skip sidesteps rather than depends on).
+        bool includeGraphRag = blendMode != RetrievalBlendMode.MemoryOnly && graphRagAvailable
+            && recallOpts.MaxGraphRagItems > 0;
 
         if (blendMode == RetrievalBlendMode.GraphRagOnly && !graphRagAvailable)
         {
@@ -130,6 +135,17 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
                 "GraphRagOnly blend mode requested for session {SessionId} but GraphRAG is unavailable " +
                 "(source not registered or EnableGraphRag=false); returning empty context.",
                 request.SessionId);
+        }
+        else if (blendMode == RetrievalBlendMode.GraphRagOnly && recallOpts.MaxGraphRagItems <= 0)
+        {
+            // #88: GraphRAG is registered/enabled (graphRagAvailable), but this turn's effective
+            // MaxGraphRagItems is zero -- e.g. an automatic recall policy excluded the GraphRag category.
+            // GraphRagOnly means nothing else is retrieved either, so without this warning a host combining
+            // GraphRagOnly with such a policy would silently get a completely empty context every turn.
+            _logger.LogWarning(
+                "GraphRagOnly blend mode requested for session {SessionId} but MaxGraphRagItems is {MaxGraphRagItems} " +
+                "(excluded by RecallOptions or an automatic recall policy decision); returning empty context.",
+                request.SessionId, recallOpts.MaxGraphRagItems);
         }
 
         // Start GraphRAG retrieval first so it overlaps memory retrieval when both are requested.
@@ -156,11 +172,16 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
             bool hasEmbedding = queryEmbedding is { Length: > 0 };
             static Task<IReadOnlyList<T>> Empty<T>() => Task.FromResult<IReadOnlyList<T>>(Array.Empty<T>());
 
-            // Recent messages need no embedding; the rest are semantic and are gated on hasEmbedding.
-            var recentTask = _shortTerm.GetRecentMessagesAsync(
-                request.SessionId, recallOpts.MaxRecentMessages, cancellationToken);
+            // Recent messages need no embedding; the rest are semantic and are gated on hasEmbedding. Each
+            // is also gated on its own MaxX > 0 (#88): a task-aware recall policy that excludes a category
+            // zeroes its limit, and skipping the call entirely (rather than issuing a LIMIT/TopK 0 query
+            // whose result is always empty) is what actually saves the embedding/database work the policy
+            // is asking to avoid.
+            var recentTask = recallOpts.MaxRecentMessages > 0
+                ? _shortTerm.GetRecentMessagesAsync(request.SessionId, recallOpts.MaxRecentMessages, cancellationToken)
+                : Empty<Message>();
 
-            var relevantTask = hasEmbedding
+            var relevantTask = hasEmbedding && recallOpts.MaxRelevantMessages > 0
                 ? _shortTerm.SearchMessagesAsync(request.SessionId, queryEmbedding, recallOpts.MaxRelevantMessages, minScore, cancellationToken)
                 : Empty<Message>();
 
@@ -171,19 +192,19 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
             bool overrideRanking = _rankingContext is not null && recallOpts.Intent != RankingIntent.Default;
             if (overrideRanking) _rankingContext!.Current = _options.Ranking.ForIntent(recallOpts.Intent);
 
-            var entitiesTask = hasEmbedding
+            var entitiesTask = hasEmbedding && recallOpts.MaxEntities > 0
                 ? _longTerm.SearchEntitiesAsync(queryEmbedding, recallOpts.MaxEntities, minScore, scope, cancellationToken)
                 : Empty<Entity>();
 
-            var preferencesTask = hasEmbedding
+            var preferencesTask = hasEmbedding && recallOpts.MaxPreferences > 0
                 ? _longTerm.SearchPreferencesAsync(queryEmbedding, recallOpts.MaxPreferences, minScore, scope, cancellationToken)
                 : Empty<Preference>();
 
-            var factsTask = hasEmbedding
+            var factsTask = hasEmbedding && recallOpts.MaxFacts > 0
                 ? _longTerm.SearchFactsAsync(queryEmbedding, recallOpts.MaxFacts, minScore, scope, cancellationToken)
                 : Empty<Fact>();
 
-            var tracesTask = hasEmbedding
+            var tracesTask = hasEmbedding && recallOpts.MaxTraces > 0
                 ? _reasoning.SearchSimilarTracesAsync(queryEmbedding, null, recallOpts.MaxTraces, minScore, scope, cancellationToken)
                 : Empty<ReasoningTrace>();
 
@@ -294,22 +315,25 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         // messages, entities, preferences, and traces — which have no valid-time window — observe only
         // systemAsOf. Facts additionally observe the valid-time clock ($validAsOf) for their validity
         // window. When the clocks are equal (single-clock recall) this is byte-for-byte the old behaviour.
-        var recentTask = _shortTerm.GetRecentMessagesAsOfAsync(
-            request.SessionId, systemAsOf, recallOpts.MaxRecentMessages, cancellationToken);
+        // Each is gated on its own MaxX > 0 (#88), same as the live AssembleContextAsync path: skip the
+        // call entirely for a category a task-aware recall policy has excluded.
+        var recentTask = recallOpts.MaxRecentMessages > 0
+            ? _shortTerm.GetRecentMessagesAsOfAsync(request.SessionId, systemAsOf, recallOpts.MaxRecentMessages, cancellationToken)
+            : Empty<Message>();
 
-        var entitiesTask = hasEmbedding
+        var entitiesTask = hasEmbedding && recallOpts.MaxEntities > 0
             ? _longTerm.SearchEntitiesAsOfAsync(queryEmbedding, systemAsOf, recallOpts.MaxEntities, minScore, scope, cancellationToken)
             : Empty<Entity>();
 
-        var preferencesTask = hasEmbedding
+        var preferencesTask = hasEmbedding && recallOpts.MaxPreferences > 0
             ? _longTerm.SearchPreferencesAsOfAsync(queryEmbedding, systemAsOf, recallOpts.MaxPreferences, minScore, scope, cancellationToken)
             : Empty<Preference>();
 
-        var factsTask = hasEmbedding
+        var factsTask = hasEmbedding && recallOpts.MaxFacts > 0
             ? _longTerm.SearchFactsAsOfAsync(queryEmbedding, validAsOf, recallOpts.MaxFacts, minScore, scope, systemAsOf, cancellationToken)
             : Empty<Fact>();
 
-        var tracesTask = hasEmbedding
+        var tracesTask = hasEmbedding && recallOpts.MaxTraces > 0
             ? _reasoning.SearchSimilarTracesAsOfAsync(queryEmbedding, systemAsOf, null, recallOpts.MaxTraces, minScore, scope, cancellationToken)
             : Empty<ReasoningTrace>();
 

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -6,6 +6,7 @@ using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Recall;
 using AgentMemory.AgentFramework.Tools;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -116,6 +117,207 @@ public sealed class Neo4jMemoryContextProviderTests
                 request.Options!.MaxFacts == RecallOptions.Default.MaxFacts &&
                 request.Options.MaxEntities == RecallOptions.Default.MaxEntities &&
                 request.Options.BlendMode == RecallOptions.Default.BlendMode),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── #88: task-aware automatic recall policy ────────────────────────────
+
+    private Neo4jMemoryContextProvider CreateSutWithPolicy(IAutomaticRecallPolicy policy, RecallOptions? recall = null) =>
+        new(
+            _memoryService,
+            _embeddingOrchestrator,
+            _clock,
+            _idGenerator,
+            Options.Create(new MemoryOptions { Recall = recall ?? RecallOptions.Default }),
+            Options.Create(new ContextFormatOptions()),
+            Options.Create(new AgentFrameworkOptions()),
+            NullLogger<Neo4jMemoryContextProvider>.Instance,
+            recallPolicy: policy);
+
+    [Fact]
+    public async Task BuildContextAsync_NoPolicySupplied_DefaultsToConfiguredAutomaticRecallPolicy()
+    {
+        // The optional ctor param defaults internally so DI-less construction (as used throughout this
+        // test class) keeps behaving exactly as it did before #88.
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await _sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicySkipsRecall_DoesNotCallMemoryService()
+    {
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(AutomaticRecallDecision.Skip);
+        var sut = CreateSutWithPolicy(policy);
+
+        var result = await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None);
+
+        result.Messages.Should().BeNullOrEmpty();
+        await _memoryService.DidNotReceive().RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>());
+        // A skipped turn must not even generate an embedding -- there is nothing left to search for.
+        await _embeddingOrchestrator.DidNotReceive().EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicySelectsCategories_ZeroesExcludedCategoryLimits()
+    {
+        var configuredRecall = new RecallOptions { MaxFacts = 5, MaxEntities = 4, MaxPreferences = 3, MaxTraces = 2, MaxGraphRagItems = 1 };
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision
+            {
+                ShouldRecall = true,
+                Categories = AutomaticRecallCategories.Preferences | AutomaticRecallCategories.Facts
+            });
+        var sut = CreateSutWithPolicy(policy, configuredRecall);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "What do you know about me?") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r =>
+                r.Options!.MaxFacts == 5 &&           // selected -- configured value preserved
+                r.Options.MaxPreferences == 3 &&      // selected -- configured value preserved
+                r.Options.MaxEntities == 0 &&         // excluded -- zeroed
+                r.Options.MaxTraces == 0 &&           // excluded -- zeroed
+                r.Options.MaxGraphRagItems == 0),     // excluded -- zeroed
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicySelectsCategories_PreservesMinSimilarityScoreAndBlendMode()
+    {
+        // Coverage gap flagged in review: the Categories-partial branch of ResolveEffectiveOptions must
+        // pass through every RecallOptions field it doesn't explicitly zero -- not just the other Max*
+        // fields already covered elsewhere, but also MinSimilarityScore and BlendMode specifically.
+        var configuredRecall = new RecallOptions
+        {
+            MinSimilarityScore = 0.42,
+            BlendMode = RetrievalBlendMode.MemoryThenGraphRag
+        };
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision { ShouldRecall = true, Categories = AutomaticRecallCategories.Facts });
+        var sut = CreateSutWithPolicy(policy, configuredRecall);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r =>
+                r.Options!.MinSimilarityScore == 0.42 && r.Options.BlendMode == RetrievalBlendMode.MemoryThenGraphRag),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicyIntentOverride_AppliesToRecallOptions()
+    {
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision { ShouldRecall = true, Intent = RankingIntent.Analog });
+        var sut = CreateSutWithPolicy(policy);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "Find a similar previous incident") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r => r.Options!.Intent == RankingIntent.Analog),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicyNoIntentOverride_PreservesConfiguredIntent()
+    {
+        // Intent=null on the decision must not reset a host-configured non-default Intent to Default.
+        var configuredRecall = new RecallOptions { Intent = RankingIntent.Latest };
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision { ShouldRecall = true });
+        var sut = CreateSutWithPolicy(policy, configuredRecall);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r => r.Options!.Intent == RankingIntent.Latest),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicyExplicitRecallOptions_UsedVerbatim()
+    {
+        var explicitOptions = new RecallOptions { MaxFacts = 99, MaxEntities = 0, BlendMode = RetrievalBlendMode.MemoryOnly };
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision { ShouldRecall = true, RecallOptions = explicitOptions });
+        var sut = CreateSutWithPolicy(policy);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r =>
+                r.Options!.MaxFacts == 99 && r.Options.MaxEntities == 0 &&
+                r.Options.BlendMode == RetrievalBlendMode.MemoryOnly),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicyExplicitRecallOptionsWithScope_ScopeIsStillCleared()
+    {
+        // Same invariant as #87/#100: even a policy-supplied full RecallOptions override must never let a
+        // statically-set Scope reach recall -- scope always comes from the invocation's authenticated userId.
+        var explicitOptions = new RecallOptions { Scope = MemoryScope.For("some-other-owner") };
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AutomaticRecallDecision { ShouldRecall = true, RecallOptions = explicitOptions });
+        var sut = CreateSutWithPolicy(policy);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "hi") }, "s1", "c1", CancellationToken.None, userId: "alice");
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(request => request.Options!.Scope == null && request.UserId == "alice"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildContextAsync_PolicyReceivesUserMessagesSessionAndUser()
+    {
+        var policy = Substitute.For<IAutomaticRecallPolicy>();
+        policy.DecideAsync(Arg.Any<AutomaticRecallContext>(), Arg.Any<CancellationToken>())
+            .Returns(AutomaticRecallDecision.Recall);
+        var sut = CreateSutWithPolicy(policy);
+        _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.System, "sys"), new(ChatRole.User, "What do I prefer?") },
+            "s1", "c1", CancellationToken.None, userId: "alice");
+
+        await policy.Received(1).DecideAsync(
+            Arg.Is<AutomaticRecallContext>(ctx =>
+                ctx.SessionId == "s1" && ctx.ConversationId == "c1" && ctx.UserId == "alice" &&
+                ctx.Messages.Count == 1 && ctx.Messages[0].Text == "What do I prefer?"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/ConfiguredAutomaticRecallPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/ConfiguredAutomaticRecallPolicyTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using AgentMemory.AgentFramework.Recall;
+
+namespace AgentMemory.Tests.Unit.AgentFramework.Recall;
+
+public sealed class ConfiguredAutomaticRecallPolicyTests
+{
+    private readonly ConfiguredAutomaticRecallPolicy _sut = new();
+
+    private static AutomaticRecallContext Context(string text = "hi") => new()
+    {
+        Messages = new[] { new ChatMessage(ChatRole.User, text) },
+        SessionId = "s1",
+        ConversationId = "c1"
+    };
+
+    [Fact]
+    public async Task DecideAsync_AlwaysRecalls()
+    {
+        var decision = await _sut.DecideAsync(Context());
+
+        decision.ShouldRecall.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DecideAsync_UsesAllCategories_SoNoCategoryIsSilentlyDisabled()
+    {
+        // Categories=All means ResolveEffectiveOptions zeroes nothing -- whatever the host configured
+        // (including reasoning traces / GraphRAG) reaches recall unchanged, the pre-#88 behavior.
+        var decision = await _sut.DecideAsync(Context());
+
+        decision.Categories.Should().Be(AutomaticRecallCategories.All);
+    }
+
+    [Fact]
+    public async Task DecideAsync_DoesNotOverrideIntent()
+    {
+        var decision = await _sut.DecideAsync(Context());
+
+        decision.Intent.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecideAsync_DoesNotOverrideRecallOptions()
+    {
+        var decision = await _sut.DecideAsync(Context());
+
+        decision.RecallOptions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecideAsync_ReturnsSameDecision_RegardlessOfMessageContent()
+    {
+        // The default policy is task-agnostic by design -- it never inspects the turn content.
+        var greeting = await _sut.DecideAsync(Context("hello"));
+        var task = await _sut.DecideAsync(Context("find a similar previous incident"));
+
+        greeting.Should().Be(task);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/HeuristicAutomaticRecallPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/HeuristicAutomaticRecallPolicyTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.AgentFramework.Recall;
+
+namespace AgentMemory.Tests.Unit.AgentFramework.Recall;
+
+public sealed class HeuristicAutomaticRecallPolicyTests
+{
+    private readonly HeuristicAutomaticRecallPolicy _sut = new();
+
+    private static AutomaticRecallContext Context(params string[] userTexts) => new()
+    {
+        Messages = userTexts.Select(t => new ChatMessage(ChatRole.User, t)).ToList(),
+        SessionId = "s1",
+        ConversationId = "c1"
+    };
+
+    // ── Skip: empty / greeting-only ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("hi")]
+    [InlineData("Hello")]
+    [InlineData("thanks!")]
+    [InlineData("ok, got it.")]
+    [InlineData("sounds good")]
+    public async Task DecideAsync_GreetingOrAcknowledgementOnly_SkipsRecall(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DecideAsync_NoMessages_SkipsRecall()
+    {
+        var decision = await _sut.DecideAsync(Context());
+
+        decision.ShouldRecall.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DecideAsync_WhitespaceOnlyMessage_SkipsRecall()
+    {
+        var decision = await _sut.DecideAsync(Context("   "));
+
+        decision.ShouldRecall.Should().BeFalse();
+    }
+
+    // ── Default: an ordinary substantive question ───────────────────────────
+
+    [Fact]
+    public async Task DecideAsync_OrdinaryQuestion_RecallsWithDefaultCategoriesPlusGraphRag()
+    {
+        var decision = await _sut.DecideAsync(Context("What seat do I normally prefer?"));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Categories.Should().Be(AutomaticRecallCategories.Default | AutomaticRecallCategories.GraphRag);
+        decision.Intent.Should().BeNull();
+    }
+
+    // ── #88 review fix: GraphRAG must never be excluded by this policy ──────
+    // AutomaticRecallCategories.Default (the enum's own baseline) deliberately excludes GraphRag, but this
+    // policy has no rule about GraphRAG at all -- it must never silently disable a host's independently
+    // configured EnableGraphRag/MaxGraphRagItems/BlendMode, in any branch.
+
+    [Theory]
+    [InlineData("What seat do I normally prefer?")]
+    [InlineData("What is the latest decision about Project Atlas?")]
+    [InlineData("Find a similar previous incident")]
+    [InlineData("Help me debug this error")]
+    public async Task DecideAsync_NeverExcludesGraphRagCategory(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.Categories.HasFlag(AutomaticRecallCategories.GraphRag).Should().BeTrue();
+    }
+
+    // ── Recency-oriented phrasing → RankingIntent.Latest ────────────────────
+
+    [Theory]
+    [InlineData("What is the latest decision about Project Atlas?")]
+    [InlineData("What's the current status?")]
+    [InlineData("What is happening right now?")]
+    public async Task DecideAsync_RecencyOrientedPhrasing_UsesLatestIntent(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Intent.Should().Be(RankingIntent.Latest);
+    }
+
+    // ── Precedent-oriented phrasing → RankingIntent.Analog + ReasoningTraces ─
+
+    [Theory]
+    [InlineData("Find a similar previous incident")]
+    [InlineData("How did we solve this before?")]
+    [InlineData("Is there a precedent for this?")]
+    public async Task DecideAsync_PrecedentOrientedPhrasing_UsesAnalogIntentAndIncludesTraces(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Intent.Should().Be(RankingIntent.Analog);
+        decision.Categories.HasFlag(AutomaticRecallCategories.ReasoningTraces).Should().BeTrue();
+    }
+
+    // ── Task/troubleshooting phrasing → ReasoningTraces, no intent override ──
+
+    [Theory]
+    [InlineData("Help me debug this error")]
+    [InlineData("Walk me through the workflow")]
+    [InlineData("What's the root cause of this bug?")]
+    public async Task DecideAsync_TaskOrientedPhrasing_IncludesReasoningTraces(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Categories.HasFlag(AutomaticRecallCategories.ReasoningTraces).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DecideAsync_NeverSetsExplicitRecallOptionsOverride()
+    {
+        // The heuristic policy only ever expresses itself via Categories/Intent, never a full override.
+        var decision = await _sut.DecideAsync(Context("Find a similar previous incident"));
+
+        decision.RecallOptions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecideAsync_MultipleUserMessages_JoinsThemForKeywordMatching()
+    {
+        var decision = await _sut.DecideAsync(Context("Tell me about the project.", "What's the latest update?"));
+
+        decision.Intent.Should().Be(RankingIntent.Latest);
+    }
+
+    // ── #88 review fix: greeting detection is a linear-time tokenizer, not a regex ──
+    // A previous regex-based implementation (a single repeating group with nested quantifiers) exhibited
+    // catastrophic backtracking -- verified experimentally to take multiple seconds on adversarial input.
+    // The tokenizer has no such failure mode; this test guards against a regex-based regression.
+
+    [Fact]
+    public async Task DecideAsync_ManyRepeatedGreetingFragments_CompletesQuickly()
+    {
+        var pathologicalInput = string.Concat(Enumerable.Repeat("hi ", 200)) + "X";
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var decision = await _sut.DecideAsync(Context(pathologicalInput));
+        sw.Stop();
+
+        sw.ElapsedMilliseconds.Should().BeLessThan(500);
+        // Trailing "X" is not a greeting/ack word, so this must NOT be treated as greeting-only.
+        decision.ShouldRecall.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DecideAsync_LongChainOfGenuineGreetingFragments_StillSkipsRecall()
+    {
+        var allGreetings = string.Concat(Enumerable.Repeat("ok, got it. thanks! ", 50));
+
+        var decision = await _sut.DecideAsync(Context(allGreetings));
+
+        decision.ShouldRecall.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DecideAsync_GreetingFollowedByRealQuestion_DoesNotSkipRecall()
+    {
+        // A greeting-only PREFIX must not cause the whole turn to be skipped once real content follows.
+        var decision = await _sut.DecideAsync(Context("Hi, what do I usually order for lunch?"));
+
+        decision.ShouldRecall.Should().BeTrue();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/ServiceCollectionExtensionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/ServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Recall;
 using AgentMemory.AgentFramework.Tools;
 using NSubstitute;
 
@@ -157,6 +158,65 @@ public sealed class ServiceCollectionExtensionsTests
         var sut = scope.ServiceProvider.GetRequiredService<Neo4jChatHistoryProvider>();
 
         sut.Should().NotBeNull();
+    }
+
+    // ── #88: task-aware automatic recall policy ────────────────────────────────
+
+    [Fact]
+    public void AddAgentMemoryFramework_RegistersConfiguredAutomaticRecallPolicy_AsScoped_ByDefault()
+    {
+        var services = BuildBaseServices();
+        services.AddAgentMemoryFramework();
+
+        services.Should().ContainSingle(d =>
+            d.ServiceType == typeof(IAutomaticRecallPolicy) &&
+            d.ImplementationType == typeof(ConfiguredAutomaticRecallPolicy) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddAgentMemoryFramework_ResolvesIAutomaticRecallPolicy_WithDependencies()
+    {
+        var provider = BuildBaseServices()
+            .AddAgentMemoryFramework()
+            .BuildServiceProvider();
+
+        using var scope = provider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<IAutomaticRecallPolicy>();
+
+        sut.Should().BeOfType<ConfiguredAutomaticRecallPolicy>();
+    }
+
+    [Fact]
+    public void AddAgentMemoryFramework_HostRegisteredPolicyBeforeCall_IsNotOverridden()
+    {
+        // TryAdd: a host that registers its own IAutomaticRecallPolicy before AddAgentMemoryFramework
+        // must keep that registration -- the built-in Configured policy must not clobber it.
+        var services = BuildBaseServices();
+        services.AddScoped<IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy>();
+        services.AddAgentMemoryFramework();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<IAutomaticRecallPolicy>();
+
+        sut.Should().BeOfType<HeuristicAutomaticRecallPolicy>();
+    }
+
+    [Fact]
+    public void AddAgentMemoryFramework_HostRegisteredPolicyAfterCall_WinsOverDefault()
+    {
+        // A host that registers its own IAutomaticRecallPolicy after AddAgentMemoryFramework must win --
+        // plain AddScoped appends, and the last registration is what resolves for a non-keyed service.
+        var services = BuildBaseServices();
+        services.AddAgentMemoryFramework();
+        services.AddScoped<IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy>();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<IAutomaticRecallPolicy>();
+
+        sut.Should().BeOfType<HeuristicAutomaticRecallPolicy>();
     }
 
     // ── idempotency ───────────────────────────────────────────────────────────

--- a/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/MemoryContextAssemblerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
@@ -186,6 +187,189 @@ public sealed class MemoryContextAssemblerTests
         result.RelevantEntities.Items.Should().BeEmpty();
         result.GraphRagContext.Should().Contain("graph-only context");
         result.BlendMode.Should().Be(RetrievalBlendMode.GraphRagOnly);
+    }
+
+    // ── #88: a zeroed per-category limit skips that category's retrieval entirely ──
+    // (as opposed to issuing a LIMIT/TopK 0 call whose result is always empty) -- this is what actually
+    // saves the embedding/database work a task-aware IAutomaticRecallPolicy is asking to avoid.
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxRecentMessagesZero_SkipsRecentMessagesCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxRecentMessages = 0 }
+        };
+
+        var result = await sut.AssembleContextAsync(request);
+
+        await _shortTerm.DidNotReceive()
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        result.RecentMessages.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxRelevantMessagesZero_SkipsSearchMessagesCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxRelevantMessages = 0 }
+        };
+
+        await sut.AssembleContextAsync(request);
+
+        await _shortTerm.DidNotReceive().SearchMessagesAsync(
+            Arg.Any<string?>(), Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxEntitiesZero_SkipsSearchEntitiesCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxEntities = 0 }
+        };
+
+        var result = await sut.AssembleContextAsync(request);
+
+        await _longTerm.DidNotReceive().SearchEntitiesAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        result.RelevantEntities.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxFactsZero_SkipsSearchFactsCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxFacts = 0 }
+        };
+
+        await sut.AssembleContextAsync(request);
+
+        await _longTerm.DidNotReceive().SearchFactsAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxPreferencesZero_SkipsSearchPreferencesCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxPreferences = 0 }
+        };
+
+        await sut.AssembleContextAsync(request);
+
+        await _longTerm.DidNotReceive().SearchPreferencesAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxTracesZero_SkipsSearchSimilarTracesCall()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxTraces = 0 }
+        };
+
+        await sut.AssembleContextAsync(request);
+
+        await _reasoning.DidNotReceive().SearchSimilarTracesAsync(
+            Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_MaxGraphRagItemsZero_SkipsGraphRagCall_EvenWhenEnabledAndBlended()
+    {
+        var options = Options.Create(new MemoryOptions { EnableGraphRag = true });
+        var sut = CreateSut(options: options, graphRag: _graphRag);
+        var request = CreateRequest(queryEmbedding: new float[1536], blendMode: RetrievalBlendMode.Blended) with
+        {
+            Options = RecallOptions.Default with { BlendMode = RetrievalBlendMode.Blended, MaxGraphRagItems = 0 }
+        };
+
+        var result = await sut.AssembleContextAsync(request);
+
+        await _graphRag.DidNotReceive()
+            .GetContextAsync(Arg.Any<GraphRagContextRequest>(), Arg.Any<CancellationToken>());
+        result.GraphRagContext.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_GraphRagOnly_MaxGraphRagItemsZero_WarnsInsteadOfSilentBlackout()
+    {
+        // #88 review finding: GraphRAG registered/enabled (graphRagAvailable=true) but this turn's
+        // effective MaxGraphRagItems is zero (e.g. an automatic recall policy excluded the GraphRag
+        // category) -- GraphRagOnly means nothing else is retrieved either, so this must be observable,
+        // not a silent completely-empty context every turn.
+        var logger = Substitute.For<ILogger<MemoryContextAssembler>>();
+        var options = Options.Create(new MemoryOptions { EnableGraphRag = true });
+        var sut = new MemoryContextAssembler(
+            _shortTerm, _longTerm, _reasoning, _graphRag, _embeddingOrchestrator, _clock,
+            options, logger, SingleTenantPolicy);
+        var request = CreateRequest(queryEmbedding: new float[1536], blendMode: RetrievalBlendMode.GraphRagOnly) with
+        {
+            Options = RecallOptions.Default with { BlendMode = RetrievalBlendMode.GraphRagOnly, MaxGraphRagItems = 0 }
+        };
+
+        var result = await sut.AssembleContextAsync(request);
+
+        await _graphRag.DidNotReceive()
+            .GetContextAsync(Arg.Any<GraphRagContextRequest>(), Arg.Any<CancellationToken>());
+        result.GraphRagContext.Should().BeNull();
+        var warned = logger.ReceivedCalls().Any(c =>
+            c.GetMethodInfo().Name == nameof(ILogger.Log) && c.GetArguments()[0] is LogLevel.Warning);
+        warned.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_AllCategoryLimitsZero_QueriesNothing_ReturnsEmptyContext()
+    {
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = new RecallOptions
+            {
+                MaxRecentMessages = 0, MaxRelevantMessages = 0, MaxEntities = 0,
+                MaxFacts = 0, MaxPreferences = 0, MaxTraces = 0, MaxGraphRagItems = 0
+            }
+        };
+
+        var result = await sut.AssembleContextAsync(request);
+
+        result.RecentMessages.Items.Should().BeEmpty();
+        result.RelevantMessages.Items.Should().BeEmpty();
+        result.RelevantEntities.Items.Should().BeEmpty();
+        result.RelevantFacts.Items.Should().BeEmpty();
+        result.RelevantPreferences.Items.Should().BeEmpty();
+        result.SimilarTraces.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsync_NonZeroLimits_StillQueriesNormally()
+    {
+        // Regression guard: the #88 gating must not accidentally suppress a normal, nonzero-limit recall.
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsync(CreateRequest(queryEmbedding: new float[1536]));
+
+        await _shortTerm.Received(1)
+            .GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        await _longTerm.Received(1).SearchEntitiesAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _longTerm.Received(1).SearchFactsAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _longTerm.Received(1).SearchPreferencesAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _reasoning.Received(1).SearchSimilarTracesAsync(
+            Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -618,6 +802,64 @@ public sealed class MemoryContextAssemblerTests
 
         result.RelevantEntities.Items.Should().BeEmpty();
         result.RelevantFacts.Items.Should().BeEmpty();
+    }
+
+    // ── #88: the same zero-limit gating applies to the bitemporal (AsOf) recall path ──
+
+    [Fact]
+    public async Task AssembleContextAsOfAsync_MaxEntitiesZero_SkipsSearchEntitiesAsOfCall()
+    {
+        _shortTerm
+            .GetRecentMessagesAsOfAsync(Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _longTerm
+            .SearchPreferencesAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Preference>>(Array.Empty<Preference>()));
+        _longTerm
+            .SearchFactsAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>()));
+        _reasoning
+            .SearchSimilarTracesAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(Array.Empty<ReasoningTrace>()));
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxEntities = 0 }
+        };
+
+        var result = await sut.AssembleContextAsOfAsync(request, _fixedTime);
+
+        await _longTerm.DidNotReceive().SearchEntitiesAsOfAsync(
+            Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        result.RelevantEntities.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AssembleContextAsOfAsync_MaxRecentMessagesZero_SkipsRecentMessagesAsOfCall()
+    {
+        _longTerm
+            .SearchEntitiesAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Entity>>(Array.Empty<Entity>()));
+        _longTerm
+            .SearchPreferencesAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Preference>>(Array.Empty<Preference>()));
+        _longTerm
+            .SearchFactsAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>()));
+        _reasoning
+            .SearchSimilarTracesAsOfAsync(Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(Array.Empty<ReasoningTrace>()));
+        var sut = CreateSut();
+        var request = CreateRequest(queryEmbedding: new float[1536]) with
+        {
+            Options = RecallOptions.Default with { MaxRecentMessages = 0 }
+        };
+
+        var result = await sut.AssembleContextAsOfAsync(request, _fixedTime);
+
+        await _shortTerm.DidNotReceive().GetRecentMessagesAsOfAsync(
+            Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        result.RecentMessages.Items.Should().BeEmpty();
     }
 
     // ---- Helpers ----


### PR DESCRIPTION
## Summary

Closes #88.

`Neo4jMemoryContextProvider` previously ran the same configured `RecallOptions` for every turn that had user text, regardless of whether the turn actually needed long-term memory. This PR introduces a pluggable policy layer that decides — before anything is queried — whether automatic recall is useful for the current turn, and if so, which memory categories, retrieval limits, and ranking intent to use.

- New `IAutomaticRecallPolicy.DecideAsync(AutomaticRecallContext, CancellationToken)` (`AgentMemory.AgentFramework.Recall`) returns an `AutomaticRecallDecision`: `ShouldRecall`, `Categories` (an `AutomaticRecallCategories` flags enum: `RecentMessages`/`RelevantMessages`/`Entities`/`Facts`/`Preferences`/`ReasoningTraces`/`GraphRag`), an optional `Intent` override, and an optional full `RecallOptions` override.
- `ConfiguredAutomaticRecallPolicy` (the default, registered by `AddAgentMemoryFramework`) always returns `Categories = All` with no overrides — this reproduces the pre-#88 behavior byte-for-byte.
- `HeuristicAutomaticRecallPolicy` is a lightweight, deterministic, model-call-free alternative: skips recall for a greeting/acknowledgement-only turn, uses `RankingIntent.Latest` for recency-oriented phrasing, `RankingIntent.Analog` plus reasoning traces for precedent-oriented phrasing, and includes reasoning traces for task/troubleshooting phrasing. Opt in via `services.AddScoped<IAutomaticRecallPolicy, HeuristicAutomaticRecallPolicy>()`, or supply a fully custom policy the same way — plain `AddScoped` wins over the `TryAdd`-registered default regardless of call order.
- Excluding a category zeroes its `RecallOptions.MaxX` limit, and `MemoryContextAssembler` (Core) now skips that category's repository call entirely (both the live and bitemporal recall paths) instead of issuing a `LIMIT`/`TopK` 0 query.
- `Scope` is always cleared from the effective options regardless of which policy/branch produced them — scope is always resolved from the invocation's authenticated `userId` (#100's isolation policy), never a statically configured or policy-supplied value.
- Fully additive; default behavior is unchanged.

## Self-review

Copilot PR review is unavailable, so this was reviewed via a 4-angle finder pass + direct verification against this diff before opening the PR (one finder even empirically timed the regex issue below in a scratch console app). Two real, confirmed bugs were found and fixed:

1. **GraphRAG silent blackout**: `HeuristicAutomaticRecallPolicy`'s baseline categories (`AutomaticRecallCategories.Default`) never included `GraphRag`, and no branch ever added it back. A host with GraphRAG configured who opted into this policy would find it silently, permanently disabled — and combined with `RetrievalBlendMode.GraphRagOnly`, would get a *completely empty* context every turn with no warning at all. Fixed by making the policy's baseline always retain `GraphRag` (it has no rule about GraphRAG, so it must never touch it), and by adding a `MemoryContextAssembler` warning when `GraphRagOnly` is requested and the effective `MaxGraphRagItems<=0` for any reason.
2. **Catastrophic-backtracking regex**: the original greeting/acknowledgement detector was a single regex with a nested-quantifier repeating group, empirically verified to take ~1.8s on a ~75-fragment adversarial input (and worse beyond that) — a real DoS vector for any host using the heuristic policy. Replaced with a linear-time tokenizer.

Also added: a regression test confirming `MinSimilarityScore`/`BlendMode` pass through unchanged in the partial-categories branch (a coverage gap the review flagged), and removed a redundant re-filter/re-join of an already-filtered message list in the heuristic policy.

## Test plan

- [x] Full unit suite: 2889/2889 passed
- [x] Full integration suite (live Neo4j via Testcontainers): 296/296 passed
- [x] New tests cover: policy skip/category-selection/intent-override/explicit-options-override wiring in `Neo4jMemoryContextProviderTests`, DI registration/precedence in `ServiceCollectionExtensionsTests`, zero-limit category skipping in both the live and bitemporal `MemoryContextAssemblerTests` paths (plus the new GraphRagOnly warning), and both built-in policies in their own test files (including a timed regression test guarding against the regex-backtracking fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)