### PR TITLE
feat: monotonic trust for facts on re-extraction (#92 Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ReasoningTrace` trust stamping, observed/inferred/verified knowledge distinctions, and richer telemetry
   are future phases.
 
+- **Monotonic trust for facts on re-extraction: Phase 5 of trust boundaries and prompt-injection defenses
+  (#92).** Phase 3 made entity trust monotonic but explicitly deferred the same protection for facts and
+  preferences, since neither had an equivalent pre-fetch step. `PersistenceStage` now pre-fetches any
+  existing fact with the same `{subject, predicate, object}` triple (via `IFactRepository.FindByTripleAsync`)
+  before persisting, and takes the higher of its existing trust level and the current call's — so an
+  ordinary, later, lower-trust re-extraction of an identical triple (e.g. a curated `ApplicationTrusted`
+  import later re-stated in a normal chat turn) can no longer silently erase the earlier elevation.
+  Deliberately scoped to **owner-scoped facts only**: `FindByTripleAsync`'s `MemoryScope?` parameter treats
+  an owner-less lookup as "search across every owner" (the read/recall convention) rather than "shared
+  bucket only" (the write convention for a `null` owner), so pre-fetching for a shared/global fact would
+  risk adopting a *different* owner's trust level — a cross-tenant leak. No existing repository primitive
+  supports a safe shared-bucket-only lookup, so shared/global facts keep today's fresh-stamp behavior; a
+  disclosed, narrower-than-ideal limitation, not a silent gap. **Preferences turned out not to need this
+  fix**: unlike facts, their extraction-time MERGE key is a freshly-generated id, not a natural key, so they
+  never collide with an existing node on re-extraction in the first place — correcting an earlier, less
+  precise description that grouped facts and preferences together. Proven live-Neo4j (not just at the
+  mocked-repository unit level): the same triple is extracted twice at two different trust levels, and the
+  surviving node — confirmed to be the same node, not a duplicate — keeps the higher one. Issue #92 remains
+  open — per-item (not per-request) trust attribution, `ReasoningTrace` trust stamping, observed/inferred/
+  verified knowledge distinctions, and richer telemetry are future phases.
+
 ## [1.2.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,17 +116,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before persisting, and takes the higher of its existing trust level and the current call's — so an
   ordinary, later, lower-trust re-extraction of an identical triple (e.g. a curated `ApplicationTrusted`
   import later re-stated in a normal chat turn) can no longer silently erase the earlier elevation.
-  Deliberately scoped to **owner-scoped facts only**: `FindByTripleAsync`'s `MemoryScope?` parameter treats
-  an owner-less lookup as "search across every owner" (the read/recall convention) rather than "shared
-  bucket only" (the write convention for a `null` owner), so pre-fetching for a shared/global fact would
-  risk adopting a *different* owner's trust level — a cross-tenant leak. No existing repository primitive
-  supports a safe shared-bucket-only lookup, so shared/global facts keep today's fresh-stamp behavior; a
-  disclosed, narrower-than-ideal limitation, not a silent gap. **Preferences turned out not to need this
-  fix**: unlike facts, their extraction-time MERGE key is a freshly-generated id, not a natural key, so they
-  never collide with an existing node on re-extraction in the first place — correcting an earlier, less
-  precise description that grouped facts and preferences together. Proven live-Neo4j (not just at the
-  mocked-repository unit level): the same triple is extracted twice at two different trust levels, and the
-  surviving node — confirmed to be the same node, not a duplicate — keeps the higher one. Issue #92 remains
+  Deliberately scoped to **owner-scoped facts only** (a null-or-empty `ownerId` skips the pre-fetch
+  entirely): `FindByTripleAsync`'s `MemoryScope?` parameter treats an owner-less lookup as "search across
+  every owner" (the read/recall convention) rather than "shared bucket only" (the write convention for a
+  `null` owner), so pre-fetching for a shared/global fact would risk adopting a *different* owner's trust
+  level — a cross-tenant leak. No existing repository primitive supports a safe shared-bucket-only lookup,
+  so shared/global facts keep today's fresh-stamp behavior; a disclosed, narrower-than-ideal limitation,
+  not a silent gap. The owner-scoped pre-fetch itself also excludes shared facts (`includeShared: false`,
+  the opposite of `MemoryScope.For`'s own default) — self-review caught that the default would let a
+  shared fact sharing the same triple be returned instead of this owner's own record (no `ORDER BY` before
+  `FindByTriple`'s `LIMIT 1`), grafting an unrelated shared record's entire metadata onto an owner-scoped
+  fact. Also fixed during self-review: a same-triple, different-casing re-extraction now persists under
+  the *existing* record's casing (found via `FindByTripleAsync`'s case-insensitive match) rather than the
+  freshly-extracted casing, since `Upsert`'s Cypher `MERGE` key is exact-string and would otherwise create
+  a duplicate node. **Preferences turned out not to need this fix**: unlike facts, their extraction-time
+  MERGE key is a freshly-generated id, not a natural key, so they never collide with an existing node on
+  re-extraction in the first place — correcting an earlier, less precise description that grouped facts
+  and preferences together. Proven live-Neo4j (not just at the mocked-repository unit level): the same
+  triple is extracted twice at two different trust levels, and the surviving node — confirmed to be the
+  same node, not a duplicate — keeps the higher one. Issue #92 remains
   open — per-item (not per-request) trust attribution, `ReasoningTrace` trust stamping, observed/inferred/
   verified knowledge distinctions, and richer telemetry are future phases.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,15 +209,31 @@ earlier elevation. `PersistenceStage` now pre-fetches any existing fact with the
 level and the current call's — the same `MaxTrustLevel` logic Phase 3 already established for entities,
 preserving any other pre-existing `Metadata` keys along the way.
 
-**Deliberately scoped to owner-scoped facts only.** `FindByTripleAsync`'s `MemoryScope?` parameter
-follows the read/recall convention where an owner-less lookup means "search across every owner" — the
-opposite of what a `null` `ownerId` means on the write side (the shared/global bucket). Pre-fetching with
-an owner-less scope for a shared/global fact would risk adopting a *different* owner's trust level into a
-shared fact — a cross-tenant leak. Unlike `FindDuplicateAsync` (whose raw `ownerId` parameter is
-documented as "null → shared bucket only"), no existing repository primitive supports a safe
-shared-bucket-only lookup, so the pre-fetch is skipped entirely when `ownerId` is `null`; shared/global
-facts keep today's fresh-stamp behavior. This is a disclosed, narrower-than-ideal limitation, not a
-silent gap.
+**Deliberately scoped to owner-scoped facts only, and deliberately excludes shared facts from the
+pre-fetch itself.** `FindByTripleAsync`'s `MemoryScope?` parameter follows the read/recall convention
+where an owner-less lookup means "search across every owner" — the opposite of what a `null` `ownerId`
+means on the write side (the shared/global bucket). Pre-fetching with an owner-less scope for a
+shared/global fact would risk adopting a *different* owner's trust level into a shared fact — a
+cross-tenant leak. Unlike `FindDuplicateAsync` (whose raw `ownerId` parameter is documented as "null →
+shared bucket only"), no existing repository primitive supports a safe shared-bucket-only lookup, so the
+pre-fetch is skipped entirely when `ownerId` is null-or-empty (`string.IsNullOrEmpty`, matching
+`DefaultMemoryIsolationPolicy`'s own null/empty treatment — an early version checked `ownerId is null`
+only, missing the empty-string case); shared/global facts keep today's fresh-stamp behavior. This is a
+disclosed, narrower-than-ideal limitation, not a silent gap.
+
+For owner-scoped facts, the pre-fetch also passes `includeShared: false` — the opposite of
+`MemoryScope.For`'s own default. The default (include shared) is right for reads (surface everything the
+caller may see), but wrong here: `FindByTriple`'s Cypher has no `ORDER BY` before its `LIMIT 1`, so with
+the default, a shared fact and this owner's own fact could both match the same triple and which one comes
+back is unspecified — silently grafting an *unrelated* shared record's entire `Metadata` (not just its
+trust level) onto this owner's fact. Excluding shared facts from the pre-fetch confines it to "does this
+owner already have their own copy of this exact fact," which is the only question this fix needs to ask.
+
+`FindByTripleAsync` also matches case-insensitively, while `Upsert`'s Cypher `MERGE` key is an
+exact-string match. If a match is found, the fact actually persisted reuses the **existing** record's
+`Subject`/`Predicate`/`Object` (not the freshly-extracted casing) — otherwise a same-triple,
+different-casing re-extraction would `MERGE` onto a *different* node than the one just found, creating an
+unwanted duplicate that also inherits the found record's trust level instead of updating it in place.
 
 **Preferences are unaffected by this specific issue and don't need the same fix.** Unlike facts,
 `Neo4jPreferenceRepository`'s MERGE key is the freshly-generated `PreferenceId` (`MERGE (p:Preference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,6 +192,48 @@ Item-level transactionality (e.g. a fact and its provenance edges committing ato
 explicit non-goal of #101 — Neo4j write ordering here is still best-effort, not atomic, and nothing
 in the API claims otherwise.
 
+#### 3.2.2 Monotonic trust for facts on re-extraction (#92 Phase 5)
+
+Phase 3 made entity trust monotonic (re-resolving onto an already-`ApplicationTrusted` entity never
+silently downgrades it) but explicitly deferred the same protection for facts and preferences, since
+neither has an equivalent pre-fetch step: entity resolution hands `PersistenceStage` the existing,
+previously-persisted record for free when it resolves a mention onto a known entity, but facts and
+preferences flow straight from extraction into `PersistenceStage` with no such lookup.
+
+Phase 5 closes this gap **for facts only**: `Neo4jFactRepository.UpsertAsync` MERGEs on the exact
+`{subject, predicate, object, owner}` triple, and its Cypher `ON MATCH SET` unconditionally overwrites
+`metadata` — so re-extracting the identical triple at a lower trust level (e.g. an ordinary later chat
+turn re-stating a fact originally imported at `ApplicationTrusted`) would otherwise silently erase the
+earlier elevation. `PersistenceStage` now pre-fetches any existing fact with the same triple via
+`IFactRepository.FindByTripleAsync` before persisting, and takes the higher of the existing fact's trust
+level and the current call's — the same `MaxTrustLevel` logic Phase 3 already established for entities,
+preserving any other pre-existing `Metadata` keys along the way.
+
+**Deliberately scoped to owner-scoped facts only.** `FindByTripleAsync`'s `MemoryScope?` parameter
+follows the read/recall convention where an owner-less lookup means "search across every owner" — the
+opposite of what a `null` `ownerId` means on the write side (the shared/global bucket). Pre-fetching with
+an owner-less scope for a shared/global fact would risk adopting a *different* owner's trust level into a
+shared fact — a cross-tenant leak. Unlike `FindDuplicateAsync` (whose raw `ownerId` parameter is
+documented as "null → shared bucket only"), no existing repository primitive supports a safe
+shared-bucket-only lookup, so the pre-fetch is skipped entirely when `ownerId` is `null`; shared/global
+facts keep today's fresh-stamp behavior. This is a disclosed, narrower-than-ideal limitation, not a
+silent gap.
+
+**Preferences are unaffected by this specific issue and don't need the same fix.** Unlike facts,
+`Neo4jPreferenceRepository`'s MERGE key is the freshly-generated `PreferenceId` (`MERGE (p:Preference
+{id: $id})`), not a natural key — so `PersistenceStage`'s extraction-time upsert never collides with an
+existing preference node in the first place; every extracted preference becomes a genuinely new node.
+The only path that reinforces an *existing* preference (`LongTermMemoryService`'s vector-similarity
+dedup-on-create, via `MarkDeduplicatedAsync`) only touches `confidence`, never `metadata` — so it carries
+no trust-downgrade risk either. (An earlier, less precise description of this limitation grouped facts
+and preferences together; this section supersedes it.)
+
+Proven live-Neo4j, not just at the mocked-repository unit level (`ExtractionOwnerStampIntegrationTests.
+FullExtractionPipeline_FactReExtractedAtLowerTrust_DoesNotDowngradeExistingHigherTrust`): the same
+"Ada works_at Acme" triple is extracted twice — first at `ApplicationTrusted`, then at a lower
+`UserProvided` — and the surviving node (confirmed to be the *same* node, not a duplicate) keeps its
+higher trust level.
+
 ### 3.3 AgentMemory.Neo4j
 
 | Attribute | Value |
@@ -356,13 +398,11 @@ speculative field in `Metadata` until its shape proves stable — see the backlo
   resolved match for a brand-new, unrelated mention. `PersistenceStage` takes the higher of the entity's
   existing trust level and the current call's, so an unrelated later low-trust mention can never silently
   erase an earlier, deliberate elevation (e.g. from a curated `ApplicationTrusted` import). **Known,
-  disclosed limitation:** the same protection does not yet extend to facts/preferences — those persist via
-  an unconditional `MERGE ... ON MATCH SET metadata = $metadata` (the same overwrite-on-re-extraction
-  semantics every other field on `Fact`/`Preference`, e.g. `Confidence`, already has), so a fact/preference
-  re-derived by a lower-trust extraction after being persisted at a higher trust level will have its trust
-  level (and every other metadata key) overwritten. Preserving it would need `PersistenceStage` to fetch the
-  existing fact/preference before upserting (entities get this for free via resolution; facts/preferences
-  don't have an equivalent pre-fetch step today) — deferred to a future phase.
+  disclosed limitation at the time of Phase 3:** the same protection did not yet extend to facts/preferences.
+  **Superseded by Phase 5** (§3.2.2): facts now get the same monotonic protection, scoped to owner-scoped
+  facts (shared/global facts remain a disclosed gap, for a different, cross-tenant-safety reason — see
+  §3.2.2). Preferences turned out not to need it: their extraction-time MERGE key is a fresh id, not a
+  natural key, so they never collide on re-extraction in the first place.
 - **Security: `trust_level` is a framework-reserved metadata key.** Because trust level lives in the same
   `Metadata` dictionary a caller can already populate through pre-existing, unrelated write paths — the
   `memory_add_fact` MCP tool's `metadataJson` parameter, and the public `IReasoningMemoryService.StartTraceAsync`

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -158,19 +158,33 @@ internal sealed class PersistenceStage : IPersistenceStage
                 // free, so this pre-fetch is the "one extra round-trip" the Phase 3 doc flagged as needed.
                 // A lookup failure falls through to the same catch below as an ordinary persistence failure.
                 //
-                // Only performed when ownerId is set: FindByTripleAsync's MemoryScope? parameter follows the
-                // read/recall convention where an unscoped lookup (null, or a scope with no OwnerId) means
-                // "search across every owner" -- the opposite of what a null ownerId means on the WRITE side
-                // (the shared/global bucket). Passing an owner-less scope here would risk adopting another
-                // owner's trust level into a shared fact -- a cross-tenant leak. Unlike FindDuplicateAsync
-                // (whose raw ownerId parameter is documented as "null -> shared bucket only"), there is no
-                // existing repository primitive for a safe shared-bucket-only lookup, so shared/global facts
-                // don't get this protection yet -- a disclosed, narrower-than-ideal limitation for this phase.
-                Fact? existingFact = ownerId is null
+                // Only performed when ownerId is set (string.IsNullOrEmpty, matching how the rest of this
+                // codebase treats an empty owner id the same as a null one -- e.g. DefaultMemoryIsolationPolicy):
+                // FindByTripleAsync's MemoryScope? parameter follows the read/recall convention where an
+                // unscoped lookup (null, or a scope with no OwnerId) means "search across every owner" -- the
+                // opposite of what a null ownerId means on the WRITE side (the shared/global bucket). Passing
+                // an owner-less scope here would risk adopting another owner's trust level into a shared fact
+                // -- a cross-tenant leak. Unlike FindDuplicateAsync (whose raw ownerId parameter is documented
+                // as "null -> shared bucket only"), there is no existing repository primitive for a safe
+                // shared-bucket-only lookup, so shared/global facts don't get this protection yet -- a
+                // disclosed, narrower-than-ideal limitation for this phase.
+                //
+                // includeShared: false -- deliberately excludes shared/global facts from the pre-fetch even
+                // though MemoryScope.For defaults to including them. The default is right for READS (surface
+                // everything the caller may see), but wrong here: with no ORDER BY, a shared fact and this
+                // owner's own fact could both match the same triple, and picking up the shared one would
+                // graft an unrelated record's ENTIRE metadata (not just its trust level) onto this owner's
+                // fact -- conflating two conceptually distinct records that merely share text.
+                //
+                // FindByTripleAsync matches case-insensitively but Upsert's MERGE key is an exact-string
+                // match -- if a match is found, this fact is built from the EXISTING record's Subject/
+                // Predicate/Object (not the freshly-extracted casing) so the subsequent Upsert's MERGE
+                // still targets the SAME node instead of creating a same-triple, different-casing duplicate.
+                Fact? existingFact = string.IsNullOrEmpty(ownerId)
                     ? null
                     : await _factRepository.FindByTripleAsync(
                         extracted.Subject, extracted.Predicate, extracted.Object,
-                        MemoryScope.For(ownerId), cancellationToken).ConfigureAwait(false);
+                        MemoryScope.For(ownerId, includeShared: false), cancellationToken).ConfigureAwait(false);
                 var effectiveFactTrustLevel = existingFact is null
                     ? trustLevel
                     : MaxTrustLevel(existingFact.Metadata.GetTrustLevel(), trustLevel);
@@ -181,9 +195,9 @@ internal sealed class PersistenceStage : IPersistenceStage
                 var fact = new Fact
                 {
                     FactId = _idGenerator.GenerateId(),
-                    Subject = extracted.Subject,
-                    Predicate = extracted.Predicate,
-                    Object = extracted.Object,
+                    Subject = existingFact?.Subject ?? extracted.Subject,
+                    Predicate = existingFact?.Predicate ?? extracted.Predicate,
+                    Object = existingFact?.Object ?? extracted.Object,
                     Confidence = extracted.Confidence,
                     ValidFrom = extracted.ValidFrom,
                     ValidUntil = extracted.ValidUntil,

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -149,6 +149,35 @@ internal sealed class PersistenceStage : IPersistenceStage
 
             try
             {
+                // Trust is monotonic for owner-scoped facts too (#92 Phase 5), mirroring entities (Phase 3):
+                // the repository's Upsert MERGEs on the exact {subject,predicate,object,owner} triple and its
+                // Cypher ON MATCH unconditionally overwrites metadata, so re-extracting the identical triple
+                // at a lower trust level (e.g. an ordinary chat turn re-stating a fact originally imported at
+                // ApplicationTrusted) would otherwise silently erase the earlier elevation. Unlike entities,
+                // facts have no upstream resolution step that hands PersistenceStage the prior record for
+                // free, so this pre-fetch is the "one extra round-trip" the Phase 3 doc flagged as needed.
+                // A lookup failure falls through to the same catch below as an ordinary persistence failure.
+                //
+                // Only performed when ownerId is set: FindByTripleAsync's MemoryScope? parameter follows the
+                // read/recall convention where an unscoped lookup (null, or a scope with no OwnerId) means
+                // "search across every owner" -- the opposite of what a null ownerId means on the WRITE side
+                // (the shared/global bucket). Passing an owner-less scope here would risk adopting another
+                // owner's trust level into a shared fact -- a cross-tenant leak. Unlike FindDuplicateAsync
+                // (whose raw ownerId parameter is documented as "null -> shared bucket only"), there is no
+                // existing repository primitive for a safe shared-bucket-only lookup, so shared/global facts
+                // don't get this protection yet -- a disclosed, narrower-than-ideal limitation for this phase.
+                Fact? existingFact = ownerId is null
+                    ? null
+                    : await _factRepository.FindByTripleAsync(
+                        extracted.Subject, extracted.Predicate, extracted.Object,
+                        MemoryScope.For(ownerId), cancellationToken).ConfigureAwait(false);
+                var effectiveFactTrustLevel = existingFact is null
+                    ? trustLevel
+                    : MaxTrustLevel(existingFact.Metadata.GetTrustLevel(), trustLevel);
+                var factMetadata = existingFact is null
+                    ? MemoryTrustMetadataExtensions.CreateWithTrustLevel(effectiveFactTrustLevel)
+                    : existingFact.Metadata.WithTrustLevel(effectiveFactTrustLevel);
+
                 var fact = new Fact
                 {
                     FactId = _idGenerator.GenerateId(),
@@ -162,7 +191,7 @@ internal sealed class PersistenceStage : IPersistenceStage
                     OwnerId = ownerId,
                     SourceMessageIds = sourceMessageIds,
                     CreatedAtUtc = _clock.UtcNow,
-                    Metadata = MemoryTrustMetadataExtensions.CreateWithTrustLevel(trustLevel)
+                    Metadata = factMetadata
                 };
 
                 await _factRepository.UpsertAsync(fact, cancellationToken).ConfigureAwait(false);

--- a/tests/AgentMemory.Tests.Integration/Extraction/ExtractionOwnerStampIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Extraction/ExtractionOwnerStampIntegrationTests.cs
@@ -215,6 +215,76 @@ public sealed class ExtractionOwnerStampIntegrationTests : IAsyncLifetime
         preference.Metadata.GetTrustLevel().Should().Be(MemoryTrustLevel.ApplicationTrusted);
     }
 
+    /// <summary>
+    /// Live-Neo4j proof of #92 Phase 5's monotonic-trust fix for facts: <c>Neo4jFactRepository.UpsertAsync</c>
+    /// MERGEs on the exact {subject,predicate,object,owner} triple and its Cypher <c>ON MATCH SET</c>
+    /// unconditionally overwrites <c>metadata</c> -- a purely in-process unit test with a mocked repository
+    /// cannot prove this actually holds against real MERGE semantics, only that <c>PersistenceStage</c> calls
+    /// the right methods. Re-extracts the identical "Ada works_at Acme" triple twice, first at
+    /// <c>ApplicationTrusted</c> then at a lower <c>UserProvided</c>, and confirms the surviving node's trust
+    /// level is never downgraded -- and that it is still exactly one node, not two.
+    /// </summary>
+    [Fact]
+    public async Task FullExtractionPipeline_FactReExtractedAtLowerTrust_DoesNotDowngradeExistingHigherTrust()
+    {
+        using var scope = _provider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        var shortTerm = sp.GetRequiredService<IShortTermMemoryService>();
+        var pipeline = sp.GetRequiredService<IMemoryExtractionPipeline>();
+        var facts = sp.GetRequiredService<IFactRepository>();
+        var aliceScope = MemoryScope.For("alice");
+
+        const string sessionId = "session-trust-monotonic";
+        const string conversationId = "conv-trust-monotonic";
+        await shortTerm.AddConversationAsync(conversationId, sessionId, userId: "alice");
+
+        // First extraction: a curated/verified import, stamped ApplicationTrusted.
+        var firstMessage = await shortTerm.AddMessageAsync(new Message
+        {
+            MessageId = $"m-{Guid.NewGuid():N}",
+            ConversationId = conversationId,
+            SessionId = sessionId,
+            Role = "user",
+            Content = "Ada works at Acme and prefers dark mode.",
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+        await pipeline.ExtractAsync(new ExtractionRequest
+        {
+            SessionId = sessionId,
+            UserId = "alice",
+            Messages = [firstMessage],
+            TrustLevel = MemoryTrustLevel.ApplicationTrusted
+        });
+
+        var factAfterFirst = await facts.FindByTripleAsync("Ada", "works_at", "Acme", scope: aliceScope);
+        factAfterFirst!.Metadata.GetTrustLevel().Should().Be(MemoryTrustLevel.ApplicationTrusted);
+
+        // Second extraction: an ordinary later turn re-stating the identical triple, at a lower trust level.
+        var secondMessage = await shortTerm.AddMessageAsync(new Message
+        {
+            MessageId = $"m-{Guid.NewGuid():N}",
+            ConversationId = conversationId,
+            SessionId = sessionId,
+            Role = "user",
+            Content = "Ada works at Acme and prefers dark mode.",
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+        await pipeline.ExtractAsync(new ExtractionRequest
+        {
+            SessionId = sessionId,
+            UserId = "alice",
+            Messages = [secondMessage],
+            TrustLevel = MemoryTrustLevel.UserProvided
+        });
+
+        var factAfterSecond = await facts.FindByTripleAsync("Ada", "works_at", "Acme", scope: aliceScope);
+        factAfterSecond.Should().NotBeNull();
+        factAfterSecond!.Metadata.GetTrustLevel().Should().Be(MemoryTrustLevel.ApplicationTrusted,
+            "a later, ordinary, lower-trust re-extraction of the identical triple must never silently downgrade an earlier deliberate elevation");
+        factAfterSecond.FactId.Should().Be(factAfterFirst.FactId, "the Cypher MERGE must still collapse re-extraction onto the SAME node, not create a second one");
+    }
+
     // ── Deterministic test extractors ──
     // The default Stub*Extractor registrations produce no output (Phase-1 no-ops), so a live test needs
     // real-ish extractors that deterministically produce one of each type plus a relationship between two

--- a/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
@@ -731,11 +731,13 @@ public sealed class PersistenceStageTests
     }
 
     [Fact]
-    public async Task PersistAsync_Fact_NoExistingTripleFound_LooksUpByTheExtractedTripleAndOwnerScope()
+    public async Task PersistAsync_Fact_NoExistingTripleFound_LooksUpByTheExtractedTripleAndOwnerScope_ExcludingShared()
     {
         // Wiring check: the pre-fetch must query by the extracted triple, scoped to the same owner the
         // fact is about to be persisted under -- otherwise it could leak another owner's trust level or
-        // never find same-owner history at all.
+        // never find same-owner history at all. IncludeShared must be false: without it, a shared/global
+        // fact sharing the same triple could be returned instead of (or nondeterministically alongside)
+        // this owner's own record, grafting an unrelated record's entire metadata onto this owner's fact.
         var extraction = EmptyResult() with
         {
             FilteredFacts = new[] { new ExtractedFact { Subject = "Ada", Predicate = "works_at", Object = "Acme", Confidence = 0.9 } }
@@ -746,7 +748,7 @@ public sealed class PersistenceStageTests
 
         await _factRepo.Received(1).FindByTripleAsync(
             "Ada", "works_at", "Acme",
-            Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"),
+            Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice" && s.IncludeShared == false),
             Arg.Any<CancellationToken>());
     }
 
@@ -770,6 +772,57 @@ public sealed class PersistenceStageTests
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
         await _factRepo.Received(1).UpsertAsync(
             Arg.Is<Fact>(f => f.Metadata.GetTrustLevel() == MemoryTrustLevel.UserProvided),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_EmptyStringOwnerId_AlsoSkipsThePreFetch_LikeNullOwnerId()
+    {
+        // Regression: an earlier version of this guard checked `ownerId is null` only. The rest of this
+        // codebase treats an empty-string owner id the same as null (e.g. DefaultMemoryIsolationPolicy),
+        // and ExtractionRequest.UserId is an unvalidated string? -- an empty string reaching this far must
+        // not slip past the guard and trigger an unscoped (MemoryScope.For("").HasOwnerFilter == false)
+        // cross-tenant lookup.
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: "", trustLevel: MemoryTrustLevel.UserProvided);
+
+        await _factRepo.DidNotReceive().FindByTripleAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_ExistingRecordHasDifferentCasing_PersistsUnderTheExistingCasing_NotADuplicate()
+    {
+        // Regression: FindByTripleAsync matches case-insensitively, but Upsert's Cypher MERGE key is an
+        // exact-string match. If the newly-extracted casing were used to build the Fact to persist, the
+        // MERGE would target a DIFFERENT node than the one just found -- creating a same-triple,
+        // different-casing duplicate that also inherits the found record's (higher) trust level instead of
+        // updating it in place. Persisting under the EXISTING record's casing keeps the MERGE on one node.
+        var existingFact = new Fact
+        {
+            FactId = "f-existing", Subject = "Ada", Predicate = "works_at", Object = "Acme", Confidence = 0.9,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Metadata = new Dictionary<string, object>().WithTrustLevel(MemoryTrustLevel.ApplicationTrusted)
+        };
+        _factRepo.FindByTripleAsync("ada", "WORKS_AT", "acme", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(existingFact);
+
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "ada", Predicate = "WORKS_AT", Object = "acme", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: "alice", trustLevel: MemoryTrustLevel.UserProvided);
+
+        await _factRepo.Received(1).UpsertAsync(
+            Arg.Is<Fact>(f => f.Subject == "Ada" && f.Predicate == "works_at" && f.Object == "Acme"
+                && f.Metadata.GetTrustLevel() == MemoryTrustLevel.ApplicationTrusted),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/PersistenceStageTests.cs
@@ -645,6 +645,134 @@ public sealed class PersistenceStageTests
             Arg.Any<CancellationToken>());
     }
 
+    // ── #92 Phase 5: monotonic trust for facts on exact-triple re-extraction ─
+
+    [Fact]
+    public async Task PersistAsync_Fact_ExistingSameTripleAlreadyTrusted_DoesNotDowngradeTrust()
+    {
+        // Trust is monotonic for facts too (#92 Phase 5), mirroring entities (Phase 3): the repository's
+        // Upsert MERGEs on the exact {subject,predicate,object,owner} triple and ON MATCH unconditionally
+        // overwrites metadata, so PersistenceStage now pre-fetches any existing fact with the same triple
+        // and never lets a later, ordinary, lower-trust re-extraction erase an earlier deliberate elevation.
+        var alreadyTrustedFact = new Fact
+        {
+            FactId = "f-existing", Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Metadata = new Dictionary<string, object>().WithTrustLevel(MemoryTrustLevel.ApplicationTrusted)
+        };
+        _factRepo.FindByTripleAsync("user", "lives in", "Zurich", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(alreadyTrustedFact);
+
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        // ownerId set: the pre-fetch only runs for owner-scoped facts (see the disclosed limitation in
+        // PersistenceStage.cs -- an owner-less lookup would risk a cross-tenant read).
+        await sut.PersistAsync(extraction, ownerId: "alice", trustLevel: MemoryTrustLevel.UserProvided); // an ordinary later mention
+
+        await _factRepo.Received(1).UpsertAsync(
+            Arg.Is<Fact>(f => f.Metadata.GetTrustLevel() == MemoryTrustLevel.ApplicationTrusted),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_ExistingSameTripleLowerTrust_UpgradesToTheNewHigherTrust()
+    {
+        var previouslyUntrustedFact = new Fact
+        {
+            FactId = "f-existing", Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Metadata = new Dictionary<string, object>().WithTrustLevel(MemoryTrustLevel.UserProvided)
+        };
+        _factRepo.FindByTripleAsync("user", "lives in", "Zurich", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(previouslyUntrustedFact);
+
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: "alice", trustLevel: MemoryTrustLevel.ApplicationTrusted);
+
+        await _factRepo.Received(1).UpsertAsync(
+            Arg.Is<Fact>(f => f.Metadata.GetTrustLevel() == MemoryTrustLevel.ApplicationTrusted),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_ExistingSameTriple_OtherMetadataKeysArePreserved()
+    {
+        var existingFact = new Fact
+        {
+            FactId = "f-existing", Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Metadata = new Dictionary<string, object> { ["custom_key"] = "custom_value" }
+        };
+        _factRepo.FindByTripleAsync("user", "lives in", "Zurich", Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(existingFact);
+
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: "alice", trustLevel: MemoryTrustLevel.VerifiedExternal);
+
+        await _factRepo.Received(1).UpsertAsync(
+            Arg.Is<Fact>(f =>
+                f.Metadata.GetTrustLevel() == MemoryTrustLevel.VerifiedExternal &&
+                f.Metadata.ContainsKey("custom_key") && (string)f.Metadata["custom_key"] == "custom_value"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_NoExistingTripleFound_LooksUpByTheExtractedTripleAndOwnerScope()
+    {
+        // Wiring check: the pre-fetch must query by the extracted triple, scoped to the same owner the
+        // fact is about to be persisted under -- otherwise it could leak another owner's trust level or
+        // never find same-owner history at all.
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "Ada", Predicate = "works_at", Object = "Acme", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: "alice", trustLevel: MemoryTrustLevel.UserProvided);
+
+        await _factRepo.Received(1).FindByTripleAsync(
+            "Ada", "works_at", "Acme",
+            Arg.Is<MemoryScope?>(s => s != null && s.OwnerId == "alice"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PersistAsync_Fact_SharedGlobalFact_SkipsThePreFetch_DisclosedLimitation()
+    {
+        // Disclosed limitation: FindByTripleAsync's MemoryScope? parameter treats an owner-less lookup as
+        // "search across every owner" (the read/recall convention), not "shared bucket only" (the write
+        // convention for a null ownerId) -- so pre-fetching for a shared/global fact would risk adopting
+        // another owner's trust level. Shared/global facts therefore don't get monotonic-trust protection
+        // yet; they keep today's fresh-stamp behavior, and the lookup must not be attempted at all.
+        var extraction = EmptyResult() with
+        {
+            FilteredFacts = new[] { new ExtractedFact { Subject = "user", Predicate = "lives in", Object = "Zurich", Confidence = 0.9 } }
+        };
+
+        var sut = CreateSut();
+        await sut.PersistAsync(extraction, ownerId: null, trustLevel: MemoryTrustLevel.UserProvided);
+
+        await _factRepo.DidNotReceive().FindByTripleAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _factRepo.Received(1).UpsertAsync(
+            Arg.Is<Fact>(f => f.Metadata.GetTrustLevel() == MemoryTrustLevel.UserProvided),
+            Arg.Any<CancellationToken>());
+    }
+
     // ── #101: structured ingestion outcomes ─────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Phase 5 of issue #92 (trust boundaries / prompt-injection defenses). Phase 3 made entity trust monotonic (re-resolving onto an already-`ApplicationTrusted` entity never silently downgrades it) but explicitly deferred the same protection for facts and preferences, since neither had an equivalent pre-fetch step.

- `PersistenceStage` now pre-fetches any existing fact with the same `{subject, predicate, object}` triple (via `IFactRepository.FindByTripleAsync`) before persisting, and takes the higher of its existing trust level and the current call's — mirroring the entity fix's `MaxTrustLevel` logic.
- **Deliberately scoped to owner-scoped facts only** (null-or-empty `ownerId` skips the pre-fetch entirely): `FindByTripleAsync`'s `MemoryScope?` parameter treats an owner-less lookup as "search across every owner" (the read/recall convention), not "shared bucket only" (the write convention) — pre-fetching for a shared/global fact would risk adopting a *different* owner's trust level, a cross-tenant leak. Disclosed, narrower-than-ideal limitation, not a silent gap.
- **Preferences turned out not to need this fix**: unlike facts, their extraction-time MERGE key is a freshly-generated id, not a natural key, so they never collide with an existing node on re-extraction in the first place — this corrects an earlier, less precise description (from the Phase 3 doc) that grouped facts and preferences together.
- Proven live-Neo4j, not just at the mocked-repository unit level: the same triple is extracted twice at two different trust levels, and the surviving node (confirmed to be the same node, not a duplicate) keeps the higher one.

## Self-review

Ran the established 3-parallel-finder-agent self-review. Two agents independently converged on the same two real bugs in the initial implementation, plus a third distinct one:

1. The pre-fetch guard checked `ownerId is null` only — missed empty-string `ownerId`, which `MemoryScope.HasOwnerFilter` treats the same as "no filter," so an empty-string owner would trigger an unscoped, cross-tenant lookup. Fixed to `string.IsNullOrEmpty`, matching the rest of the codebase's null/empty-owner convention.
2. The pre-fetch used `MemoryScope.For(ownerId)`'s default `includeShared: true`, so a shared/global fact sharing the same triple could be returned instead of this owner's own record (`FindByTriple` has no `ORDER BY` before its `LIMIT 1`) — grafting an unrelated shared record's *entire* metadata onto an owner-scoped fact. Fixed to `includeShared: false`.
3. `FindByTripleAsync` matches case-insensitively but `Upsert`'s Cypher `MERGE` key is exact-string — a same-triple, different-casing re-extraction would have `MERGE`d onto a *different* node than the one just found, creating a duplicate that inherited the found record's trust level instead of updating it in place. Fixed: the fact now persists under the existing record's casing when found.

All three are covered by new regression tests (unit + the pre-existing live-Neo4j test path).

## Test plan

- [x] Full unit suite: 2982/2982 passing (Release build, 0 warnings)
- [x] Full live-Neo4j integration suite: 299/299 passing, including the new bundled cross-extraction test
- [x] Manual self-review (3 parallel finder agents: correctness, cross-file/removed-behavior, cleanup/conventions) — findings triaged and fixed
- [x] `docs/architecture.md` §3.2.2 and `CHANGELOG.md` updated

Issue #92 stays open — per-item (not per-request) trust attribution, `ReasoningTrace` trust stamping, observed/inferred/verified knowledge distinctions, and richer telemetry remain future phases.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>