### PR TITLE
NAMS Phase 0: baseline freeze + contract discovery

### DIFF
--- a/docs/reviews/NAMS_Phase0_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase0_PlanningAndImplementationPlan.md
@@ -1,0 +1,94 @@
+# NAMS Phase 0 — Planning and Implementation Plan
+
+**Prepared:** 2026-07-17
+**Branch:** `nams/phase0-baseline-freeze`
+**Purpose:** Phase 1 of a 3-phase plan (stabilization [done, #127] → **this phase: NAMS Phase 0 baseline freeze** → NAMS package skeleton). Executes the "Phase 0: Contract confirmation and baseline freeze" section of `strategy/AgentMemory_NAMS_Backend_Engineering_Plan_V03.md` (§7), whose own "no-code gate" says production NAMS code must not start until this phase's unknowns are answered or explicitly deferred.
+
+---
+
+## 1. Task and scope
+
+The NAMS plan's own Phase 0 task list (§7) has 7 items. Four are things I can do directly against this repository; two require a live NAMS sandbox or a direct answer from Neo4j (out of my reach — I can only *record* them as open questions, not resolve them); one is a documentation/issue-tracking task.
+
+| # | Plan's task | In scope for me? | How |
+|---|---|---|---|
+| 1 | Record the exact target commit SHA | Yes | `git log -1` on `main` post-stabilization-merge |
+| 2 | Create a release tag or immutable baseline branch | Yes | Annotated, non-destructive git tag |
+| 3 | Run and archive: Release build, unit suite, live-Neo4j integration suite, TCK suites, public API compatibility checks, package build, sample build | Yes | All runnable locally; TCK is already part of the integration suite (`docs/neo4j-memory-ecosystem.md` confirms 178/178 Bronze/Silver/Gold) |
+| 4 | Record test counts/duration/package versions/target frameworks/benchmark baselines/warning count/public API snapshot | Yes | Derived from #3's runs; public API snapshot needs a lightweight one-off tool (no `Microsoft.CodeAnalysis.PublicApiAnalyzers`/`PublicAPI.txt` exists in this repo today — confirmed by grep, not assumed) |
+| 5 | Confirm with Neo4j (client canonicity, versioning, auth, idempotency, rate limits, etc.) | **No — requires a human conversation with Neo4j** | Record as open questions in a tracking issue instead of resolving them |
+| 6 | Obtain/generate an immutable API contract snapshot (OpenAPI or fixture) | **Partial — best-effort only** | Attempt `WebFetch` against the public NAMS REST reference/limits pages; if no machine-readable OpenAPI doc is published, hand-transcribe the confirmed endpoints from the plan's own §4.2/Phase 2 table into a checked-in fixture, explicitly marked as *not authoritative* until Neo4j confirms it |
+| 7 | Open an implementation issue recording every assumption | Yes | GitHub issue, using the plan's own Section 11 (35 questions) as the body, tiered per the earlier `backlog-triage-and-nams-assessment-2026-07.md` §1.5 grouping |
+
+**Explicitly out of scope for this phase** (per the plan's own ADR-4/Phase 1+ boundary): no `AgentMemory.Nams` code, no client adapter, no package skeleton — that's Phase 2 of this 3-phase plan. This phase produces only: a tagged baseline, an archived test/build record, a best-effort contract fixture, and a tracking issue. Nothing in this phase touches `src/` production code.
+
+## 2. Detailed implementation plan
+
+1. **Baseline tag.** `git tag -a baseline/pre-nams-<date> -m "..."` on the current `main` HEAD (post-#127 stabilization merge), pushed to `origin`. Non-destructive — a tag is purely additive and never affects existing history/branches.
+2. **Archive the build/test record.** Run, in this order (matching the repo's own established discipline of full-suite-before-anything-else):
+   - `dotnet build AgentMemory.slnx -c Release` → record warning/error count.
+   - `dotnet test tests/AgentMemory.Tests.Unit` → record pass count/duration.
+   - `dotnet test tests/AgentMemory.Tests.Unit.SemanticKernel` → record pass count/duration.
+   - `dotnet test tests/AgentMemory.Tests.Integration` (live Neo4j, includes TCK-mirrored behavior tests per `docs/neo4j-memory-ecosystem.md`) → record pass count/duration.
+   - Package build: dry-run `dotnet pack` per `strategy/STATUS.md`'s documented release-dry-run recipe (reuses the existing, proven procedure — no new tooling).
+   - Sample build: already covered by the Release build above (samples are in the same solution).
+   - Save all of this as a dated snapshot section in this same planning doc (not a separate file — keeps the "plan" and "what actually happened" in one place, matching the stabilization doc's own pattern of an "Implementation notes" section added after the fact).
+3. **Public API snapshot.** No public-API-diff tool exists in this repo yet (confirmed: no `PublicAPI.Shipped.txt`/`Unshipped.txt`, no `Microsoft.CodeAnalysis.PublicApiAnalyzers` package reference, no `api-compat` CI step). Rather than bolt on a new, permanent analyzer as a side effect of this one-off baseline task, generate a one-time reflection-based snapshot (a small throwaway console script run from the scratchpad, not committed as new tooling) listing every public type and member across the 12 shipped `AgentMemory.*` assemblies, and commit the *output* (a plain text listing) as this phase's dated artifact. This gives Phase 7 of the NAMS plan (public API diff review before any convergence work) something concrete to diff against later, without committing this repository to a new analyzer/CI dependency it didn't ask for.
+4. **NAMS API contract snapshot (best-effort).** `WebFetch` the public NAMS REST API reference (`https://neo4j.com/labs/agent-memory/reference/rest-api/`) and limits page (`https://neo4j.com/labs/agent-memory/reference/nams-limits/`). If a machine-readable OpenAPI/JSON spec is linked or fetchable, save it verbatim. If not (most likely, per the NAMS plan's own repeated observation that several operations are "not documented" at the level Phase 2 needs), transcribe the CONFIRMED endpoint table already built in the plan's own §4.2/Phase 2 section into a checked-in fixture file, explicitly labeled as **transcribed from public docs on 2026-07-17, not Neo4j-confirmed, not authoritative** — matching the plan's own repeated discipline of never overstating certainty.
+5. **Tracking issue.** Open a GitHub issue titled around "NAMS backend integration — tracking" with:
+   - A short summary linking `strategy/AgentMemory_NAMS_Backend_Engineering_Plan_V03.md` (note: this file lives under the gitignored `strategy/` directory, so the issue body will need to inline the essential content — a plan file not tracked in git can't be linked by path in an issue for anyone without local repo access).
+   - The plan's own Section 11 (35 questions), organized into the same three tiers already worked out in `strategy/backlog-triage-and-nams-assessment-2026-07.md` §1.5 (must-ask-live / technical-unblockers / follow-up-email) so this issue doubles as the literal Neo4j-meeting agenda artifact.
+   - A checklist mirroring the plan's own Phase 0 "no-code gate" list, so the issue itself tracks when Phase 4+ (real NAMS recall/persistence code) becomes unblocked.
+
+## 3. Explicit non-goals for this phase (so scope doesn't creep)
+
+- No code in `src/AgentMemory.Nams` — that's Phase 2.
+- No live NAMS sandbox calls — no credentials exist yet, and the plan's own Phase 0 doesn't require them (only Phase 10's live integration tests do).
+- No resolution of the Section 11 questions — only recording them clearly enough that a 30-60 minute meeting can work through the tiered list efficiently.
+- No changes to `strategy/AgentMemory_NAMS_Backend_Engineering_Plan_V03.md` itself — it's already been assessed (see `strategy/backlog-triage-and-nams-assessment-2026-07.md`) and doesn't need edits for this phase.
+
+## 4. Definition of done for this phase
+
+- [x] Baseline tag pushed.
+- [x] Full build/test record archived in this doc with exact numbers (not carried over from memory — freshly run).
+- [x] Public API snapshot generated and committed.
+- [x] NAMS contract fixture attempted and committed (clearly labeled with its actual confidence level).
+- [x] Tracking GitHub issue opened with the tiered Section 11 questions.
+- [ ] Self-reviewed, PR opened, CI green, merged to `main`.
+
+---
+
+## 5. What actually happened (executed 2026-07-17)
+
+### Baseline
+
+- **Commit:** `60eb7c1fa1e79e607923259f67c207258fd16c40` (main, post-#127 stabilization merge).
+- **Tag:** `baseline/pre-nams-2026-07-17`, pushed to `origin`.
+
+### Build/test archive
+
+- Release build: **0 warnings, 0 errors** across all 12 packages + samples/tools.
+- Unit: **3041/3041** passing.
+- Semantic Kernel unit: **54/54** passing.
+- Live-Neo4j integration (includes TCK-mirrored behavior tests): **308/308** passing.
+- Package dry-run pack (all 12 `eng/release-packages.txt` entries, `-c Release --no-build`): all 12 packed successfully with no errors. (Gotcha hit and fixed: `eng/release-packages.txt` has CRLF line endings, which corrupts the `$proj` variable with a trailing `\r` in a naive bash `while read` loop — stripped explicitly.)
+- Package versions/target frameworks: net8.0/net9.0/net10.0 multi-targeted, current shipped version `1.2.0` (unchanged by this phase — no release cut here).
+
+### Public API snapshot
+
+No `PublicAPI.Shipped.txt`/`Microsoft.CodeAnalysis.PublicApiAnalyzers`/api-compat tooling exists in this repo (confirmed by grep, not assumed). Rather than add a new permanent analyzer dependency as a side effect of a one-off baseline task, generated a reflection-based snapshot (`System.Reflection.MetadataLoadContext`, run from a scratchpad throwaway tool, not committed) covering all 12 shipped packages plus the `Cli`/`TckBridge` tools — saved as `docs/reviews/nams-phase0-public-api-snapshot.txt`. Gotcha: `Assembly.LoadFrom` fails on partial-dependency library output folders (a library's own `bin/` doesn't get transitive NuGet deps copied) and on runtime-version-mismatched executable folders; `MetadataLoadContext` with an explicit core-assembly name and a resolver spanning both the target folder and the matching shared-framework directory (`dotnet --list-runtimes`) is the robust way to do this without executing any code.
+
+### NAMS API contract snapshot — better than expected
+
+The plan (§4.8, §11 Q1-2) treated the existence of a machine-readable OpenAPI contract as an open question requiring a Neo4j answer. **It isn't open — `https://memory.neo4jlabs.com/openapi.json` is live, public, and fetched clean**: valid Swagger 2.0, title "NAMS Memory API" v1.0, **80 paths / 92 operations**, `BearerAuth` security scheme. Saved verbatim as `docs/reviews/nams-openapi-snapshot-2026-07-17.json`. This directly resolves one of the plan's own flagged uncertainties:
+
+- **Phase 2's `SearchMessagesAsync` gap (plan §7 Phase 2, flagged as "may not map to anything the API actually exposes") is resolved**: `POST /v1/conversations/{id}/search` exists in the spec. `POST /v1/entities/search` also confirmed (already assumed in the plan).
+- **Auth confirmed**: `Authorization: Bearer <token>` with both `/v1/auth/exchange` (Auth0-style) and `/v1/auth/api-keys` (`nams_…` key lifecycle: create/list/revoke/reveal/rotate) present in the spec.
+- **Idempotency (plan §11 Q12-16) is still genuinely unanswered**: checked `POST /v1/conversations` and `POST /v1/conversations/{id}/messages/bulk`'s documented parameters directly in the spec — neither exposes an idempotency-key or caller-supplied-ID parameter. This is a confirmed gap, not an unresearched one, going into the tracking issue.
+- **Rate/payload limits (plan §11 Q24-25)**: confirmed narrow-endpoint limits only (ontology 30/hr/workspace, feedback 10/min+100/hr/user+200/hr/workspace, general 413 on oversized bodies) — nothing published for the core conversation/message/context path Phases 4-5 exercise most. Still an open question for Neo4j.
+- **2-day managed-workspace reclamation (plan §11 Q26, risk register)**: reconfirmed verbatim from the public limits page — still doesn't state whether it applies to BYOD/production tiers. Still an open question.
+- This snapshot is a real fetch of a live, versioned service, not a fixture Neo4j has agreed is stable — it can drift or require auth differently at any time. Treated as **informative, not contractually pinned**, exactly as the plan's own Phase 0 "no-code gate" anticipates ("a spike may proceed with explicit temporary assumptions, but it may not be released").
+
+### Tracking issue
+
+Opened as [#128](https://github.com/joslat/agent-memory-dotnet/issues/128) with the plan's Section 11 questions, tiered per `strategy/backlog-triage-and-nams-assessment-2026-07.md` §1.5, updated to mark the two items this research resolved (OpenAPI existence, `SearchMessagesAsync` mapping) as answered rather than open. Kept open (not closed by this PR) — it tracks Neo4j's answers, which haven't happened yet.

--- a/docs/reviews/nams-openapi-snapshot-2026-07-17.json
+++ b/docs/reviews/nams-openapi-snapshot-2026-07-17.json
@@ -1,0 +1,6626 @@
+{
+  "basePath": "/",
+  "definitions": {
+    "gin.H": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "handlers.APIKey": {
+      "properties": {
+        "createdAt": {
+          "type": "string"
+        },
+        "expiresAt": {
+          "description": "ExpiresAt is the 90-day rotation deadline. Empty for legacy keys; the\nUI treats absent values as \"no expiry\" so legacy keys keep working\nuntil rotated.",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "revokedAt": {
+          "type": "string"
+        },
+        "scopes": {
+          "description": "Scopes is the comma-separated scope string stored on the key. Empty for\nlegacy keys (which default to all scopes at validation).",
+          "type": "string"
+        },
+        "workspaceId": {
+          "description": "WorkspaceID is set for a Workspace key (data-plane, bound) and empty for\nan account-wide Admin key. The dashboard derives the type badge from it.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ActivateOntologyRequest": {
+      "properties": {
+        "version_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "version_id"
+      ],
+      "type": "object"
+    },
+    "handlers.ActiveOntologyResponse": {
+      "properties": {
+        "ontology": {
+          "$ref": "#/definitions/ontology.Ontology"
+        },
+        "version": {
+          "$ref": "#/definitions/ontology.OntologyVersionRecord"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.AddMessageResponse": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.AddMessagesBatchResponse": {
+      "properties": {
+        "messages": {
+          "items": {
+            "$ref": "#/definitions/handlers.AddMessageResponse"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ContextResponse": {
+      "properties": {
+        "observations": {
+          "items": {
+            "$ref": "#/definitions/handlers.Observation"
+          },
+          "type": "array"
+        },
+        "recentMessages": {
+          "items": {
+            "$ref": "#/definitions/handlers.Message"
+          },
+          "type": "array"
+        },
+        "reflections": {
+          "items": {
+            "$ref": "#/definitions/handlers.Reflection"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.Conversation": {
+      "properties": {
+        "createdAt": {
+          "type": "string"
+        },
+        "firstMessageSnippet": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "messageCount": {
+          "type": "integer"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ConversationReasoningResponse": {
+      "properties": {
+        "conversationId": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/handlers.ReasoningStep"
+          },
+          "type": "array"
+        },
+        "toolCalls": {
+          "items": {
+            "$ref": "#/definitions/handlers.ToolCall"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ConversationResponse": {
+      "properties": {
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workspaceId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ConversationsResponse": {
+      "properties": {
+        "conversations": {
+          "items": {
+            "$ref": "#/definitions/handlers.Conversation"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.CreateConversationResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workspaceId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.CreateOntologyRequest": {
+      "properties": {
+        "message": {
+          "description": "Message is an optional commit-style note describing the change.",
+          "type": "string"
+        },
+        "ontology": {
+          "$ref": "#/definitions/ontology.Ontology"
+        },
+        "validation_mode": {
+          "$ref": "#/definitions/ontology.Mode"
+        }
+      },
+      "required": [
+        "ontology"
+      ],
+      "type": "object"
+    },
+    "handlers.EntitiesResponse": {
+      "properties": {
+        "entities": {
+          "items": {
+            "$ref": "#/definitions/handlers.Entity"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.Entity": {
+      "properties": {
+        "confidence": {
+          "type": "number"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        },
+        "sourceStage": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityDetailsResponse": {
+      "properties": {
+        "confidence": {
+          "type": "number"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "relationships": {
+          "items": {
+            "$ref": "#/definitions/handlers.EntityRelationship"
+          },
+          "type": "array"
+        },
+        "sourceStage": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityGraphResponse": {
+      "properties": {
+        "edges": {
+          "items": {
+            "$ref": "#/definitions/handlers.graphEdge"
+          },
+          "type": "array"
+        },
+        "nodes": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityProvenanceResponse": {
+      "properties": {
+        "entityId": {
+          "type": "string"
+        },
+        "mentions": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityReasoningProvenanceResponse": {
+      "properties": {
+        "entityId": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityRelationship": {
+      "properties": {
+        "relType": {
+          "type": "string"
+        },
+        "targetId": {
+          "type": "string"
+        },
+        "targetName": {
+          "type": "string"
+        },
+        "targetType": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.EntityResponse": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ErrorResponse": {
+      "properties": {
+        "error": {
+          "example": "internal error",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ExchangeAuth0Response": {
+      "properties": {
+        "workspaces": {
+          "items": {
+            "$ref": "#/definitions/handlers.WorkspaceAuthInfo"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ExpandNode": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "properties": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ExpandRequest": {
+      "properties": {
+        "loadedIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nodeId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ExpandResponse": {
+      "properties": {
+        "edges": {
+          "items": {
+            "$ref": "#/definitions/handlers.graphEdge"
+          },
+          "type": "array"
+        },
+        "nodes": {
+          "items": {
+            "$ref": "#/definitions/handlers.ExpandNode"
+          },
+          "type": "array"
+        },
+        "truncated": {
+          "$ref": "#/definitions/handlers.ExpandTruncation"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ExpandTruncation": {
+      "properties": {
+        "nodeId": {
+          "type": "string"
+        },
+        "shown": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ImportOntologyRequest": {
+      "properties": {
+        "content": {
+          "description": "Content is the raw source document (JSON, YAML, RDF, etc.). Mutually\nexclusive with URL: supply one or the other.",
+          "type": "string"
+        },
+        "format": {
+          "description": "Format is an explicit converter id (e.g. \"arrows\") or \"auto\"/\"\" to\ndetect from the content.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL, when set and Content is empty, is fetched server-side (https only,\nSSRF-guarded, size-capped) and its body used as the content.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ImportOntologyResponse": {
+      "properties": {
+        "detected_format": {
+          "type": "string"
+        },
+        "ontology": {
+          "$ref": "#/definitions/ontology.Ontology"
+        },
+        "suggested_name": {
+          "type": "string"
+        },
+        "warnings": {
+          "items": {
+            "$ref": "#/definitions/importers.Warning"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.InfluencedEntity": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ListAPIKeysResponse": {
+      "properties": {
+        "keys": {
+          "items": {
+            "$ref": "#/definitions/handlers.APIKey"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ListOntologiesResponse": {
+      "properties": {
+        "ontologies": {
+          "items": {
+            "$ref": "#/definitions/ontology.OntologySummary"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.MapPendingTypeRequest": {
+      "properties": {
+        "target": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object"
+    },
+    "handlers.MergeEntitiesResponse": {
+      "properties": {
+        "sourceId": {
+          "type": "string"
+        },
+        "status": {
+          "example": "merged",
+          "type": "string"
+        },
+        "targetId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.Message": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        },
+        "tokenCount": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.MessagesResponse": {
+      "properties": {
+        "messages": {
+          "items": {
+            "$ref": "#/definitions/handlers.Message"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.MigrateRequest": {
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/ontology.MigrationSpec"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object"
+    },
+    "handlers.Observation": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "sourceMsgIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ObservationsResponse": {
+      "properties": {
+        "observations": {
+          "items": {
+            "$ref": "#/definitions/handlers.Observation"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.PreviewEntity": {
+      "properties": {
+        "aliases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "confidence": {
+          "type": "number"
+        },
+        "decision": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "existing_id": {
+          "type": "string"
+        },
+        "existing_name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resolution_confidence": {
+          "type": "number"
+        },
+        "source_stage": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.PreviewRelationship": {
+      "properties": {
+        "confidence": {
+          "type": "number"
+        },
+        "method": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.PreviewRequest": {
+      "properties": {
+        "ontology": {
+          "$ref": "#/definitions/ontology.Ontology"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    },
+    "handlers.PreviewResolutionSummary": {
+      "properties": {
+        "auto_merge": {
+          "type": "integer"
+        },
+        "new": {
+          "type": "integer"
+        },
+        "review": {
+          "type": "integer"
+        },
+        "total_candidates": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.PreviewResponse": {
+      "properties": {
+        "entities": {
+          "items": {
+            "$ref": "#/definitions/handlers.PreviewEntity"
+          },
+          "type": "array"
+        },
+        "relationships": {
+          "items": {
+            "$ref": "#/definitions/handlers.PreviewRelationship"
+          },
+          "type": "array"
+        },
+        "resolution_summary": {
+          "$ref": "#/definitions/handlers.PreviewResolutionSummary"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.QueryResponse": {
+      "properties": {
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rows": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "stats": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ReasoningStep": {
+      "properties": {
+        "actionTaken": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "reasoning": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ReasoningStepDetailsResponse": {
+      "properties": {
+        "actionTaken": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "influencedEntities": {
+          "items": {
+            "$ref": "#/definitions/handlers.InfluencedEntity"
+          },
+          "type": "array"
+        },
+        "reasoning": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "toolCalls": {
+          "items": {
+            "$ref": "#/definitions/handlers.ToolCall"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ReasoningStepsResponse": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/handlers.ReasoningStep"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.RecordReasoningStepResponse": {
+      "properties": {
+        "actionTaken": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "reasoning": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.RecordToolCallResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "stepId": {
+          "type": "string"
+        },
+        "toolName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.Reflection": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "sourceObsIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "supersededById": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ReflectionsResponse": {
+      "properties": {
+        "reflections": {
+          "items": {
+            "$ref": "#/definitions/handlers.Reflection"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.SearchEntitiesResponse": {
+      "properties": {
+        "entities": {
+          "items": {
+            "$ref": "#/definitions/handlers.Entity"
+          },
+          "type": "array"
+        },
+        "searchType": {
+          "example": "vector",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.SearchMessagesResponse": {
+      "properties": {
+        "messages": {
+          "items": {
+            "$ref": "#/definitions/handlers.Message"
+          },
+          "type": "array"
+        },
+        "searchType": {
+          "example": "vector",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.StatusResponse": {
+      "properties": {
+        "status": {
+          "example": "success",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.TenantQueryErrorResponse": {
+      "properties": {
+        "error": {
+          "enum": [
+            "database_unavailable",
+            "db_unreachable",
+            "cypher_error",
+            "internal"
+          ],
+          "example": "database_unavailable",
+          "type": "string"
+        },
+        "message": {
+          "example": "the workspace database is unreachable or has been removed; reprovision it or update the external connection",
+          "type": "string"
+        },
+        "workspaceId": {
+          "example": "b3f1c2d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.ToolCall": {
+      "properties": {
+        "createdAt": {
+          "type": "string"
+        },
+        "durationMs": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "stepId": {
+          "type": "string"
+        },
+        "toolName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.UpdateOntologyRequest": {
+      "properties": {
+        "message": {
+          "description": "Message is an optional commit-style note describing the change.",
+          "type": "string"
+        },
+        "ontology": {
+          "$ref": "#/definitions/ontology.Ontology"
+        },
+        "validation_mode": {
+          "$ref": "#/definitions/ontology.Mode"
+        }
+      },
+      "required": [
+        "ontology"
+      ],
+      "type": "object"
+    },
+    "handlers.UpdateSchemaResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceAuthInfo": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "workspace_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceConnectionInfo": {
+      "properties": {
+        "database": {
+          "example": "neo4j",
+          "type": "string"
+        },
+        "expiresAt": {
+          "example": "2026-06-10T12:00:00Z",
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "uri": {
+          "example": "neo4j+s://abc123.databases.neo4j.io",
+          "type": "string"
+        },
+        "username": {
+          "example": "neo4j",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceCreateRequest": {
+      "properties": {
+        "name": {
+          "example": "my-workspace",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceCreateResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "example": "pending",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceDatabaseConfigResponse": {
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/handlers.WorkspaceConnectionInfo"
+        },
+        "connections": {
+          "$ref": "#/definitions/handlers.WorkspaceManagedConnections"
+        },
+        "mode": {
+          "example": "managed",
+          "type": "string"
+        },
+        "sandboxActive": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceDetailsResponse": {
+      "properties": {
+        "createdAt": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "managedDbInactivityDays": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "plan": {
+          "type": "string"
+        },
+        "provisioningStage": {
+          "type": "string"
+        },
+        "status": {
+          "example": "active",
+          "type": "string"
+        },
+        "statusMessage": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceListResponse": {
+      "properties": {
+        "workspaces": {
+          "items": {
+            "$ref": "#/definitions/handlers.WorkspaceSummary"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceManagedConnections": {
+      "properties": {
+        "ro": {
+          "$ref": "#/definitions/handlers.WorkspaceConnectionInfo"
+        },
+        "rw": {
+          "$ref": "#/definitions/handlers.WorkspaceConnectionInfo"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceMember": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "joinedAt": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "role": {
+          "example": "developer",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceMembersResponse": {
+      "properties": {
+        "members": {
+          "items": {
+            "$ref": "#/definitions/handlers.WorkspaceMember"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceRelationsConfig": {
+      "properties": {
+        "allowed_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "custom_descriptions": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "example": true,
+          "type": "boolean"
+        },
+        "fallback_type": {
+          "example": "RELATED_TO",
+          "type": "string"
+        },
+        "min_confidence": {
+          "example": 0.5,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceResolutionConfig": {
+      "properties": {
+        "auto_merge_threshold": {
+          "example": 0.92,
+          "type": "number"
+        },
+        "embedding_weight": {
+          "example": 0.6,
+          "type": "number"
+        },
+        "enabled": {
+          "example": true,
+          "type": "boolean"
+        },
+        "fuzzy_min_score": {
+          "example": 0.5,
+          "type": "number"
+        },
+        "fuzzy_weight": {
+          "example": 0.4,
+          "type": "number"
+        },
+        "review_threshold": {
+          "example": 0.78,
+          "type": "number"
+        },
+        "semantic_min_score": {
+          "example": 0.55,
+          "type": "number"
+        },
+        "top_k": {
+          "example": 25,
+          "type": "integer"
+        },
+        "type_strict": {
+          "example": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceSummary": {
+      "properties": {
+        "dbMode": {
+          "example": "managed",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "role": {
+          "example": "owner",
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceTestConnectionRequest": {
+      "properties": {
+        "database": {
+          "example": "neo4j",
+          "type": "string"
+        },
+        "password": {
+          "example": "secret",
+          "type": "string"
+        },
+        "uri": {
+          "example": "neo4j+s://abc123.databases.neo4j.io",
+          "type": "string"
+        },
+        "username": {
+          "example": "neo4j",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.WorkspaceTestConnectionResponse": {
+      "properties": {
+        "error": {
+          "example": "connection failed",
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.addMessageRequest": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "handlers.addMessagesBulkRequest": {
+      "properties": {
+        "messages": {
+          "items": {
+            "$ref": "#/definitions/handlers.addMessageRequest"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "type": "object"
+    },
+    "handlers.bulkReviewRequest": {
+      "properties": {
+        "action": {
+          "description": "Action is currently only \"confirm\" - auto-applies merges to every\npending pair whose confidence is at least MinConfidence. PRD §6\n\"bulk-confirm all ≥ 0.95 confidence\" workflow.",
+          "type": "string"
+        },
+        "minConfidence": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "handlers.bulkReviewSkillsRequest": {
+      "properties": {
+        "decision": {
+          "description": "approve | reject",
+          "type": "string"
+        },
+        "feedback": {
+          "type": "string"
+        },
+        "skillIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.createAPIKeyRequest": {
+      "properties": {
+        "category": {
+          "description": "Category is \"workspace\" or \"admin\". Empty defaults to \"admin\" so the\nlegacy {label}-only body keeps minting account-wide keys.",
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "workspaceId": {
+          "description": "WorkspaceID is required for a workspace key and forbidden for an admin\nkey. Scopes are NOT accepted from the client: they are derived from the\ncategory to keep the data/control-plane boundary unforgeable.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "type": "object"
+    },
+    "handlers.createAPIKeyResponse": {
+      "properties": {
+        "category": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "workspaceId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.createConversationRequest": {
+      "properties": {
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.createEntityRequest": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Properties carries typed property values for the entity. On an explicit\nAPI write the ontology's `required` properties are enforced here (hard\n422); the extraction path flags-not-drops instead (E2/Q13 asymmetry).",
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "handlers.createFeedbackRequest": {
+      "properties": {
+        "clientErrors": {
+          "items": {
+            "$ref": "#/definitions/handlers.feedbackClientError"
+          },
+          "type": "array"
+        },
+        "clientMeta": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "contactEmail": {
+          "type": "string"
+        },
+        "context": {
+          "$ref": "#/definitions/handlers.feedbackContext"
+        },
+        "message": {
+          "type": "string"
+        },
+        "rating": {
+          "type": "integer"
+        },
+        "sentiment": {
+          "type": "string"
+        },
+        "type": {
+          "description": "binding tags are for OpenAPI required-field generation; runtime validation\nis enforced manually below because decoding is done with json.Decoder.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "type"
+      ],
+      "type": "object"
+    },
+    "handlers.entityFeedbackRequest": {
+      "properties": {
+        "confirmed": {
+          "type": "boolean"
+        },
+        "userScore": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackClientError": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "ts": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackConnection": {
+      "properties": {
+        "downlink": {
+          "type": "number"
+        },
+        "effectiveType": {
+          "type": "string"
+        },
+        "rtt": {
+          "type": "integer"
+        },
+        "saveData": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackContext": {
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "appVersion": {
+          "type": "string"
+        },
+        "capturedAt": {
+          "type": "string"
+        },
+        "connection": {
+          "$ref": "#/definitions/handlers.feedbackConnection"
+        },
+        "deviceMemory": {
+          "type": "number"
+        },
+        "devicePixelRatio": {
+          "type": "number"
+        },
+        "hardwareConcurrency": {
+          "type": "integer"
+        },
+        "languages": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "online": {
+          "type": "boolean"
+        },
+        "pageUrl": {
+          "type": "string"
+        },
+        "perf": {
+          "$ref": "#/definitions/handlers.feedbackPerf"
+        },
+        "provisioningStage": {
+          "type": "string"
+        },
+        "referrer": {
+          "description": "Browser / device",
+          "type": "string"
+        },
+        "route": {
+          "type": "string"
+        },
+        "sandboxActive": {
+          "type": "boolean"
+        },
+        "screen": {
+          "$ref": "#/definitions/handlers.feedbackScreen"
+        },
+        "theme": {
+          "description": "App runtime (from React hooks at submit time)",
+          "type": "string"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "userAgent": {
+          "type": "string"
+        },
+        "userAgentData": {
+          "$ref": "#/definitions/handlers.feedbackUserAgentData"
+        },
+        "viewport": {
+          "$ref": "#/definitions/handlers.feedbackViewport"
+        },
+        "workspaceDbMode": {
+          "type": "string"
+        },
+        "workspaceId": {
+          "type": "string"
+        },
+        "workspaceRole": {
+          "type": "string"
+        },
+        "workspaceStatus": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackPerf": {
+      "properties": {
+        "domInteractiveMs": {
+          "type": "number"
+        },
+        "loadCompleteMs": {
+          "type": "number"
+        },
+        "navigationType": {
+          "type": "string"
+        },
+        "ttfbMs": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackScreen": {
+      "properties": {
+        "colorDepth": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "width": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackUserAgentData": {
+      "properties": {
+        "brands": {
+          "type": "string"
+        },
+        "mobile": {
+          "type": "boolean"
+        },
+        "platform": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.feedbackViewport": {
+      "properties": {
+        "height": {
+          "type": "integer"
+        },
+        "width": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.generateSkillRequest": {
+      "properties": {
+        "nameHint": {
+          "type": "string"
+        },
+        "procedureFormat": {
+          "description": "Optional per-run override for the graph-vs-prose eval A/B: \"graph\"|\"prose\".",
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/handlers.skillScope"
+        },
+        "skillId": {
+          "description": "re-distill target (new version)",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.graphEdge": {
+      "properties": {
+        "confidence": {
+          "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "legacyType": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "predicate": {
+          "type": "string"
+        },
+        "sourceId": {
+          "type": "string"
+        },
+        "sourceMessageCount": {
+          "type": "integer"
+        },
+        "targetId": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.mergeEntitiesRequest": {
+      "properties": {
+        "targetId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetId"
+      ],
+      "type": "object"
+    },
+    "handlers.oauthCallbackRequest": {
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "provider": {
+          "description": "\"github\" or \"google\"",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "provider"
+      ],
+      "type": "object"
+    },
+    "handlers.queryRequest": {
+      "properties": {
+        "cypher": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "cypher"
+      ],
+      "type": "object"
+    },
+    "handlers.recordStepRequest": {
+      "properties": {
+        "actionTaken": {
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "reasoning": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "actionTaken",
+        "conversationId",
+        "reasoning"
+      ],
+      "type": "object"
+    },
+    "handlers.recordToolCallRequest": {
+      "properties": {
+        "durationMs": {
+          "example": 150,
+          "type": "integer"
+        },
+        "input": {
+          "example": "{\"query\":\"project status\"}",
+          "type": "string"
+        },
+        "output": {
+          "example": "{\"results\":[\"r1\",\"r2\"]}",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "pending",
+            "success",
+            "failure",
+            "error",
+            "timeout",
+            "cancelled"
+          ],
+          "example": "success",
+          "type": "string"
+        },
+        "stepId": {
+          "type": "string"
+        },
+        "toolName": {
+          "example": "web_search",
+          "type": "string"
+        }
+      },
+      "required": [
+        "input",
+        "toolName"
+      ],
+      "type": "object"
+    },
+    "handlers.refreshRequest": {
+      "properties": {
+        "client_id": {
+          "description": "ClientID binds the rotation to the originating client (RFC 9700 §4.14).\nRequired when the stored token has a ClientID; optional otherwise so\nfirst-party (non-OAuth) refresh callers continue to work.",
+          "type": "string"
+        },
+        "refresh_token": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "refresh_token"
+      ],
+      "type": "object"
+    },
+    "handlers.refreshResponse": {
+      "properties": {
+        "refresh_token": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.revealAPIKeyResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.reviewDecisionRequest": {
+      "properties": {
+        "action": {
+          "description": "Action must be one of confirm | reject | merge_into.",
+          "type": "string"
+        },
+        "mergeInto": {
+          "description": "MergeIntoTarget overrides the merge target when Action == merge_into.\nDefaults to TargetID. Useful when the reviewer prefers a third entity\nover the resolver's pick.",
+          "type": "string"
+        },
+        "sourceId": {
+          "description": "SourceID + TargetID are required because pairId is a one-way hash -\nwe need the underlying IDs to MATCH the SAME_AS edge.",
+          "type": "string"
+        },
+        "targetId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "action",
+        "sourceId",
+        "targetId"
+      ],
+      "type": "object"
+    },
+    "handlers.reviewSkillRequest": {
+      "properties": {
+        "decision": {
+          "description": "approve | reject",
+          "type": "string"
+        },
+        "feedback": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.rotateAPIKeyResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.searchEntitiesRequest": {
+      "properties": {
+        "limit": {
+          "type": "integer"
+        },
+        "query": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    },
+    "handlers.searchMessagesRequest": {
+      "properties": {
+        "limit": {
+          "type": "integer"
+        },
+        "query": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    },
+    "handlers.skillScope": {
+      "properties": {
+        "conversationIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "entityId": {
+          "type": "string"
+        },
+        "focusEntityIds": {
+          "description": "narrows a re-distill to one community (F1/F2)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "from": {
+          "type": "string"
+        },
+        "nameHint": {
+          "type": "string"
+        },
+        "ontologyClass": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "handlers.updateEntityRequest": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "importers.Warning": {
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.Domain": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "emoji": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tagline": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.EntityChange": {
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.EntityType": {
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "pii_sensitive": {
+          "description": "PIISensitive marks a type whose entities are subject to redaction\npolicies. Surfaced to the extraction worker; consumed by retrieval.",
+          "type": "boolean"
+        },
+        "pole_type": {
+          "$ref": "#/definitions/ontology.PoleType"
+        },
+        "properties": {
+          "items": {
+            "$ref": "#/definitions/ontology.Property"
+          },
+          "type": "array"
+        },
+        "subtype": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.EntityTypeDiff": {
+      "properties": {
+        "added": {
+          "items": {
+            "$ref": "#/definitions/ontology.EntityType"
+          },
+          "type": "array"
+        },
+        "modified": {
+          "items": {
+            "$ref": "#/definitions/ontology.EntityChange"
+          },
+          "type": "array"
+        },
+        "removed": {
+          "items": {
+            "$ref": "#/definitions/ontology.EntityType"
+          },
+          "type": "array"
+        },
+        "renamed": {
+          "items": {
+            "$ref": "#/definitions/ontology.TypeRename"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.MigrationJob": {
+      "properties": {
+        "completed_at": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "string"
+        },
+        "error_message": {
+          "type": "string"
+        },
+        "errored": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ontology_id": {
+          "type": "string"
+        },
+        "processed": {
+          "type": "integer"
+        },
+        "spec": {
+          "$ref": "#/definitions/ontology.MigrationSpec"
+        },
+        "started_at": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/ontology.MigrationStatus"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "workspace_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.MigrationSpec": {
+      "properties": {
+        "batch_size": {
+          "description": "BatchSize caps the per-transaction node count. 0 → default (1000).",
+          "type": "integer"
+        },
+        "dedup_by_name": {
+          "description": "DedupByName runs a tiered duplicate-entity pass after the type mappings:\nsame-name + same-(canonical)-type entities are auto-merged; same-name +\ndifferent-type collisions are routed to HITL as pending SAME_AS pairs.\nTypically paired with property-keyed type-canonicalization mappings so the\ncasing-split duplicates collapse once their types agree.",
+          "type": "boolean"
+        },
+        "dry_run": {
+          "type": "boolean"
+        },
+        "from_version_id": {
+          "type": "string"
+        },
+        "to_version_id": {
+          "type": "string"
+        },
+        "type_mappings": {
+          "items": {
+            "$ref": "#/definitions/ontology.TypeMapping"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.MigrationStatus": {
+      "enum": [
+        "pending",
+        "running",
+        "paused",
+        "completed",
+        "failed"
+      ],
+      "type": "string",
+      "x-enum-varnames": [
+        "MigrationPending",
+        "MigrationRunning",
+        "MigrationPaused",
+        "MigrationCompleted",
+        "MigrationFailed"
+      ]
+    },
+    "ontology.Mode": {
+      "enum": [
+        "strict",
+        "permissive",
+        "review"
+      ],
+      "type": "string",
+      "x-enum-varnames": [
+        "ModeStrict",
+        "ModePermissive",
+        "ModeReview"
+      ]
+    },
+    "ontology.ModeChange": {
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/ontology.Mode"
+        },
+        "to": {
+          "$ref": "#/definitions/ontology.Mode"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.Ontology": {
+      "properties": {
+        "domain": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ontology.Domain"
+            }
+          ],
+          "description": "Domain is the create-context-graph metadata block (may be empty for\nthe _base template itself)."
+        },
+        "entity_types": {
+          "description": "EntityTypes is the fully merged list (base + domain).",
+          "items": {
+            "$ref": "#/definitions/ontology.EntityType"
+          },
+          "type": "array"
+        },
+        "extraction_aliases": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ExtractionAliases maps an extraction SURFACE form to a declared\nentity-type label (surface → type, N:1) — e.g. \"doctor\" → \"Provider\",\n\"physician\" → \"Provider\". The deterministic alias pass and GLiNER label\nderivation consume this direction. Legacy type → surface rows are flipped\non read by NormalizeExtractionAliases. See extraction_aliases.go.",
+          "type": "object"
+        },
+        "relationships": {
+          "description": "Relationships is the fully merged list.",
+          "items": {
+            "$ref": "#/definitions/ontology.RelationshipType"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.OntologyDetail": {
+      "properties": {
+        "record": {
+          "$ref": "#/definitions/ontology.OntologyRecord"
+        },
+        "versions": {
+          "items": {
+            "$ref": "#/definitions/ontology.OntologyVersionRecord"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.OntologyDiff": {
+      "properties": {
+        "entity_types": {
+          "$ref": "#/definitions/ontology.EntityTypeDiff"
+        },
+        "from_revision": {
+          "type": "integer"
+        },
+        "mode_change": {
+          "$ref": "#/definitions/ontology.ModeChange"
+        },
+        "relationships": {
+          "$ref": "#/definitions/ontology.RelationshipDiff"
+        },
+        "to_revision": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.OntologyRecord": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "string"
+        },
+        "deleted_at": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "is_system": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "source_sha": {
+          "type": "string"
+        },
+        "workspace_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.OntologySummary": {
+      "properties": {
+        "current_revision": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "emoji": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "is_active": {
+          "type": "boolean"
+        },
+        "is_system": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tagline": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.OntologyVersionRecord": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is an optional commit-style note explaining what changed in\nthis revision. Surfaced in the Version History UI + diff header.",
+          "type": "string"
+        },
+        "ontology_id": {
+          "type": "string"
+        },
+        "parent_version_id": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer"
+        },
+        "schema_hash": {
+          "type": "string"
+        },
+        "schema_json": {
+          "type": "string"
+        },
+        "semver_tag": {
+          "type": "string"
+        },
+        "validation_mode": {
+          "$ref": "#/definitions/ontology.Mode"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.PoleType": {
+      "enum": [
+        "PERSON",
+        "OBJECT",
+        "LOCATION",
+        "EVENT",
+        "ORGANIZATION"
+      ],
+      "type": "string",
+      "x-enum-varnames": [
+        "PolePerson",
+        "PoleObject",
+        "PoleLocation",
+        "PoleEvent",
+        "PoleOrganization"
+      ]
+    },
+    "ontology.Property": {
+      "properties": {
+        "default": {},
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pii": {
+          "description": "PII marks this property's values as personally-identifiable. Values are\ntransformed per the workspace's PII action (hash/redact/store-as-is) at\nevery choke point they flow through — property-write, embedding, and\nobservation/reflection (Q9). The default hash is deterministic so a\nhashed Unique property still dedups via the unique-key resolver.",
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.RelationshipDiff": {
+      "properties": {
+        "added": {
+          "items": {
+            "$ref": "#/definitions/ontology.RelationshipType"
+          },
+          "type": "array"
+        },
+        "removed": {
+          "items": {
+            "$ref": "#/definitions/ontology.RelationshipType"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.RelationshipType": {
+      "properties": {
+        "cardinality": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "properties": {
+          "items": {
+            "$ref": "#/definitions/ontology.Property"
+          },
+          "type": "array"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.TypeMapping": {
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "match_by": {
+          "description": "MatchBy selects how nodes are matched for this mapping:\n  \"label\" (default) — MATCH (n:\u003cFrom\u003e); for renaming an existing type LABEL.\n  \"property\"        — MATCH (e:Entity) WHERE e.type = \u003cFrom\u003e; for backfilling\n                      legacy entities that carry only the :Entity label and a\n                      `type` property (no type label), e.g. canonicalizing\n                      \"tool\" → \"SoftwareTool\".",
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "to_pole": {
+          "description": "ToPole is the canonical POLE base label (e.g. \"Object\") to also stamp on the\nnode in property mode, materializing the (:Entity:\u003cPole\u003e:\u003cTo\u003e) label scheme.\nOptional; ignored in label mode.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ontology.TypeRename": {
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "host": "memory.neo4jlabs.com",
+  "info": {
+    "contact": {
+      "name": "Neo4j DevRel",
+      "url": "https://github.com/neo4j-labs/project-gaylord"
+    },
+    "description": "API key (nams_...) used directly as Bearer token, or JWT from Auth0 exchange",
+    "license": {
+      "name": "Apache 2.0"
+    },
+    "title": "NAMS Memory API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/.well-known/jwks.json": {
+      "get": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nReturns the public RSA key(s) used to verify NAMS JWTs. Used by other services for token validation.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "JWKS format public key set",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get public keys (JWKS)",
+        "tags": [
+          "JWKS"
+        ]
+      }
+    },
+    "/v1/auth/api-keys": {
+      "get": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nList API keys owned by the authenticated user. Raw key values are never returned - only metadata (ID, label, created/revoked/expiry timestamps). Auth: requires a user token or an Admin API key (workspace:admin); workspace-bound data keys are rejected with 403.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns keys array with id, label, createdAt, revokedAt, expiresAt",
+            "schema": {
+              "$ref": "#/definitions/handlers.ListAPIKeysResponse"
+            }
+          },
+          "401": {
+            "description": "No user in token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Requires a user token or an Admin API key",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List API keys",
+        "tags": [
+          "Auth"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nGenerate a new API key owned by the authenticated user. The category selects the key's privilege and binding: \"workspace\" requires a workspaceId and produces a data-plane key bound to that workspace (scopes derived server-side, never workspace:admin); \"admin\" forbids workspaceId and produces an account-wide key with full scopes. Category defaults to \"admin\" when omitted. The raw key is returned once and also stored encrypted-at-rest for later reveal; it is bcrypt-validated on every request. Auth: requires a user token or an Admin API key (workspace:admin); workspace-bound data keys are rejected with 403.",
+        "parameters": [
+          {
+            "description": "Label, category, and optional workspaceId",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.createAPIKeyRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Key ID, raw key (save this), and label",
+            "schema": {
+              "$ref": "#/definitions/handlers.createAPIKeyResponse"
+            }
+          },
+          "400": {
+            "description": "Missing required fields",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "No user in token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Requires a user token or an Admin API key",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create an API key",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/api-keys/{id}": {
+      "delete": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nRevoke an API key by ID. The key is immediately invalidated - any active JWTs issued from it are blocklisted. This action is irreversible. Owner-only: only the user who owns the key can revoke it. Non-owners receive 404 (indistinguishable from a missing key) to prevent key-id enumeration. Auth: requires a user token or an Admin API key (workspace:admin); workspace-bound data keys are rejected with 403.",
+        "parameters": [
+          {
+            "description": "API key ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status: revoked",
+            "schema": {
+              "$ref": "#/definitions/handlers.StatusResponse"
+            }
+          },
+          "401": {
+            "description": "No user in token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Requires a user token or an Admin API key",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Key not found or not owned by caller",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Revoke an API key",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/api-keys/{id}/reveal": {
+      "get": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nReturns the decrypted raw API key value for keys created with encrypted storage. Owner-only: only the user who owns the key can reveal it. Non-owners receive 404 (indistinguishable from a missing key) to prevent credential disclosure and key-id enumeration. Returns 410 if the key was revoked or predates encrypted storage. Auth: requires a user token or an Admin API key (workspace:admin); workspace-bound data keys are rejected with 403.",
+        "parameters": [
+          {
+            "description": "API key ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Key ID and decrypted raw key",
+            "schema": {
+              "$ref": "#/definitions/handlers.revealAPIKeyResponse"
+            }
+          },
+          "401": {
+            "description": "No user in token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Requires a user token or an Admin API key",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Key not found or not owned by caller",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Key revoked or not revealable",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Reveal a stored API key",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/api-keys/{id}/rotate": {
+      "post": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nMint a new API key inheriting the old key's label and scopes, and atomically revoke the old one. The new raw key is returned exactly once in the response (and is also persisted encrypted-at-rest so it can be revealed again later). Owner-only: only the user who owns the key can rotate it. Non-owners receive 404 (indistinguishable from a missing key) to prevent key-id enumeration. Auth: requires a user token or an Admin API key (workspace:admin); workspace-bound data keys are rejected with 403.",
+        "parameters": [
+          {
+            "description": "API key ID to rotate",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "New key ID, new raw key (save this), and inherited label",
+            "schema": {
+              "$ref": "#/definitions/handlers.rotateAPIKeyResponse"
+            }
+          },
+          "401": {
+            "description": "No user in token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Requires a user token or an Admin API key",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Key not found or not owned by caller",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Key is already revoked",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Rotate an API key",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/exchange": {
+      "post": {
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nValidate an Auth0 Bearer token via JWKS and return per-workspace NAMS JWTs. Automatically provisions a default workspace for first-time users. Returns an array of {workspace_id, token} pairs - one per workspace the user belongs to.",
+        "parameters": [
+          {
+            "description": "Auth0 Bearer token",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns workspaces array with workspace_id and token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ExchangeAuth0Response"
+            }
+          },
+          "401": {
+            "description": "Invalid or missing token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "501": {
+            "description": "Auth0 exchange not configured",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "summary": "Exchange Auth0 token for NAMS JWTs",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/oauth/callback": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nHandles OAuth2 authorization code flow. Exchanges the provider code for user info and returns a NAMS JWT. Currently returns 501 - implementation pending.",
+        "parameters": [
+          {
+            "description": "OAuth provider and authorization code",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.oauthCallbackRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "JWT token (when implemented)",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "501": {
+            "description": "Not implemented",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "summary": "OAuth2 callback (not yet implemented)",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/refresh": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "**Auth service base URL:** `https://memory.neo4jlabs.com`\n\nExchange a refresh token for a new access token and rotated refresh token.",
+        "parameters": [
+          {
+            "description": "Refresh token",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.refreshRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "New access and refresh tokens",
+            "schema": {
+              "$ref": "#/definitions/handlers.refreshResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Invalid or expired refresh token",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "summary": "Refresh an access token",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/conversations": {
+      "get": {
+        "description": "List conversations for the workspace, newest first. Returns metadata only (no message bodies), plus a display title and firstMessageSnippet per conversation. The title is read from the conversation's metadata \"title\" key (set metadata.title at creation to give a conversation a display name); firstMessageSnippet is the first message's content truncated to 120 characters. Both are empty strings when unset.",
+        "parameters": [
+          {
+            "description": "Max conversations to return (1-200, default 50)",
+            "in": "query",
+            "name": "limit",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns conversations array",
+            "schema": {
+              "$ref": "#/definitions/handlers.ConversationsResponse"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List conversations",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Create a new conversation session. Returns the conversation ID used for all subsequent message, context, and search calls. Entity extraction runs asynchronously after messages are added.",
+        "parameters": [
+          {
+            "description": "Optional user ID and metadata",
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/handlers.createConversationRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns id, workspaceId, userId, metadata",
+            "schema": {
+              "$ref": "#/definitions/handlers.CreateConversationResponse"
+            }
+          },
+          "400": {
+            "description": "workspace_id required",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/v1/conversations/{id}": {
+      "delete": {
+        "description": "Delete a conversation and all its messages.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status: deleted",
+            "schema": {
+              "$ref": "#/definitions/handlers.StatusResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "get": {
+        "description": "Get conversation metadata by ID.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns id, workspaceId, userId, metadata, createdAt, updatedAt",
+            "schema": {
+              "$ref": "#/definitions/handlers.ConversationResponse"
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/context": {
+      "get": {
+        "description": "Get the structured context for an agent to build its prompt from. Returns three tiers: (1) reflections - highest-level compressed insights, (2) observations - mid-level summaries, (3) recentMessages - raw recent messages. Call this before constructing an agent's system prompt.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns reflections, observations, recentMessages arrays",
+            "schema": {
+              "$ref": "#/definitions/handlers.ContextResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get three-tier context",
+        "tags": [
+          "Messages"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/extraction-status": {
+      "get": {
+        "description": "Per-unit extraction status for a conversation's messages (E6): status, last run, attempts, error.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get extraction status",
+        "tags": [
+          "Short-Term Memory"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/messages": {
+      "get": {
+        "description": "List messages in a conversation, newest first. Use the limit parameter to control page size (default 50, max 200).",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Max messages to return (1-200, default 50)",
+            "in": "query",
+            "name": "limit",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns messages array",
+            "schema": {
+              "$ref": "#/definitions/handlers.MessagesResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List messages",
+        "tags": [
+          "Messages"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Add a message to a conversation. Triggers asynchronous entity extraction via the memory worker. Role must be \"user\", \"assistant\", or \"system\".",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Message role and content",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.addMessageRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns id, conversationId, role, content",
+            "schema": {
+              "$ref": "#/definitions/handlers.AddMessageResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid role or missing fields",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Add a message",
+        "tags": [
+          "Messages"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/messages/bulk": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Add multiple messages to a conversation in a single request. Each message triggers async entity extraction independently. Maximum 100 messages per request.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Array of messages",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.addMessagesBulkRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns messages array with IDs",
+            "schema": {
+              "$ref": "#/definitions/handlers.AddMessagesBatchResponse"
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Add messages in bulk",
+        "tags": [
+          "Messages"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/observations": {
+      "get": {
+        "description": "List compressed observations for a conversation. Observations are auto-generated summaries of message windows, created by the memory worker after sufficient messages accumulate.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Max observations to return (1-200, default 50)",
+            "in": "query",
+            "name": "limit",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns observations array",
+            "schema": {
+              "$ref": "#/definitions/handlers.ObservationsResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List observations",
+        "tags": [
+          "Observations"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/reflections": {
+      "get": {
+        "description": "List reflections for a conversation. Reflections are higher-level insights synthesized from multiple observations. Each new reflection supersedes the previous.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns reflections array",
+            "schema": {
+              "$ref": "#/definitions/handlers.ReflectionsResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List reflections",
+        "tags": [
+          "Observations"
+        ]
+      }
+    },
+    "/v1/conversations/{id}/search": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Search messages within a conversation by content. Uses vector similarity search when embeddings are available, falling back to text CONTAINS. Returns searchType field indicating which method was used.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Search query and optional limit",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.searchMessagesRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns messages array and searchType",
+            "schema": {
+              "$ref": "#/definitions/handlers.SearchMessagesResponse"
+            }
+          },
+          "400": {
+            "description": "Missing query",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Search messages",
+        "tags": [
+          "Messages"
+        ]
+      }
+    },
+    "/v1/entities": {
+      "get": {
+        "description": "List all entities in the knowledge graph. Filter by type using the optional query parameter.",
+        "parameters": [
+          {
+            "description": "Filter by type: person, organization, location, concept, tool, custom",
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns entities array",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntitiesResponse"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List entities",
+        "tags": [
+          "Entities"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Create a new entity in the knowledge graph. Entities are automatically created during entity extraction, but can also be created manually.",
+        "parameters": [
+          {
+            "description": "Entity name, type, and optional description",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.createEntityRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns id, name, type, description",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntityResponse"
+            }
+          },
+          "400": {
+            "description": "Missing required fields",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create an entity",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/count": {
+      "get": {
+        "description": "Returns the count of canonical (non-merged) entities in the workspace. A cheap signal the Memory Browser polls to surface a \"new entities available\" refresh affordance without re-fetching the full graph.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns count",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Missing workspace_id",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Count entities",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/graph": {
+      "get": {
+        "description": "Get the full entity graph with nodes and edges for visualization. Used by the Memory Browser in the dashboard.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns nodes and edges arrays",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntityGraphResponse"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get entity graph",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/search": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Search entities by name or description. Uses vector similarity search when embeddings are available, falling back to text CONTAINS. Returns searchType field indicating which method was used.",
+        "parameters": [
+          {
+            "description": "Search query with optional type filter and limit",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.searchEntitiesRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns entities array and searchType",
+            "schema": {
+              "$ref": "#/definitions/handlers.SearchEntitiesResponse"
+            }
+          },
+          "400": {
+            "description": "Missing query",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Search entities",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}": {
+      "delete": {
+        "description": "Delete an entity and all its relationships from the knowledge graph.",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status: deleted",
+            "schema": {
+              "$ref": "#/definitions/handlers.StatusResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete an entity",
+        "tags": [
+          "Entities"
+        ]
+      },
+      "get": {
+        "description": "Get entity details including all relationships (incoming and outgoing edges in the knowledge graph).",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns entity fields and relationships array",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntityDetailsResponse"
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get an entity",
+        "tags": [
+          "Entities"
+        ]
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Update an entity's name or description.",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Fields to update",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.updateEntityRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status: updated",
+            "schema": {
+              "$ref": "#/definitions/handlers.StatusResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update an entity",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/feedback": {
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Provide feedback on entity quality. userScore is a float 0-1 representing confidence. confirmed=true marks the entity as human-verified.",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Score and/or confirmation",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.entityFeedbackRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns id, updated: true",
+            "schema": {
+              "$ref": "#/definitions/handlers.UpdateSchemaResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Score an entity",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/history": {
+      "get": {
+        "description": "Get cross-conversation history - all messages that mention this entity, across all conversations in the workspace.",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns entityId and mentions array",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntityProvenanceResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get entity history",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/merge": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Merge the source entity into a target entity. All relationships are transferred to the target. A SAME_AS relationship is created for provenance. The source entity is not deleted but becomes inert.",
+        "parameters": [
+          {
+            "description": "Source entity ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Target entity ID to merge into",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.mergeEntitiesRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status: merged, sourceId, targetId",
+            "schema": {
+              "$ref": "#/definitions/handlers.MergeEntitiesResponse"
+            }
+          },
+          "400": {
+            "description": "Missing targetId or attempted self-merge",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Target entity not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Merge entities",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/feedback": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Persists a feedback submission (bug, feature request, question, or general) to the operational database with auto-captured context.",
+        "parameters": [
+          {
+            "description": "Feedback payload",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.createFeedbackRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "validation error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "payload too large",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "rate limited",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "503": {
+            "description": "feature disabled",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Submit user feedback",
+        "tags": [
+          "Feedback"
+        ]
+      }
+    },
+    "/v1/feedback/config": {
+      "get": {
+        "description": "Returns whether in-app feedback submission is enabled for this deployment.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "{\\\"enabled\\\": true}",
+            "schema": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Feedback feature flag",
+        "tags": [
+          "Feedback"
+        ]
+      }
+    },
+    "/v1/graph/expand": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Returns the 1-hop neighborhood of a node plus the complete, canonical-resolved set of relationships among the resulting node set, for the Memory Browser. Provenance edges (MENTIONS/INFLUENCED) are included; merge plumbing (MERGED_REL/SAME_AS) is excluded. New neighbors are capped with loud truncation metadata.",
+        "parameters": [
+          {
+            "description": "nodeId to expand and the currently-loaded node ids",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.ExpandRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns nodes, edges and truncated metadata",
+            "schema": {
+              "$ref": "#/definitions/handlers.ExpandResponse"
+            }
+          },
+          "400": {
+            "description": "Missing workspace_id or nodeId, or loadedIds exceeds cap",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Expand a graph node",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/ontologies": {
+      "get": {
+        "description": "List system templates and workspace-owned ontologies. The active ontology is flagged.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.ListOntologiesResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List ontologies",
+        "tags": [
+          "Ontology"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Ontology body",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.CreateOntologyRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create ontology",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/active": {
+      "get": {
+        "description": "Get the workspace's currently active ontology version and its parsed body.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.ActiveOntologyResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get active ontology",
+        "tags": [
+          "Ontology"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Version to activate",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.ActivateOntologyRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Activate an ontology version",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/import": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Convert an Arrows / Neo4j Data Importer / RDF / GraphQL / Cypher / LinkML / native document into a native ontology draft. Supply either `content` (inline) or `url` (fetched server-side, SSRF-guarded, https only). Returns the draft and conversion warnings; does not persist.",
+        "parameters": [
+          {
+            "description": "Source document/url and format",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.ImportOntologyRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.ImportOntologyResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Import an ontology from an external format",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/migrations/{job_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Migration job ID",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.MigrationJob"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get migration status",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/migrations/{job_id}/pause": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Migration job ID",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Pause a running migration",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/migrations/{job_id}/resume": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Migration job ID",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Resume a paused migration",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/pending-types": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List pending types for the workspace's active ontology",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/preview": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Sample text + draft ontology",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.PreviewRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.PreviewResponse"
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Live-preview entity extraction",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete ontology (soft delete)",
+        "tags": [
+          "Ontology"
+        ]
+      },
+      "get": {
+        "description": "Get one ontology (system or workspace-owned) and its version history.",
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyDetail"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get ontology",
+        "tags": [
+          "Ontology"
+        ]
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "New body",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.UpdateOntologyRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update ontology (creates new revision)",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/clone": {
+      "post": {
+        "parameters": [
+          {
+            "description": "System template name",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Clone a system template",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/diff": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "From revision",
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "To revision",
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyDiff"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Diff two ontology revisions",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/migrate": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Migration spec",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.MigrateRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/ontology.MigrationJob"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Enqueue an ontology migration",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/pending-types": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List pending types for a specific ontology",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/pending-types/{ptId}/map": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Pending Type ID",
+            "in": "path",
+            "name": "ptId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Target entity type label",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.MapPendingTypeRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Map a pending type to an existing entity type (adds alias)",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/ontologies/{id}/versions/{revision}": {
+      "get": {
+        "description": "Get one specific revision of an ontology.",
+        "parameters": [
+          {
+            "description": "Ontology ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Revision number",
+            "in": "path",
+            "name": "revision",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ontology.OntologyVersionRecord"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/gin.H"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get ontology version",
+        "tags": [
+          "Ontology"
+        ]
+      }
+    },
+    "/v1/query": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Runs caller-supplied Cypher against the tenant's graph database with Neo4j's READ access mode. Writes are rejected server-side. Returns columns, rows, and stats.",
+        "parameters": [
+          {
+            "description": "Cypher query string and optional params map",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.queryRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns columns, rows, stats",
+            "schema": {
+              "$ref": "#/definitions/handlers.QueryResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid query, write operation attempted, or Cypher error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "502": {
+            "description": "Query backend unavailable",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Execute a read-only Cypher query",
+        "tags": [
+          "Query"
+        ]
+      }
+    },
+    "/v1/reasoning/explain/{stepId}": {
+      "get": {
+        "description": "Get a detailed explanation of a reasoning step including its tool calls and the entities it influenced.",
+        "parameters": [
+          {
+            "description": "Step ID",
+            "in": "path",
+            "name": "stepId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns step details, toolCalls, and influencedEntities",
+            "schema": {
+              "$ref": "#/definitions/handlers.ReasoningStepDetailsResponse"
+            }
+          },
+          "404": {
+            "description": "Step not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Explain a reasoning step",
+        "tags": [
+          "Reasoning"
+        ]
+      }
+    },
+    "/v1/reasoning/provenance/{entityId}": {
+      "get": {
+        "description": "Get the reasoning chain that influenced the creation of an entity - which steps and tool calls contributed to it.",
+        "parameters": [
+          {
+            "description": "Entity ID",
+            "in": "path",
+            "name": "entityId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns entityId and provenance chain",
+            "schema": {
+              "$ref": "#/definitions/handlers.EntityReasoningProvenanceResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get entity provenance",
+        "tags": [
+          "Reasoning"
+        ]
+      }
+    },
+    "/v1/reasoning/steps": {
+      "get": {
+        "description": "List reasoning steps for a conversation. The conversation_id query parameter is required.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "query",
+            "name": "conversation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns steps array",
+            "schema": {
+              "$ref": "#/definitions/handlers.ReasoningStepsResponse"
+            }
+          },
+          "400": {
+            "description": "Missing conversation_id",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List reasoning steps",
+        "tags": [
+          "Reasoning"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Record a reasoning step taken by an agent. Captures the agent's thought process (reasoning), the action it decided to take (actionTaken), and optionally the result.",
+        "parameters": [
+          {
+            "description": "Step details",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.recordStepRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns id, conversationId, reasoning, actionTaken, result",
+            "schema": {
+              "$ref": "#/definitions/handlers.RecordReasoningStepResponse"
+            }
+          },
+          "400": {
+            "description": "Missing required fields",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Record a reasoning step",
+        "tags": [
+          "Reasoning"
+        ]
+      }
+    },
+    "/v1/reasoning/tool-calls": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Record a tool invocation made by an agent during a reasoning step. Optionally link to a step via stepId.\n\n`input` and `output` must be JSON-encoded strings, not objects. Pre-serialize structured payloads before sending (e.g. `\"input\": \"{\\\"query\\\":\\\"foo\\\"}\"`, not `\"input\": {\"query\":\"foo\"}`). The graph stores them as scalar string properties on the :ToolCall node.\n\nStatus values: `pending`, `success` (default), `failure`, `error`, `timeout`, `cancelled`. Legacy `completed`/`failed` are accepted and rewritten to `success`/`failure`.",
+        "parameters": [
+          {
+            "description": "Tool call details",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.recordToolCallRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns id, stepId, toolName, status",
+            "schema": {
+              "$ref": "#/definitions/handlers.RecordToolCallResponse"
+            }
+          },
+          "400": {
+            "description": "Missing required fields",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Record a tool call",
+        "tags": [
+          "Reasoning"
+        ]
+      }
+    },
+    "/v1/reasoning/trace/{conversationId}": {
+      "get": {
+        "description": "Get the full reasoning trace for a conversation - all steps and their tool calls, in order.",
+        "parameters": [
+          {
+            "description": "Conversation ID",
+            "in": "path",
+            "name": "conversationId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns conversationId, steps with nested toolCalls",
+            "schema": {
+              "$ref": "#/definitions/handlers.ConversationReasoningResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get reasoning trace",
+        "tags": [
+          "Reasoning"
+        ]
+      }
+    },
+    "/v1/reviews": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Page size (1..200, default 50)",
+            "in": "query",
+            "name": "limit",
+            "type": "integer"
+          },
+          {
+            "description": "Pagination offset (default 0)",
+            "in": "query",
+            "name": "offset",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List pending entity-resolution review pairs",
+        "tags": [
+          "Reviews"
+        ]
+      }
+    },
+    "/v1/reviews/bulk": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Bulk decision payload",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.bulkReviewRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Bulk-apply a decision to high-confidence pending pairs",
+        "tags": [
+          "Reviews"
+        ]
+      }
+    },
+    "/v1/reviews/stats": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Pending review queue stats",
+        "tags": [
+          "Reviews"
+        ]
+      }
+    },
+    "/v1/reviews/stats/pending": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "Workspace database removed (database_unavailable) - reprovision or update the external connection",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal error (cypher_error or internal)",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          },
+          "503": {
+            "description": "Workspace database unreachable (db_unreachable); also returned as {error: workspace_not_provisioned, status, statusMessage} while the workspace is provisioning",
+            "schema": {
+              "$ref": "#/definitions/handlers.TenantQueryErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Pending review queue count (badge-only)",
+        "tags": [
+          "Reviews"
+        ]
+      }
+    },
+    "/v1/reviews/{pairId}/decision": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Pair ID (hash of sourceId→targetId)",
+            "in": "path",
+            "name": "pairId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Decision payload",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.reviewDecisionRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Confirm, reject, or redirect a SAME_AS pending pair",
+        "tags": [
+          "Reviews"
+        ]
+      }
+    },
+    "/v1/skills": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List skills",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/capabilities": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Report enabled skill features and gate thresholds",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/generate": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Scope to distill",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.generateSkillRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Run enqueued; returns runId",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Generate a skill from workspace memory",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/governance": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Audit the skill corpus (governance)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/published": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Discover published skills (workspace-scoped)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/review/bulk": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Skill IDs plus one shared decision",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.bulkReviewSkillsRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Bulk-review skills (approve/reject up to 100 in one call)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/runs/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Run ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get distillation run status",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get a skill and its versions",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/download": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/zip"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "file"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Download a skill package (zip)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/drift": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Detect skill provenance drift",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/edit": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Validate a proposed skill edit (dry run)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/edit/commit": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Edit enqueued; returns runId",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "invalid edit",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Commit a validated skill edit as a new in_review version",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/explain-provenance": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Explain a skill's provenance",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/extract-subprocedure": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Extraction enqueued; returns runId",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Extract steps into a reusable sub-procedure skill",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/publish": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "not approved",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Publish a skill",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/review": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Review decision",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.reviewSkillRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Review a skill (approve/reject)",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/steps/{stepId}/repair": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Step ID",
+            "in": "path",
+            "name": "stepId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Repair enqueued; returns runId",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Repair one drifted step of a skill",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/skills/{id}/verify": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Verify a skill version's attestation",
+        "tags": [
+          "Skills"
+        ]
+      }
+    },
+    "/v1/users/me/workspaces": {
+      "get": {
+        "description": "List the workspaces the authenticated user is a member of. A workspace-bound API key returns only its bound workspace; an admin key or user token returns all. Requires no workspace:admin scope.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceListResponse"
+            }
+          },
+          "401": {
+            "description": "no user identity",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List my workspaces",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace": {
+      "get": {
+        "description": "Return details for the workspace identified by the X-Workspace-Id header.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceDetailsResponse"
+            }
+          },
+          "401": {
+            "description": "no workspace identity",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get the current workspace",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace/database": {
+      "get": {
+        "description": "Return the workspace's database mode and connection info. The password is never included.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceDatabaseConfigResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "workspace not found",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get database configuration",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace/database/test": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Test reachability of an external Neo4j connection without storing anything. The URI is SSRF-validated.",
+        "parameters": [
+          {
+            "description": "External connection to test",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceTestConnectionRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceTestConnectionResponse"
+            }
+          },
+          "400": {
+            "description": "invalid uri",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceTestConnectionResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Test an external database connection",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace/members": {
+      "get": {
+        "description": "Return all members of the workspace.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceMembersResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List workspace members",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace/relations": {
+      "get": {
+        "description": "Return the workspace's typed-relation allowlist configuration, falling back to system defaults when unset.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceRelationsConfig"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get typed-relation config",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspace/resolution": {
+      "get": {
+        "description": "Return the workspace's entity-resolution configuration, falling back to system defaults when unset.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceResolutionConfig"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get entity-resolution config",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
+    "/v1/workspaces": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Create a new workspace with status \"pending\". A database is not provisioned automatically — provisioning is a separate step that requires a user-token session (performed from the dashboard). Workspace names are unique per owner.",
+        "parameters": [
+          {
+            "description": "Workspace name",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceCreateRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/handlers.WorkspaceCreateResponse"
+            }
+          },
+          "400": {
+            "description": "name is required",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "workspace_limit_reached",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          },
+          "409": {
+            "description": "name_taken (includes existing_workspace_id)",
+            "schema": {
+              "$ref": "#/definitions/handlers.ErrorResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create a workspace",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BearerAuth": {
+      "description": "API key (nams_...) used directly as Bearer token, or JWT from Auth0 exchange",
+      "in": "header",
+      "name": "Authorization",
+      "type": "apiKey"
+    }
+  },
+  "swagger": "2.0",
+  "tags": [
+    {
+      "description": "Short-term memory: create conversation sessions and add messages. Entity extraction runs automatically after each message.",
+      "name": "Conversations"
+    },
+    {
+      "description": "Read and search messages within a conversation.",
+      "name": "Messages"
+    },
+    {
+      "description": "Auto-generated compressed summaries of conversation message windows.",
+      "name": "Observations"
+    },
+    {
+      "description": "Long-term memory: knowledge graph entities (people, orgs, locations, concepts, tools).",
+      "name": "Entities"
+    },
+    {
+      "description": "Reasoning memory: record and retrieve agent steps, tool calls, and decision traces.",
+      "name": "Reasoning"
+    },
+    {
+      "description": "Execute read-only Cypher queries directly against the tenant graph.",
+      "name": "Query"
+    },
+    {
+      "description": "Workspace management: CRUD, membership, database provisioning (managed sandbox or external Neo4j), backups, and feature configuration. Served by the nams-tenants service via reverse proxy.",
+      "name": "Workspace"
+    },
+    {
+      "description": "Health and status endpoints.",
+      "name": "System"
+    },
+    {
+      "description": "Authentication - token exchange and API key management.",
+      "name": "Auth"
+    }
+  ]
+}

--- a/docs/reviews/nams-phase0-public-api-snapshot.txt
+++ b/docs/reviews/nams-phase0-public-api-snapshot.txt
@@ -1,0 +1,2642 @@
+# Public API Snapshot
+# Generated: 2026-07-17 (NAMS Phase 0 baseline, commit 60eb7c1 / tag baseline/pre-nams-2026-07-17)
+
+## AgentMemory.Abstractions (172 public types)
+
+### class AgentMemory.Abstractions.Domain.CompressedContext
+  .ctor()
+  Int32 CompressedTokenCount { get; set; }
+  IReadOnlyList`1 Observations { get; set; }
+  Int32 OriginalTokenCount { get; set; }
+  IReadOnlyList`1 RecentMessages { get; set; }
+  IReadOnlyList`1 Reflections { get; set; }
+  Boolean WasCompressed { get; set; }
+
+### class AgentMemory.Abstractions.Domain.Conversation
+  .ctor()
+  Conversation <Clone>$()
+  Boolean Archived { get; set; }
+  String ConversationId { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Conversation other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String SessionId { get; set; }
+  String Title { get; set; }
+  String ToString()
+  DateTimeOffset UpdatedAtUtc { get; set; }
+  String UserId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.DeduplicationStats
+  .ctor(Int32 PendingCount, Int32 ConfirmedCount, Int32 RejectedCount, Int32 MergedCount)
+  DeduplicationStats <Clone>$()
+  Int32 ConfirmedCount { get; set; }
+  Void Deconstruct(Int32& PendingCount, Int32& ConfirmedCount, Int32& RejectedCount, Int32& MergedCount)
+  Boolean Equals(Object obj)
+  Boolean Equals(DeduplicationStats other)
+  Int32 GetHashCode()
+  Int32 MergedCount { get; set; }
+  Int32 PendingCount { get; set; }
+  Int32 RejectedCount { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.DuplicatePair
+  .ctor(Entity Source, Entity Target, Double Similarity, DuplicateStatus Status)
+  DuplicatePair <Clone>$()
+  Void Deconstruct(Entity& Source, Entity& Target, Double& Similarity, DuplicateStatus& Status)
+  Boolean Equals(Object obj)
+  Boolean Equals(DuplicatePair other)
+  Int32 GetHashCode()
+  Double Similarity { get; set; }
+  Entity Source { get; set; }
+  DuplicateStatus Status { get; set; }
+  Entity Target { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Domain.DuplicateStatus
+  DuplicateStatus Confirmed
+  DuplicateStatus Merged
+  DuplicateStatus Pending
+  DuplicateStatus Rejected
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.Enrichment.EnrichmentResult
+  .ctor()
+  EnrichmentResult <Clone>$()
+  Nullable`1 Confidence { get; set; }
+  String Description { get; set; }
+  String EntityName { get; set; }
+  String EntityType { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EnrichmentResult other)
+  String ErrorMessage { get; set; }
+  Int32 GetHashCode()
+  String ImageUrl { get; set; }
+  IReadOnlyList`1 Images { get; set; }
+  IReadOnlyDictionary`2 Properties { get; set; }
+  String Provider { get; set; }
+  String ProviderUri { get; set; }
+  IReadOnlyList`1 RelatedEntities { get; set; }
+  DateTimeOffset RetrievedAtUtc { get; set; }
+  String SourceUrl { get; set; }
+  Nullable`1 Status { get; set; }
+  String Summary { get; set; }
+  String ToString()
+  String WikipediaUrl { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.Enrichment.EnrichmentStatus
+  EnrichmentStatus Error
+  EnrichmentStatus NotFound
+  EnrichmentStatus RateLimited
+  EnrichmentStatus Skipped
+  EnrichmentStatus Success
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.Enrichment.GeocodingResult
+  .ctor()
+  GeocodingResult <Clone>$()
+  String City { get; set; }
+  Nullable`1 Confidence { get; set; }
+  String Country { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(GeocodingResult other)
+  String FormattedAddress { get; set; }
+  Int32 GetHashCode()
+  Double Latitude { get; set; }
+  Double Longitude { get; set; }
+  String Provider { get; set; }
+  String Region { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Enrichment.RelatedEntity
+  .ctor()
+  RelatedEntity <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(RelatedEntity other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  String ProviderUri { get; set; }
+  String Relation { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Entity
+  .ctor()
+  Entity <Clone>$()
+  IReadOnlyList`1 Aliases { get; set; }
+  IReadOnlyDictionary`2 Attributes { get; set; }
+  String CanonicalName { get; set; }
+  Double Confidence { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  String Description { get; set; }
+  Single[] Embedding { get; set; }
+  String EntityId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Entity other)
+  Int32 GetHashCode()
+  Nullable`1 Latitude { get; set; }
+  Nullable`1 Longitude { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Name { get; set; }
+  String OwnerId { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  String Subtype { get; set; }
+  String ToString()
+  String Type { get; set; }
+  Nullable`1 UpdatedAtUtc { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.EntityMatchType
+  EntityMatchType Exact
+  EntityMatchType Fuzzy
+  EntityMatchType New
+  EntityMatchType Semantic
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.EntityProvenance
+  .ctor(String EntityId, IReadOnlyList`1 Sources, IReadOnlyList`1 Extractors)
+  EntityProvenance <Clone>$()
+  Void Deconstruct(String& EntityId, IReadOnlyList`1& Sources, IReadOnlyList`1& Extractors)
+  String EntityId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntityProvenance other)
+  IReadOnlyList`1 Extractors { get; set; }
+  Int32 GetHashCode()
+  IReadOnlyList`1 Sources { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.EntityResolutionResult
+  .ctor()
+  EntityResolutionResult <Clone>$()
+  Double Confidence { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntityResolutionResult other)
+  Int32 GetHashCode()
+  EntityMatchType MatchType { get; set; }
+  String MergedFromEntityId { get; set; }
+  Entity ResolvedEntity { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.EntityType
+  IReadOnlyList`1 All
+  String Event
+  Boolean IsKnownType(String type)
+  String Location
+  String Normalize(String type)
+  String Object
+  String Organization
+  String Person
+  String Unknown
+
+### class AgentMemory.Abstractions.Domain.ExtractedEntity
+  .ctor()
+  ExtractedEntity <Clone>$()
+  IReadOnlyList`1 Aliases { get; set; }
+  IReadOnlyDictionary`2 Attributes { get; set; }
+  Double Confidence { get; set; }
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractedEntity other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  String Subtype { get; set; }
+  String ToString()
+  String Type { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ExtractedFact
+  .ctor()
+  ExtractedFact <Clone>$()
+  Double Confidence { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractedFact other)
+  Int32 GetHashCode()
+  String Object { get; set; }
+  String Predicate { get; set; }
+  String Subject { get; set; }
+  String ToString()
+  Nullable`1 ValidFrom { get; set; }
+  Nullable`1 ValidUntil { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ExtractedPreference
+  .ctor()
+  ExtractedPreference <Clone>$()
+  String Category { get; set; }
+  Double Confidence { get; set; }
+  String Context { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractedPreference other)
+  Int32 GetHashCode()
+  String PreferenceText { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ExtractedRelationship
+  .ctor()
+  ExtractedRelationship <Clone>$()
+  IReadOnlyDictionary`2 Attributes { get; set; }
+  Double Confidence { get; set; }
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractedRelationship other)
+  Int32 GetHashCode()
+  String RelationshipType { get; set; }
+  String SourceEntity { get; set; }
+  String TargetEntity { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Extraction.Streaming.ChunkInfo
+  .ctor()
+  ChunkInfo <Clone>$()
+  Int32 ApproxTokenCount { get; }
+  Int32 CharCount { get; }
+  Int32 EndChar { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ChunkInfo other)
+  Int32 GetHashCode()
+  Int32 Index { get; set; }
+  Boolean IsFirst { get; set; }
+  Boolean IsLast { get; set; }
+  Int32 StartChar { get; set; }
+  String Text { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Extraction.Streaming.StreamingChunkResult
+  .ctor()
+  StreamingChunkResult <Clone>$()
+  ChunkInfo Chunk { get; set; }
+  Double DurationMs { get; set; }
+  Int32 EntityCount { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(StreamingChunkResult other)
+  String Error { get; set; }
+  Int32 GetHashCode()
+  Int32 RelationCount { get; }
+  ExtractionResult Result { get; set; }
+  Boolean Success { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Extraction.Streaming.StreamingExtractionResult
+  .ctor()
+  StreamingExtractionResult <Clone>$()
+  IReadOnlyList`1 ChunkResults { get; set; }
+  IReadOnlyList`1 Entities { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(StreamingExtractionResult other)
+  Int32 GetHashCode()
+  IReadOnlyList`1 Relationships { get; set; }
+  StreamingExtractionStats Stats { get; set; }
+  ExtractionResult ToExtractionResult()
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Extraction.Streaming.StreamingExtractionStats
+  .ctor()
+  StreamingExtractionStats <Clone>$()
+  Int32 DeduplicatedEntities { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(StreamingExtractionStats other)
+  Int32 FailedChunks { get; set; }
+  Int32 GetHashCode()
+  Int32 SuccessfulChunks { get; set; }
+  String ToString()
+  Int32 TotalCharacters { get; set; }
+  Int32 TotalChunks { get; set; }
+  Double TotalDurationMs { get; set; }
+  Int32 TotalEntities { get; set; }
+  Int32 TotalRelations { get; set; }
+  Int32 TotalTokensApprox { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ExtractionRequest
+  .ctor()
+  ExtractionRequest <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractionRequest other)
+  Int32 GetHashCode()
+  IReadOnlyList`1 Messages { get; set; }
+  IReadOnlyDictionary`2 Options { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+  Nullable`1 TrustLevel { get; set; }
+  ExtractionTypes TypesToExtract { get; set; }
+  String UserId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ExtractionResult
+  .ctor()
+  ExtractionResult <Clone>$()
+  IReadOnlyList`1 Entities { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractionResult other)
+  IReadOnlyList`1 Facts { get; set; }
+  Int32 GetHashCode()
+  Boolean IsPartial { get; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  IReadOnlyList`1 Outcomes { get; set; }
+  IReadOnlyList`1 Preferences { get; set; }
+  IReadOnlyList`1 Relationships { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  IngestionStatus Status { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ExtractionStats
+  .ctor(Int32 TotalEntities, Int32 TotalMessages, Double AvgEntitiesPerMessage)
+  ExtractionStats <Clone>$()
+  Double AvgEntitiesPerMessage { get; set; }
+  Void Deconstruct(Int32& TotalEntities, Int32& TotalMessages, Double& AvgEntitiesPerMessage)
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractionStats other)
+  Int32 GetHashCode()
+  String ToString()
+  Int32 TotalEntities { get; set; }
+  Int32 TotalMessages { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.ExtractionTypes
+  ExtractionTypes All
+  ExtractionTypes Entities
+  ExtractionTypes Facts
+  ExtractionTypes None
+  ExtractionTypes Preferences
+  ExtractionTypes Relationships
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.Extractor
+  .ctor()
+  Extractor <Clone>$()
+  String ConfigJson { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Extractor other)
+  String ExtractorId { get; set; }
+  Int32 GetHashCode()
+  String Name { get; set; }
+  String ToString()
+  String Version { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ExtractorStats
+  .ctor(String ExtractorName, Int32 EntityCount, Double AvgConfidence, Int32 TotalExtractions)
+  ExtractorStats <Clone>$()
+  Double AvgConfidence { get; set; }
+  Void Deconstruct(String& ExtractorName, Int32& EntityCount, Double& AvgConfidence, Int32& TotalExtractions)
+  Int32 EntityCount { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ExtractorStats other)
+  String ExtractorName { get; set; }
+  Int32 GetHashCode()
+  String ToString()
+  Int32 TotalExtractions { get; set; }
+
+### class AgentMemory.Abstractions.Domain.Fact
+  .ctor()
+  Fact <Clone>$()
+  String Category { get; set; }
+  Double Confidence { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Fact other)
+  String FactId { get; set; }
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Object { get; set; }
+  String OwnerId { get; set; }
+  String Predicate { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  String Subject { get; set; }
+  String ToString()
+  Nullable`1 ValidFrom { get; set; }
+  Nullable`1 ValidUntil { get; set; }
+
+### class AgentMemory.Abstractions.Domain.GraphRagContextItem
+  .ctor()
+  GraphRagContextItem <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(GraphRagContextItem other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  Double Score { get; set; }
+  IReadOnlyList`1 SourceNodeIds { get; set; }
+  String Text { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.GraphRagContextRequest
+  .ctor()
+  GraphRagContextRequest <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(GraphRagContextRequest other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Options { get; set; }
+  String Query { get; set; }
+  GraphRagSearchMode SearchMode { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+  Int32 TopK { get; set; }
+  String UserId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.GraphRagContextResult
+  .ctor()
+  GraphRagContextResult <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(GraphRagContextResult other)
+  Int32 GetHashCode()
+  IReadOnlyList`1 Items { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Domain.GraphRagSearchMode
+  GraphRagSearchMode Fulltext
+  GraphRagSearchMode Graph
+  GraphRagSearchMode Hybrid
+  GraphRagSearchMode Vector
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.IngestionItemOutcome
+  .ctor()
+  IngestionItemOutcome <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(IngestionItemOutcome other)
+  String ErrorCode { get; set; }
+  String ErrorMessage { get; set; }
+  Int32 GetHashCode()
+  MemoryItemKind Kind { get; set; }
+  String PersistedId { get; set; }
+  Boolean Retryable { get; set; }
+  String SourceKey { get; set; }
+  IngestionStage Stage { get; set; }
+  IngestionItemStatus Status { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Domain.IngestionItemStatus
+  IngestionItemStatus Failed
+  IngestionItemStatus Skipped
+  IngestionItemStatus Succeeded
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.IngestionStage
+  IngestionStage Embedding
+  IngestionStage Extraction
+  IngestionStage Persistence
+  IngestionStage Provenance
+  IngestionStage RelationshipPersistence
+  IngestionStage Resolution
+  IngestionStage Validation
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.IngestionStatus
+  IngestionStatus Failed
+  IngestionStatus PartiallySucceeded
+  IngestionStatus Succeeded
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.MemoryContext
+  .ctor()
+  MemoryContext <Clone>$()
+  DateTimeOffset AssembledAtUtc { get; set; }
+  RetrievalBlendMode BlendMode { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryContext other)
+  Int32 GetHashCode()
+  String GraphRagContext { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  MemoryContextSection`1 RecentMessages { get; set; }
+  MemoryContextSection`1 RelevantEntities { get; set; }
+  MemoryContextSection`1 RelevantFacts { get; set; }
+  MemoryContextSection`1 RelevantMessages { get; set; }
+  MemoryContextSection`1 RelevantPreferences { get; set; }
+  String SessionId { get; set; }
+  MemoryContextSection`1 SimilarTraces { get; set; }
+  String ToString()
+  Boolean Truncated { get; set; }
+
+### class AgentMemory.Abstractions.Domain.MemoryContextSection`1
+  .ctor()
+  MemoryContextSection`1 <Clone>$()
+  MemoryContextSection`1 Empty { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryContextSection`1 other)
+  Int32 GetHashCode()
+  IReadOnlyList`1 Items { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Domain.MemoryHistoryKind
+  MemoryHistoryKind Entity
+  MemoryHistoryKind Fact
+  MemoryHistoryKind Preference
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.MemoryHistoryQuery
+  .ctor()
+  MemoryHistoryQuery <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryHistoryQuery other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  Boolean IncludeInvalidated { get; set; }
+  Boolean IncludeShared { get; set; }
+  Nullable`1 Kind { get; set; }
+  Int32 Limit { get; set; }
+  String OwnerId { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.MemoryHistoryRecord
+  .ctor()
+  MemoryHistoryRecord <Clone>$()
+  Int32 AccessCount { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryHistoryRecord other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  Nullable`1 InvalidatedAtUtc { get; set; }
+  MemoryHistoryKind Kind { get; set; }
+  Nullable`1 LastAccessedAtUtc { get; set; }
+  Nullable`1 LastReadAuditAtUtc { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String OwnerId { get; set; }
+  Int32 ReadAuditCount { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  MemoryHistoryStatus Status { get; set; }
+  String Summary { get; set; }
+  IReadOnlyList`1 SupersededByIds { get; set; }
+  IReadOnlyList`1 SupersedesIds { get; set; }
+  String ToString()
+  Nullable`1 UpdatedAtUtc { get; set; }
+  Nullable`1 ValidFromUtc { get; set; }
+  Nullable`1 ValidUntilUtc { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.MemoryHistoryStatus
+  MemoryHistoryStatus Invalidated
+  MemoryHistoryStatus Live
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.MemoryItemKind
+  MemoryItemKind Entity
+  MemoryItemKind Fact
+  MemoryItemKind Preference
+  MemoryItemKind Relationship
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.MemoryNodeKind
+  MemoryNodeKind Entity
+  MemoryNodeKind Fact
+  MemoryNodeKind Preference
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.MemoryOperationAccess
+  MemoryOperationAccess Administrative
+  MemoryOperationAccess Tenant
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Domain.MemoryTrustLevel
+  MemoryTrustLevel ApplicationTrusted
+  MemoryTrustLevel ModelGenerated
+  MemoryTrustLevel ToolDerived
+  MemoryTrustLevel Untrusted
+  MemoryTrustLevel UserProvided
+  MemoryTrustLevel VerifiedExternal
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.MemoryTrustMetadataExtensions
+  IReadOnlyDictionary`2 CreateWithTrustLevel(MemoryTrustLevel trustLevel)
+  MemoryTrustLevel GetTrustLevel(IReadOnlyDictionary`2 metadata)
+  IReadOnlyDictionary`2 WithTrustLevel(IReadOnlyDictionary`2 metadata, MemoryTrustLevel trustLevel)
+  IReadOnlyDictionary`2 WithoutCallerSuppliedTrustLevel(IReadOnlyDictionary`2 metadata)
+
+### enum AgentMemory.Abstractions.Domain.MergeStrategyType
+  MergeStrategyType Cascade
+  MergeStrategyType Confidence
+  MergeStrategyType FirstSuccess
+  MergeStrategyType Intersection
+  MergeStrategyType Union
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.Message
+  .ctor()
+  Message <Clone>$()
+  String Content { get; set; }
+  String ConversationId { get; set; }
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Message other)
+  Int32 GetHashCode()
+  String MessageId { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Role { get; set; }
+  String SessionId { get; set; }
+  DateTimeOffset TimestampUtc { get; set; }
+  String ToString()
+  IReadOnlyList`1 ToolCallIds { get; set; }
+
+### class AgentMemory.Abstractions.Domain.PagedResult`1
+  .ctor(IReadOnlyList`1 items, Boolean hasNextPage)
+  PagedResult`1 <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(PagedResult`1 other)
+  Int32 GetHashCode()
+  Boolean HasNextPage { get; set; }
+  IReadOnlyList`1 Items { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Preference
+  .ctor()
+  Preference <Clone>$()
+  String Category { get; set; }
+  Double Confidence { get; set; }
+  String Context { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Preference other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String OwnerId { get; set; }
+  String PreferenceId { get; set; }
+  String PreferenceText { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ProvenanceExtractor
+  .ctor(String ExtractorName, Double Confidence, Nullable`1 ExtractionTimeMs)
+  ProvenanceExtractor <Clone>$()
+  Double Confidence { get; set; }
+  Void Deconstruct(String& ExtractorName, Double& Confidence, Nullable`1& ExtractionTimeMs)
+  Boolean Equals(Object obj)
+  Boolean Equals(ProvenanceExtractor other)
+  Nullable`1 ExtractionTimeMs { get; set; }
+  String ExtractorName { get; set; }
+  Int32 GetHashCode()
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ProvenanceSource
+  .ctor(String MessageId, Nullable`1 Confidence, Nullable`1 StartPos, Nullable`1 EndPos)
+  ProvenanceSource <Clone>$()
+  Nullable`1 Confidence { get; set; }
+  Void Deconstruct(String& MessageId, Nullable`1& Confidence, Nullable`1& StartPos, Nullable`1& EndPos)
+  Nullable`1 EndPos { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ProvenanceSource other)
+  Int32 GetHashCode()
+  String MessageId { get; set; }
+  Nullable`1 StartPos { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ReasoningStep
+  .ctor()
+  ReasoningStep <Clone>$()
+  String Action { get; set; }
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ReasoningStep other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Observation { get; set; }
+  String StepId { get; set; }
+  Int32 StepNumber { get; set; }
+  String Thought { get; set; }
+  Nullable`1 TimestampUtc { get; set; }
+  String ToString()
+  String TraceId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ReasoningTrace
+  .ctor()
+  ReasoningTrace <Clone>$()
+  Nullable`1 CompletedAtUtc { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ReasoningTrace other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Outcome { get; set; }
+  String OwnerId { get; set; }
+  String SessionId { get; set; }
+  DateTimeOffset StartedAtUtc { get; set; }
+  Nullable`1 Success { get; set; }
+  String Task { get; set; }
+  Single[] TaskEmbedding { get; set; }
+  String ToString()
+  String TraceId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.RecallRequest
+  .ctor()
+  RecallRequest <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(RecallRequest other)
+  Int32 GetHashCode()
+  RecallOptions Options { get; set; }
+  String Query { get; set; }
+  Single[] QueryEmbedding { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+  String UserId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.RecallResult
+  .ctor()
+  RecallResult <Clone>$()
+  MemoryContext Context { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(RecallResult other)
+  Nullable`1 EstimatedTokenCount { get; set; }
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String ToString()
+  Int32 TotalItemsRetrieved { get; set; }
+  Boolean Truncated { get; set; }
+
+### class AgentMemory.Abstractions.Domain.Relationship
+  .ctor()
+  Relationship <Clone>$()
+  IReadOnlyDictionary`2 Attributes { get; set; }
+  Double Confidence { get; set; }
+  DateTimeOffset CreatedAtUtc { get; set; }
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(Relationship other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String OwnerId { get; set; }
+  String RelationshipId { get; set; }
+  String RelationshipType { get; set; }
+  String SourceEntityId { get; set; }
+  IReadOnlyList`1 SourceMessageIds { get; set; }
+  String TargetEntityId { get; set; }
+  String ToString()
+  Nullable`1 ValidFrom { get; set; }
+  Nullable`1 ValidUntil { get; set; }
+
+### class AgentMemory.Abstractions.Domain.Schema.DefaultSchemas
+  IReadOnlyList`1 GetLegacyEntityTypes()
+  IReadOnlyList`1 GetPoleoEntityTypes()
+  IReadOnlyList`1 GetPoleoRelationTypes()
+  IReadOnlyDictionary`2 LegacyToPoleoMapping
+
+### class AgentMemory.Abstractions.Domain.Schema.EntitySchemaConfig
+  .ctor()
+  EntitySchemaConfig <Clone>$()
+  String DefaultEntityType { get; set; }
+  String Description { get; set; }
+  Boolean EnableSubtypes { get; set; }
+  IReadOnlyList`1 EntityTypes { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntitySchemaConfig other)
+  IReadOnlyList`1 GetEntityTypeNames()
+  Int32 GetHashCode()
+  IReadOnlyList`1 GetRelationTypeNames()
+  IReadOnlyList`1 GetSubtypes(String entityType)
+  Boolean IsValidType(String entityType)
+  String Name { get; set; }
+  String NormalizeType(String entityType)
+  IReadOnlyList`1 RelationTypes { get; set; }
+  Boolean StrictTypes { get; set; }
+  String ToString()
+  String Version { get; set; }
+
+### class AgentMemory.Abstractions.Domain.Schema.EntityTypeConfig
+  .ctor()
+  EntityTypeConfig <Clone>$()
+  IReadOnlyList`1 Attributes { get; set; }
+  String Color { get; set; }
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntityTypeConfig other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  IReadOnlyList`1 Subtypes { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Schema.RelationTypeConfig
+  .ctor()
+  RelationTypeConfig <Clone>$()
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(RelationTypeConfig other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  IReadOnlyList`1 Properties { get; set; }
+  IReadOnlyList`1 SourceTypes { get; set; }
+  IReadOnlyList`1 TargetTypes { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.Schema.SchemaListItem
+  .ctor()
+  SchemaListItem <Clone>$()
+  String Description { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(SchemaListItem other)
+  Int32 GetHashCode()
+  Boolean IsActive { get; set; }
+  String LatestVersion { get; set; }
+  String Name { get; set; }
+  String ToString()
+  Int32 VersionCount { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.Schema.SchemaModel
+  SchemaModel Custom
+  SchemaModel Legacy
+  SchemaModel Poleo
+  Int32 value__
+
+### class AgentMemory.Abstractions.Domain.SessionInfo
+  .ctor()
+  SessionInfo <Clone>$()
+  Nullable`1 EndedAtUtc { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(SessionInfo other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String SessionId { get; set; }
+  DateTimeOffset StartedAtUtc { get; set; }
+  String ToString()
+  String UserId { get; set; }
+
+### class AgentMemory.Abstractions.Domain.SessionSummary
+  .ctor(String SessionId, Int32 ConversationCount, Int32 MessageCount, String LastMessagePreview, Nullable`1 LastActivity)
+  SessionSummary <Clone>$()
+  Int32 ConversationCount { get; set; }
+  Void Deconstruct(String& SessionId, Int32& ConversationCount, Int32& MessageCount, String& LastMessagePreview, Nullable`1& LastActivity)
+  Boolean Equals(Object obj)
+  Boolean Equals(SessionSummary other)
+  Int32 GetHashCode()
+  Nullable`1 LastActivity { get; set; }
+  String LastMessagePreview { get; set; }
+  Int32 MessageCount { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Domain.ToolCall
+  .ctor()
+  ToolCall <Clone>$()
+  String ArgumentsJson { get; set; }
+  String Description { get; set; }
+  Nullable`1 DurationMs { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ToolCall other)
+  String Error { get; set; }
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String ResultJson { get; set; }
+  ToolCallStatus Status { get; set; }
+  String StepId { get; set; }
+  Nullable`1 TimestampUtc { get; set; }
+  String ToString()
+  String ToolCallId { get; set; }
+  String ToolName { get; set; }
+
+### class AgentMemory.Abstractions.Domain.ToolCallStats
+  .ctor(String ToolName, Int32 TotalCalls, Int32 SuccessfulCalls, Int32 FailedCalls, Double SuccessRate, Nullable`1 AvgDurationMs)
+  ToolCallStats <Clone>$()
+  Nullable`1 AvgDurationMs { get; set; }
+  Void Deconstruct(String& ToolName, Int32& TotalCalls, Int32& SuccessfulCalls, Int32& FailedCalls, Double& SuccessRate, Nullable`1& AvgDurationMs)
+  Boolean Equals(Object obj)
+  Boolean Equals(ToolCallStats other)
+  Int32 FailedCalls { get; set; }
+  Int32 GetHashCode()
+  Double SuccessRate { get; set; }
+  Int32 SuccessfulCalls { get; set; }
+  String ToString()
+  String ToolName { get; set; }
+  Int32 TotalCalls { get; set; }
+
+### enum AgentMemory.Abstractions.Domain.ToolCallStatus
+  ToolCallStatus Cancelled
+  ToolCallStatus Error
+  ToolCallStatus Failure
+  ToolCallStatus Pending
+  ToolCallStatus Success
+  ToolCallStatus Timeout
+  Int32 value__
+
+### class AgentMemory.Abstractions.Exceptions.EmbeddingDimensionMismatchException
+  .ctor(Int32 expectedDimensions, IReadOnlyList`1 mismatches)
+  Int32 ExpectedDimensions { get; }
+  IReadOnlyList`1 Mismatches { get; }
+
+### class AgentMemory.Abstractions.Exceptions.EmbeddingGenerationException
+  .ctor(String message)
+  .ctor(String message, String inputText)
+  .ctor(String message, Exception innerException)
+  String InputText { get; }
+
+### class AgentMemory.Abstractions.Exceptions.EntityNotFoundException
+  .ctor(String entityId)
+  .ctor(String entityId, Exception innerException)
+  String EntityId { get; }
+
+### class AgentMemory.Abstractions.Exceptions.EntityResolutionException
+  .ctor(String message)
+  .ctor(String message, String entityName)
+  .ctor(String message, Exception innerException)
+  String EntityName { get; }
+
+### class AgentMemory.Abstractions.Exceptions.ExtractionException
+  .ctor(String message)
+  .ctor(String message, String extractionStep)
+  .ctor(String message, Exception innerException)
+  String ExtractionStep { get; }
+
+### class AgentMemory.Abstractions.Exceptions.FactNotFoundException
+  .ctor(String factId)
+  .ctor(String factId, Exception innerException)
+  String FactId { get; }
+
+### class AgentMemory.Abstractions.Exceptions.GraphQueryException
+  .ctor(String message)
+  .ctor(String message, String cypherQuery)
+  .ctor(String message, Exception innerException)
+  String CypherQuery { get; }
+
+### class AgentMemory.Abstractions.Exceptions.MemoryConfigurationException
+  .ctor(String message)
+  .ctor(String message, String optionName)
+  .ctor(String message, Exception innerException)
+  String OptionName { get; }
+
+### class AgentMemory.Abstractions.Exceptions.MemoryError
+  MemoryErrorBuilder Create(String message)
+
+### class AgentMemory.Abstractions.Exceptions.MemoryErrorBuilder
+  MemoryException Build()
+  Void Throw()
+  MemoryErrorBuilder WithCode(String code)
+  MemoryErrorBuilder WithEntityId(String entityId)
+  MemoryErrorBuilder WithInner(Exception inner)
+  MemoryErrorBuilder WithMetadata(String key, Object value)
+  MemoryErrorBuilder WithQuery(String cypherQuery)
+  MemoryErrorBuilder WithSessionId(String sessionId)
+
+### class AgentMemory.Abstractions.Exceptions.MemoryErrorCodes
+  String ConfigurationInvalid
+  String ContextBudgetExceeded
+  String DuplicateEntity
+  String EmbeddingDimensionMismatch
+  String EmbeddingFailed
+  String EmbeddingGenerationFailed
+  String EntityExtractionFailed
+  String EntityNotFound
+  String EntityPersistenceFailed
+  String EntityResolutionFailed
+  String EntityValidationFailed
+  String ExtractionFailed
+  String FactExtractionFailed
+  String FactNotFound
+  String FactPersistenceFailed
+  String PersistenceFailed
+  String PreferenceExtractionFailed
+  String PreferenceNotFound
+  String PreferencePersistenceFailed
+  String ProvenancePersistenceFailed
+  String QueryFailed
+  String RelationshipEndpointNotPersisted
+  String RelationshipEndpointUnresolved
+  String RelationshipExtractionFailed
+  String RelationshipPersistenceFailed
+  String ResolutionFailed
+  String SchemaBootstrapFailed
+  String TraceNotFound
+  String TransactionFailed
+  String ValidationFailed
+
+### class AgentMemory.Abstractions.Exceptions.MemoryException
+  .ctor(String message)
+  .ctor(String message, Exception innerException)
+  String Code { get; }
+  IReadOnlyDictionary`2 Metadata { get; }
+
+### class AgentMemory.Abstractions.Exceptions.MemoryIngestionException
+  .ctor(String message, IReadOnlyList`1 completedOutcomes)
+  .ctor(String message, IReadOnlyList`1 completedOutcomes, Exception innerException)
+  IReadOnlyList`1 CompletedOutcomes { get; }
+
+### class AgentMemory.Abstractions.Exceptions.MemoryOwnerScopeRequiredException
+  .ctor(String operationName)
+  String OperationName { get; }
+
+### class AgentMemory.Abstractions.Exceptions.SchemaInitializationException
+  .ctor(String message)
+  .ctor(String message, String schemaOperation)
+  .ctor(String message, Exception innerException)
+  String SchemaOperation { get; }
+
+### class AgentMemory.Abstractions.Exceptions.VectorIndexDimension
+  .ctor(String IndexName, Int32 ActualDimensions)
+  VectorIndexDimension <Clone>$()
+  Int32 ActualDimensions { get; set; }
+  Void Deconstruct(String& IndexName, Int32& ActualDimensions)
+  Boolean Equals(Object obj)
+  Boolean Equals(VectorIndexDimension other)
+  Int32 GetHashCode()
+  String IndexName { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.ContextBudget
+  .ctor()
+  ContextBudget <Clone>$()
+  ContextBudget Default { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ContextBudget other)
+  Int32 GetHashCode()
+  Nullable`1 MaxCharacters { get; set; }
+  Nullable`1 MaxTokens { get; set; }
+  String ToString()
+  TruncationStrategy TruncationStrategy { get; set; }
+
+### class AgentMemory.Abstractions.Options.ContextCompressionOptions
+  .ctor()
+  Boolean EnableReflections { get; set; }
+  Int32 MaxObservations { get; set; }
+  Int32 RecentMessageCount { get; set; }
+  Int32 TokenThreshold { get; set; }
+
+### class AgentMemory.Abstractions.Options.DiffbotEnrichmentOptions
+  .ctor()
+  DiffbotEnrichmentOptions <Clone>$()
+  String ApiKey { get; set; }
+  String BaseUrl { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(DiffbotEnrichmentOptions other)
+  Int32 GetHashCode()
+  Double RateLimitSeconds { get; set; }
+  TimeSpan Timeout { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.EnrichmentQueueOptions
+  .ctor()
+  EnrichmentQueueOptions <Clone>$()
+  Boolean Enabled { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EnrichmentQueueOptions other)
+  Int32 GetHashCode()
+  Int32 MaxConcurrency { get; set; }
+  Int32 MaxQueueCapacity { get; set; }
+  Int32 MaxRetries { get; set; }
+  TimeSpan RetryDelay { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.EntityResolutionOptions
+  .ctor()
+  Boolean EnableExactMatch { get; set; }
+  Boolean EnableFuzzyMatch { get; set; }
+  Boolean EnableSemanticMatch { get; set; }
+  Double FuzzyMatchThreshold { get; set; }
+  Double SemanticMatchThreshold { get; set; }
+  Boolean TypeStrictFiltering { get; set; }
+
+### class AgentMemory.Abstractions.Options.EntityValidationOptions
+  .ctor()
+  Int32 MinNameLength { get; set; }
+  Boolean RejectNumericOnly { get; set; }
+  Boolean RejectPunctuationOnly { get; set; }
+  Boolean UseStopwordFilter { get; set; }
+
+### class AgentMemory.Abstractions.Options.ExtractionOptions
+  .ctor()
+  Double AutoMergeThreshold { get; set; }
+  MemoryTrustLevel DefaultTrustLevel { get; set; }
+  Boolean EnableAutoMerge { get; set; }
+  EntityResolutionOptions EntityResolution { get; set; }
+  IngestionFailureMode FailureMode { get; set; }
+  MergeStrategyType MergeStrategy { get; set; }
+  Double MinConfidenceThreshold { get; set; }
+  Double RegexMatchConfidence { get; set; }
+  Double SameAsThreshold { get; set; }
+  Double StrongPatternConfidence { get; set; }
+  EntityValidationOptions Validation { get; set; }
+
+### enum AgentMemory.Abstractions.Options.IngestionFailureMode
+  IngestionFailureMode BestEffort
+  IngestionFailureMode FailFast
+  Int32 value__
+
+### class AgentMemory.Abstractions.Options.LongTermMemoryOptions
+  .ctor()
+  LongTermMemoryOptions <Clone>$()
+  Boolean DeduplicateOnCreate { get; set; }
+  Double DeduplicationConfidenceBump { get; set; }
+  Double DeduplicationSimilarityThreshold { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(LongTermMemoryOptions other)
+  Double FeedbackConfidenceDelta { get; set; }
+  Boolean GenerateEntityEmbeddings { get; set; }
+  Boolean GenerateFactEmbeddings { get; set; }
+  Boolean GeneratePreferenceEmbeddings { get; set; }
+  Int32 GetHashCode()
+  Double MinConfidenceThreshold { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.MemoryDecayOptions
+  .ctor()
+  MemoryDecayOptions <Clone>$()
+  Double AccessBoostFactor { get; set; }
+  Double DecayHalfLifeDays { get; set; }
+  MemoryDecayOptions Default { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryDecayOptions other)
+  Int32 GetHashCode()
+  Double MinRetentionScore { get; set; }
+  Boolean NonDestructive { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Options.MemoryIsolationMode
+  MemoryIsolationMode SingleTenant
+  MemoryIsolationMode StrictMultiTenant
+  MemoryIsolationMode WarnOnUnscoped
+  Int32 value__
+
+### class AgentMemory.Abstractions.Options.MemoryIsolationOptions
+  .ctor()
+  MemoryIsolationMode Mode { get; set; }
+
+### class AgentMemory.Abstractions.Options.MemoryOptions
+  .ctor()
+  MemoryOptions <Clone>$()
+  ContextBudget ContextBudget { get; set; }
+  Boolean EnableGraphRag { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryOptions other)
+  ExtractionOptions Extraction { get; set; }
+  Int32 GetHashCode()
+  MemoryIsolationOptions Isolation { get; set; }
+  LongTermMemoryOptions LongTerm { get; set; }
+  MemoryDecayOptions MemoryDecay { get; set; }
+  MemoryRankingOptions Ranking { get; set; }
+  ReasoningMemoryOptions Reasoning { get; set; }
+  RecallOptions Recall { get; set; }
+  ShortTermMemoryOptions ShortTerm { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Options.MemoryProfile
+  MemoryProfile Bitemporal
+  MemoryProfile Enhanced
+  MemoryProfile Parity
+  Int32 value__
+
+### class AgentMemory.Abstractions.Options.MemoryRankingOptions
+  .ctor()
+  MemoryRankingOptions <Clone>$()
+  MemoryRankingOptions Default { get; }
+  Double EffectiveRecencyWeight { get; }
+  Double EffectiveStructuralDecayGamma { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryRankingOptions other)
+  MemoryRankingOptions ForIntent(RankingIntent intent)
+  Int32 GetHashCode()
+  MemoryProfile Profile { get; set; }
+  Boolean RecencyRerankEnabled { get; }
+  Nullable`1 RecencyWeight { get; set; }
+  Boolean StructuralDecayEnabled { get; }
+  Nullable`1 StructuralDecayGamma { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.MemoryScope
+  .ctor()
+  MemoryScope <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryScope other)
+  MemoryScope For(String ownerId, Boolean includeShared)
+  Int32 GetHashCode()
+  MemoryScope Global { get; }
+  Boolean HasOwnerFilter { get; }
+  Boolean IncludeShared { get; set; }
+  String OwnerId { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Options.RankingIntent
+  RankingIntent Analog
+  RankingIntent Default
+  RankingIntent Latest
+  Int32 value__
+
+### class AgentMemory.Abstractions.Options.ReasoningMemoryOptions
+  .ctor()
+  ReasoningMemoryOptions <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(ReasoningMemoryOptions other)
+  Boolean GenerateTaskEmbeddings { get; set; }
+  Int32 GetHashCode()
+  Nullable`1 MaxTracesPerSession { get; set; }
+  Boolean StoreToolCalls { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.RecallOptions
+  .ctor()
+  RecallOptions <Clone>$()
+  RetrievalBlendMode BlendMode { get; set; }
+  RecallOptions Default { get; }
+  Boolean Equals(Object obj)
+  Boolean Equals(RecallOptions other)
+  Int32 GetHashCode()
+  RankingIntent Intent { get; set; }
+  Int32 MaxEntities { get; set; }
+  Int32 MaxFacts { get; set; }
+  Int32 MaxGraphRagItems { get; set; }
+  Int32 MaxPreferences { get; set; }
+  Int32 MaxRecentMessages { get; set; }
+  Int32 MaxRelevantMessages { get; set; }
+  Int32 MaxTraces { get; set; }
+  Double MinSimilarityScore { get; set; }
+  MemoryScope Scope { get; set; }
+  String ToString()
+
+### enum AgentMemory.Abstractions.Options.RetrievalBlendMode
+  RetrievalBlendMode Blended
+  RetrievalBlendMode GraphRagOnly
+  RetrievalBlendMode GraphRagThenMemory
+  RetrievalBlendMode MemoryOnly
+  RetrievalBlendMode MemoryThenGraphRag
+  Int32 value__
+
+### enum AgentMemory.Abstractions.Options.SessionStrategy
+  SessionStrategy PerConversation
+  SessionStrategy PerDay
+  SessionStrategy PersistentPerUser
+  Int32 value__
+
+### class AgentMemory.Abstractions.Options.ShortTermMemoryOptions
+  .ctor()
+  ShortTermMemoryOptions <Clone>$()
+  Int32 DefaultRecentMessageLimit { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ShortTermMemoryOptions other)
+  Boolean GenerateEmbeddings { get; set; }
+  Int32 GetHashCode()
+  Int32 MaxMessagesPerQuery { get; set; }
+  SessionStrategy SessionStrategy { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Options.StreamingExtractionOptions
+  .ctor()
+  Boolean ChunkByTokens { get; set; }
+  Int32 ChunkSize { get; set; }
+  Int32 DefaultChunkSize
+  Int32 DefaultOverlap
+  Int32 DefaultTokenChunkSize
+  Int32 DefaultTokenOverlap
+  StreamingExtractionOptions ForTokens()
+  Int32 Overlap { get; set; }
+  Boolean SplitOnSentences { get; set; }
+  Void Validate()
+
+### enum AgentMemory.Abstractions.Options.TruncationStrategy
+  TruncationStrategy Fail
+  TruncationStrategy LowestScoreFirst
+  TruncationStrategy OldestFirst
+  TruncationStrategy Proportional
+  Int32 value__
+
+### interface AgentMemory.Abstractions.Repositories.IConversationRepository
+  Task DeleteAsync(String conversationId, CancellationToken cancellationToken)
+  Task DeleteBySessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String conversationId, CancellationToken cancellationToken)
+  Task`1 GetBySessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 ListSessionsAsync(Int32 limit, CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Conversation conversation, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IEntityRepository
+  Task`1 ApplyConfidenceDeltaAsync(String entityId, Double delta, MemoryScope scope, CancellationToken cancellationToken)
+  Task CreateExtractedFromRelationshipAsync(String entityId, String messageId, Nullable`1 confidence, Nullable`1 startPos, Nullable`1 endPos, String context, CancellationToken cancellationToken)
+  Task`1 DeleteAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 FindSimilarByEmbeddingAsync(String entityId, Double minSimilarity, Int32 limit, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String entityId, CancellationToken cancellationToken)
+  Task`1 GetByNameAsync(String name, Boolean includeAliases, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetByTypeAsync(String type, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetDeduplicationStatsAsync(CancellationToken cancellationToken)
+  Task`1 GetEntitiesFromMessageAsync(String messageId, CancellationToken cancellationToken)
+  Task`1 GetPageWithoutEmbeddingAsync(Int32 limit, CancellationToken cancellationToken)
+  Task`1 GetPendingDuplicatesAsync(Int32 limit, CancellationToken cancellationToken)
+  Task`1 InvalidateAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 MergeEntitiesAsync(String sourceEntityId, String targetEntityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task RefreshEntitySearchFieldsAsync(String entityId, CancellationToken cancellationToken)
+  Task`1 SearchByLocationAsync(Double latitude, Double longitude, Double radiusKm, Int32 limit, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchInBoundingBoxAsync(Double minLat, Double minLon, Double maxLat, Double maxLon, Int32 limit, MemoryScope scope, CancellationToken cancellationToken)
+  Task UpdateEmbeddingAsync(String entityId, Single[] embedding, CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Entity entity, CancellationToken cancellationToken)
+  Task`1 UpsertBatchAsync(IReadOnlyList`1 entities, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IExtractorRepository
+  Task CreateExtractedByRelationshipAsync(String entityId, String extractorName, Double confidence, Nullable`1 extractionTimeMs, CancellationToken cancellationToken)
+  Task`1 DeleteProvenanceAsync(String entityId, CancellationToken cancellationToken)
+  Task`1 GetByNameAsync(String name, CancellationToken cancellationToken)
+  Task`1 GetEntitiesByExtractorAsync(String extractorName, Int32 limit, CancellationToken cancellationToken)
+  Task`1 GetExtractionStatsAsync(CancellationToken cancellationToken)
+  Task`1 GetExtractorStatsAsync(String extractorName, CancellationToken cancellationToken)
+  Task`1 GetProvenanceAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 ListAsync(CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Extractor extractor, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IFactRepository
+  Task CreateAboutRelationshipAsync(String factId, String entityId, CancellationToken cancellationToken)
+  Task CreateConversationFactRelationshipAsync(String conversationId, String factId, CancellationToken cancellationToken)
+  Task CreateExtractedFromRelationshipAsync(String factId, String messageId, CancellationToken cancellationToken)
+  Task`1 DeleteAsync(String factId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 FindByTripleAsync(String subject, String predicate, String object, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 FindDuplicateAsync(String subject, String predicate, Single[] embedding, String ownerId, Double threshold, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String factId, CancellationToken cancellationToken)
+  Task`1 GetBySubjectAsync(String subject, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetPageWithoutEmbeddingAsync(Int32 limit, CancellationToken cancellationToken)
+  Task`1 InvalidateAsync(String factId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 MarkDeduplicatedAsync(String factId, Double confidence, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, Nullable`1 systemAsOf, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SupersedeAsync(String loserFactId, String winnerFactId, MemoryScope scope, CancellationToken cancellationToken)
+  Task UpdateEmbeddingAsync(String factId, Single[] embedding, CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Fact fact, CancellationToken cancellationToken)
+  Task`1 UpsertBatchAsync(IReadOnlyList`1 facts, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IMessageRepository
+  Task`1 AddAsync(Message message, CancellationToken cancellationToken)
+  Task`1 AddBatchAsync(IEnumerable`1 messages, CancellationToken cancellationToken)
+  Task`1 DeleteAsync(String messageId, Boolean cascade, CancellationToken cancellationToken)
+  Task DeleteBySessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetAllBySessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetByConversationAsync(String conversationId, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String messageId, CancellationToken cancellationToken)
+  Task`1 GetRecentBySessionAsOfAsync(String sessionId, DateTimeOffset asOf, Int32 limit, CancellationToken cancellationToken)
+  Task`1 GetRecentBySessionAsync(String sessionId, Int32 limit, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsync(Single[] queryEmbedding, String sessionId, Int32 limit, Double minScore, IReadOnlyDictionary`2 metadataFilters, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IPreferenceRepository
+  Task CreateAboutRelationshipAsync(String preferenceId, String entityId, CancellationToken cancellationToken)
+  Task CreateConversationPreferenceRelationshipAsync(String conversationId, String preferenceId, CancellationToken cancellationToken)
+  Task CreateExtractedFromRelationshipAsync(String preferenceId, String messageId, CancellationToken cancellationToken)
+  Task DeleteAsync(String preferenceId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 FindDuplicateAsync(String category, Single[] embedding, String ownerId, Double threshold, CancellationToken cancellationToken)
+  Task`1 GetByCategoryAsync(String category, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String preferenceId, CancellationToken cancellationToken)
+  Task`1 GetPageWithoutEmbeddingAsync(Int32 limit, CancellationToken cancellationToken)
+  Task`1 InvalidateAsync(String preferenceId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 MarkDeduplicatedAsync(String preferenceId, Double confidence, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchByVectorAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SupersedeAsync(String loserPreferenceId, String winnerPreferenceId, MemoryScope scope, CancellationToken cancellationToken)
+  Task UpdateEmbeddingAsync(String preferenceId, Single[] embedding, CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Preference preference, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IReasoningStepRepository
+  Task`1 AddAsync(ReasoningStep step, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String stepId, CancellationToken cancellationToken)
+  Task`1 GetByTraceAsync(String traceId, CancellationToken cancellationToken)
+  Task`1 GetTouchedEntityIdsAsync(String stepId, CancellationToken cancellationToken)
+  Task`1 LinkTouchedEntitiesAsync(String stepId, IReadOnlyList`1 entityIds, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IReasoningTraceRepository
+  Task`1 AddAsync(ReasoningTrace trace, CancellationToken cancellationToken)
+  Task CreateConversationTraceRelationshipsAsync(String conversationId, String traceId, CancellationToken cancellationToken)
+  Task CreateInitiatedByRelationshipAsync(String traceId, String messageId, CancellationToken cancellationToken)
+  Task DeleteBySessionAsync(String sessionId, String ownerId, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String traceId, CancellationToken cancellationToken)
+  Task`1 ListAllAsync(Int32 limit, Int32 offset, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 ListBySessionAsync(String sessionId, Int32 limit, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 PruneSessionTracesAsync(String sessionId, Int32 maxToKeep, String ownerId, CancellationToken cancellationToken)
+  Task`1 SearchByTaskVectorAsOfAsync(Single[] taskEmbedding, DateTimeOffset asOf, Nullable`1 successFilter, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchByTaskVectorAsync(Single[] taskEmbedding, Nullable`1 successFilter, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 UpdateAsync(ReasoningTrace trace, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IRelationshipRepository
+  Task`1 GetByEntityAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String relationshipId, CancellationToken cancellationToken)
+  Task`1 GetBySourceEntityAsync(String sourceEntityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetByTargetEntityAsync(String targetEntityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 UpsertAsync(Relationship relationship, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.ISchemaRepository
+  Task ApplyMigrationAsync(Int32 targetVersion, CancellationToken cancellationToken)
+  Task`1 GetSchemaVersionAsync(CancellationToken cancellationToken)
+  Task InitializeSchemaAsync(CancellationToken cancellationToken)
+  Task`1 IsSchemaInitializedAsync(CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Repositories.IToolCallRepository
+  Task`1 AddAsync(ToolCall toolCall, CancellationToken cancellationToken)
+  Task CreateTriggeredByRelationshipAsync(String toolCallId, String messageId, CancellationToken cancellationToken)
+  Task`1 GetByIdAsync(String toolCallId, CancellationToken cancellationToken)
+  Task`1 GetByStepAsync(String stepId, CancellationToken cancellationToken)
+  Task`1 GetStatsAsync(String toolName, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 UpdateAsync(ToolCall toolCall, CancellationToken cancellationToken)
+
+### class AgentMemory.Abstractions.Services.ConflictDetectionOptions
+  .ctor()
+  ConflictDetectionOptions <Clone>$()
+  Boolean DetectFactContradictions { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ConflictDetectionOptions other)
+  Int32 GetHashCode()
+  Int32 MaxConflicts { get; set; }
+  Nullable`1 MinConfidence { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConflictReport
+  .ctor()
+  ConflictReport <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(ConflictReport other)
+  Int32 FactConflictCount { get; }
+  IReadOnlyList`1 FactConflicts { get; set; }
+  Int32 GetHashCode()
+  DateTimeOffset RanAtUtc { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConflictResolutionOptions
+  .ctor()
+  ConflictResolutionOptions <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(ConflictResolutionOptions other)
+  Int32 GetHashCode()
+  Int32 MaxConflicts { get; set; }
+  Nullable`1 MinConfidence { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConflictResolutionResult
+  .ctor()
+  ConflictResolutionResult <Clone>$()
+  Int32 ConflictsResolved { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ConflictResolutionResult other)
+  Int32 FactsSuperseded { get; set; }
+  Int32 GetHashCode()
+  DateTimeOffset RanAtUtc { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConflictingFactValue
+  .ctor(String FactId, String Object, Double Confidence)
+  ConflictingFactValue <Clone>$()
+  Double Confidence { get; set; }
+  Void Deconstruct(String& FactId, String& Object, Double& Confidence)
+  Boolean Equals(Object obj)
+  Boolean Equals(ConflictingFactValue other)
+  String FactId { get; set; }
+  Int32 GetHashCode()
+  String Object { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConsolidationOptions
+  .ctor()
+  ConsolidationOptions <Clone>$()
+  Boolean ArchiveExpiredConversations { get; set; }
+  TimeSpan ConversationExpiry { get; set; }
+  Boolean DetectDuplicateEntities { get; set; }
+  Boolean DetectLongTraces { get; set; }
+  Boolean DryRun { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ConsolidationOptions other)
+  Int32 GetHashCode()
+  Int32 LongTraceStepThreshold { get; set; }
+  Boolean RemoveDuplicatePreferences { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.ConsolidationReport
+  .ctor()
+  ConsolidationReport <Clone>$()
+  Int32 ConversationsArchived { get; set; }
+  Boolean DryRun { get; set; }
+  Int32 DuplicateEntitiesDetected { get; set; }
+  Int32 DuplicatePreferencesRemoved { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(ConsolidationReport other)
+  Int32 GetHashCode()
+  Int32 LongTraceCandidates { get; set; }
+  DateTimeOffset RanAtUtc { get; set; }
+  String RunId { get; set; }
+  String ToString()
+  Int32 TotalChanges { get; }
+
+### class AgentMemory.Abstractions.Services.EmbeddingOrchestratorExtensions
+  Task`1 EmbedEntityAsync(IEmbeddingOrchestrator orchestrator, String entityName, CancellationToken cancellationToken)
+  Task`1 EmbedFactAsync(IEmbeddingOrchestrator orchestrator, String subject, String predicate, String obj, CancellationToken cancellationToken)
+  Task`1 EmbedMessageAsync(IEmbeddingOrchestrator orchestrator, String content, CancellationToken cancellationToken)
+  Task`1 EmbedPreferenceAsync(IEmbeddingOrchestrator orchestrator, String preferenceText, CancellationToken cancellationToken)
+  Task`1 EmbedQueryAsync(IEmbeddingOrchestrator orchestrator, String query, CancellationToken cancellationToken)
+  Task`1 EmbedTextAsync(IEmbeddingOrchestrator orchestrator, String text, CancellationToken cancellationToken)
+
+### class AgentMemory.Abstractions.Services.FactConflict
+  .ctor(String Subject, String Predicate, String OwnerId, IReadOnlyList`1 Values)
+  FactConflict <Clone>$()
+  Void Deconstruct(String& Subject, String& Predicate, String& OwnerId, IReadOnlyList`1& Values)
+  Boolean Equals(Object obj)
+  Boolean Equals(FactConflict other)
+  Int32 GetHashCode()
+  String OwnerId { get; set; }
+  String Predicate { get; set; }
+  String Subject { get; set; }
+  String ToString()
+  IReadOnlyList`1 Values { get; set; }
+
+### interface AgentMemory.Abstractions.Services.IBackgroundEnrichmentQueue
+  Task EnqueueAsync(String entityId, CancellationToken cancellationToken)
+  Task EnqueueBatchAsync(IEnumerable`1 entityIds, CancellationToken cancellationToken)
+  Boolean IsProcessing { get; }
+  Int32 QueueDepth { get; }
+
+### interface AgentMemory.Abstractions.Services.IClock
+  DateTimeOffset UtcNow { get; }
+
+### interface AgentMemory.Abstractions.Services.IConflictDetectionService
+  Task`1 DetectConflictsAsync(ConflictDetectionOptions options, CancellationToken cancellationToken)
+  Task`1 ResolveFactContradictionsAsync(ConflictResolutionOptions options, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IConsolidationService
+  Task`1 ConsolidateAsync(ConsolidationOptions options, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IContextCompressor
+  Task`1 CompressAsync(IReadOnlyList`1 messages, ContextCompressionOptions options, CancellationToken cancellationToken)
+  Int32 EstimateTokenCount(IReadOnlyList`1 messages)
+
+### interface AgentMemory.Abstractions.Services.IEmbeddingOrchestrator
+  Task`1 EmbedAsync(String text, CancellationToken cancellationToken)
+  Task`1 EmbedBatchAsync(IReadOnlyList`1 texts, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IEnrichmentService
+  Task`1 EnrichEntityAsync(String entityName, String entityType, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IEntityExtractor
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IEntityResolver
+  Task`1 FindPotentialDuplicatesAsync(String name, String type, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 ResolveEntityAsync(ExtractedEntity extractedEntity, IReadOnlyList`1 sourceMessageIds, MemoryScope scope, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IFactExtractor
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IGeocodingService
+  Task`1 GeocodeAsync(String locationText, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IGraphQueryService
+  Task`1 QueryAsync(String cypherQuery, IReadOnlyDictionary`2 parameters, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IGraphRagContextSource
+  Task`1 GetContextAsync(GraphRagContextRequest request, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IIdGenerator
+  String GenerateId()
+
+### interface AgentMemory.Abstractions.Services.ILongTermMemoryService
+  Task`1 AddEntityAsync(Entity entity, CancellationToken cancellationToken)
+  Task`1 AddFactAsync(Fact fact, CancellationToken cancellationToken)
+  Task`1 AddPreferenceAsync(Preference preference, CancellationToken cancellationToken)
+  Task`1 AddRelationshipAsync(Relationship relationship, CancellationToken cancellationToken)
+  Task DeletePreferenceAsync(String preferenceId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetEntitiesByNameAsync(String name, Boolean includeAliases, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetEntityRelationshipsAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetFactsBySubjectAsync(String subject, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 GetPreferencesByCategoryAsync(String category, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 InvalidateEntityAsync(String entityId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 InvalidateFactAsync(String factId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 InvalidatePreferenceAsync(String preferenceId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 RecordEntityFeedbackAsync(String entityId, Boolean positive, Nullable`1 delta, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchEntitiesAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchEntitiesAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchFactsAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, Nullable`1 systemAsOf, CancellationToken cancellationToken)
+  Task`1 SearchFactsAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchPreferencesAsOfAsync(Single[] queryEmbedding, DateTimeOffset asOf, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchPreferencesAsync(Single[] queryEmbedding, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SupersedeFactAsync(String loserFactId, String winnerFactId, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SupersedePreferenceAsync(String loserPreferenceId, String winnerPreferenceId, MemoryScope scope, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryContextAssembler
+  Task`1 AssembleContextAsOfAsync(RecallRequest request, DateTimeOffset asOf, Nullable`1 systemAsOf, CancellationToken cancellationToken)
+  Task`1 AssembleContextAsync(RecallRequest request, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryDecayService
+  Task`1 CalculateRetentionScoreAsync(String nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken)
+  Task`1 PruneExpiredMemoriesAsync(MemoryScope scope, CancellationToken cancellationToken)
+  Task UpdateAccessTimestampAsync(String nodeId, MemoryNodeKind nodeKind, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryExtractionPipeline
+  Task`1 ExtractAsync(ExtractionRequest request, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryHistoryService
+  Task`1 GetHistoryAsync(MemoryHistoryQuery query, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryIngestion
+  Task`1 AddMessageAsync(String sessionId, String conversationId, String role, String content, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 AddMessageWithIdAsync(String sessionId, String conversationId, String role, String content, String messageId, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 AddMessagesAsync(IEnumerable`1 messages, CancellationToken cancellationToken)
+  Task`1 ExtractAndPersistAsync(ExtractionRequest request, CancellationToken cancellationToken)
+  Task ExtractFromConversationAsync(String conversationId, String userId, CancellationToken cancellationToken)
+  Task ExtractFromSessionAsync(String sessionId, String userId, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryIsolationPolicy
+  MemoryScope ResolveReadScope(MemoryScope explicitScope, String ownerId, String operationName, MemoryOperationAccess access)
+  String ResolveWriteOwner(String ownerId, String operationName, MemoryOperationAccess access)
+
+### interface AgentMemory.Abstractions.Services.IMemoryMaintenance
+  Task ClearSessionAsync(String sessionId, String ownerId, CancellationToken cancellationToken)
+  Task`1 GenerateEmbeddingsBatchAsync(MemoryNodeKind nodeKind, Int32 batchSize, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryOwnerContext
+  String UserId { get; }
+
+### interface AgentMemory.Abstractions.Services.IMemoryQueryFacade
+  Task`1 FindSimilarTasksAsync(String taskDescription, CancellationToken cancellationToken)
+  Task`1 RecallPreferencesAsync(String category, String query, CancellationToken cancellationToken)
+  Task`1 RememberFactAsync(String subject, String predicate, String object, CancellationToken cancellationToken)
+  Task`1 RememberPreferenceAsync(String preferenceText, String category, CancellationToken cancellationToken)
+  Task`1 SearchKnowledgeAsync(String query, CancellationToken cancellationToken)
+  Task`1 SearchMemoryAsync(String query, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryRankingContext
+  MemoryRankingOptions Current { get; }
+
+### interface AgentMemory.Abstractions.Services.IMemoryRecall
+  Task`1 RecallAsOfAsync(RecallRequest request, DateTimeOffset asOf, Nullable`1 systemAsOf, CancellationToken cancellationToken)
+  Task`1 RecallAsync(RecallRequest request, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IMemoryService
+
+### interface AgentMemory.Abstractions.Services.IMemoryStoreContext
+  String ApplicationId { get; }
+
+### interface AgentMemory.Abstractions.Services.IMergeStrategy`1
+  IReadOnlyList`1 Merge(IReadOnlyList`1 extractorResults)
+  MergeStrategyType StrategyType { get; }
+
+### interface AgentMemory.Abstractions.Services.IPreferenceExtractor
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IReasoningMemoryService
+  Task`1 AddStepAsync(String traceId, Int32 stepNumber, String thought, String action, String observation, Single[] embedding, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 CompleteTraceAsync(String traceId, String outcome, Nullable`1 success, CancellationToken cancellationToken)
+  Task`1 GetTouchedEntitiesAsync(String stepId, CancellationToken cancellationToken)
+  Task`1 GetTraceWithStepsAsync(String traceId, CancellationToken cancellationToken)
+  Task`1 ListAllTracesAsync(Int32 limit, Int32 offset, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 ListTracesAsync(String sessionId, Int32 limit, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 RecordToolCallAsync(String stepId, String toolName, String argumentsJson, String resultJson, ToolCallStatus status, Nullable`1 durationMs, String error, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 RecordTouchedEntitiesAsync(String stepId, IReadOnlyList`1 entityIds, CancellationToken cancellationToken)
+  Task`1 SearchSimilarTracesAsOfAsync(Single[] taskEmbedding, DateTimeOffset asOf, Nullable`1 successFilter, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 SearchSimilarTracesAsync(Single[] taskEmbedding, Nullable`1 successFilter, Int32 limit, Double minScore, MemoryScope scope, CancellationToken cancellationToken)
+  Task`1 StartTraceAsync(String sessionId, String task, Single[] taskEmbedding, IReadOnlyDictionary`2 metadata, String ownerId, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IRelationshipExtractor
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.ISchemaManager
+  Task`1 DeleteSchemaAsync(String schemaId, CancellationToken cancellationToken)
+  Task`1 ListSchemasAsync(String nameFilter, CancellationToken cancellationToken)
+  Task`1 LoadSchemaAsync(String name, CancellationToken cancellationToken)
+  Task`1 LoadSchemaVersionAsync(String name, String version, CancellationToken cancellationToken)
+  Task SaveSchemaAsync(EntitySchemaConfig schema, String createdBy, Boolean setActive, CancellationToken cancellationToken)
+  Task`1 SchemaExistsAsync(String name, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.ISessionIdGenerator
+  String GenerateSessionId(String userId)
+
+### interface AgentMemory.Abstractions.Services.IShortTermMemoryService
+  Task`1 AddConversationAsync(String conversationId, String sessionId, String userId, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 AddMessageAsync(Message message, CancellationToken cancellationToken)
+  Task`1 AddMessagesAsync(IEnumerable`1 messages, CancellationToken cancellationToken)
+  Task ClearSessionAsync(String sessionId, String ownerId, CancellationToken cancellationToken)
+  Task`1 GetAllSessionMessagesAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetConversationMessagesAsync(String conversationId, CancellationToken cancellationToken)
+  Task`1 GetRecentMessagesAsOfAsync(String sessionId, DateTimeOffset asOf, Int32 limit, CancellationToken cancellationToken)
+  Task`1 GetRecentMessagesAsync(String sessionId, Nullable`1 limit, CancellationToken cancellationToken)
+  Task`1 SearchMessagesAsync(String sessionId, Single[] queryEmbedding, Int32 limit, Double minScore, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IStreamingExtractor
+  IReadOnlyList`1 ChunkDocument(String text, StreamingExtractionOptions options)
+  Task`1 ExtractAsync(String text, IEntityExtractor extractor, StreamingExtractionOptions options, Boolean deduplicate, CancellationToken cancellationToken)
+  IAsyncEnumerable`1 ExtractStreamingAsync(String text, IEntityExtractor extractor, StreamingExtractionOptions options, CancellationToken cancellationToken)
+
+### interface AgentMemory.Abstractions.Services.IWritableMemoryOwnerContext
+  String UserId { get; set; }
+
+### interface AgentMemory.Abstractions.Services.IWritableMemoryRankingContext
+  MemoryRankingOptions Current { get; set; }
+
+### interface AgentMemory.Abstractions.Services.IWritableMemoryStoreContext
+  String ApplicationId { get; set; }
+
+### class AgentMemory.Abstractions.Services.MemoryOwnerContextExtensions
+  IDisposable BeginOwnerScope(IWritableMemoryOwnerContext context, String userId)
+
+### struct AgentMemory.Abstractions.Services.MemoryQueryResult
+  .ctor(Boolean Success, String Text, String Error)
+  Void Deconstruct(Boolean& Success, String& Text, String& Error)
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryQueryResult other)
+  String Error { get; set; }
+  MemoryQueryResult Failed(String error)
+  Int32 GetHashCode()
+  MemoryQueryResult Ok(String text)
+  Boolean Success { get; set; }
+  String Text { get; set; }
+  String ToString()
+
+### class AgentMemory.Abstractions.Services.MemoryStoreContextExtensions
+  IDisposable BeginStoreScope(IWritableMemoryStoreContext context, String applicationId)
+
+## AgentMemory.AgentFramework (25 public types)
+
+### class AgentMemory.AgentFramework.AIAgentMemoryScopingExtensions
+  AIAgent WithMemoryOwnerScoping(AIAgent agent, IWritableMemoryOwnerContext ownerContext, IWritableMemoryStoreContext storeContext, AgentFrameworkOptions options, ILogger`1 logger)
+  AIAgent WithMemoryOwnerScoping(AIAgent agent, IServiceProvider serviceProvider)
+
+### class AgentMemory.AgentFramework.AgentFrameworkOptions
+  .ctor()
+  Boolean AutoExtractOnPersist { get; set; }
+  ContextFormatOptions ContextFormat { get; set; }
+  String DefaultApplicationIdKey { get; set; }
+  String DefaultConversationIdKey { get; set; }
+  String DefaultSessionIdKey { get; set; }
+  String DefaultUserIdKey { get; set; }
+  Boolean ExposeMemoryToolsFromContextProvider { get; set; }
+  Boolean PersistReasoningTraces { get; set; }
+
+### class AgentMemory.AgentFramework.AgentSessionMemoryExtensions
+  MemoryIdentity GetMemoryIdentity(AgentSession session, AgentFrameworkOptions options)
+  AgentSession WithMemoryIdentity(AgentSession session, String userId, String sessionId, String conversationId, String applicationId, AgentFrameworkOptions options)
+
+### class AgentMemory.AgentFramework.AgentTraceRecorder
+  .ctor(IReasoningMemoryService reasoningService, IClock clock, IIdGenerator idGenerator, IOptions`1 options, ILogger`1 logger)
+  Task CompleteTraceAsync(String traceId, String outcome, CancellationToken cancellationToken)
+  Task`1 RecordStepAsync(String traceId, String stepType, String content, IReadOnlyDictionary`2 metadata, CancellationToken cancellationToken)
+  Task`1 RecordToolCallAsync(String stepId, String toolName, String input, String output, ToolCallStatus status, CancellationToken cancellationToken)
+  Task`1 StartTraceAsync(String sessionId, String task, String ownerId, CancellationToken cancellationToken)
+
+### class AgentMemory.AgentFramework.ContextFormatOptions
+  .ctor()
+  String ContextPrefix { get; set; }
+  RecalledMemoryMessageRole DefaultMemoryRole { get; set; }
+  Boolean IncludeEntities { get; set; }
+  Boolean IncludeFacts { get; set; }
+  Boolean IncludePreferences { get; set; }
+  Boolean IncludeReasoningTraces { get; set; }
+  Int32 MaxChatHistoryMessages { get; set; }
+  Int32 MaxContextMessages { get; set; }
+  MemoryTrustLevel MinimumTrustForAdmissionBypass { get; set; }
+  MemoryTrustLevel MinimumTrustForSystemRole { get; set; }
+  MemoryContextSecurityMode SecurityMode { get; set; }
+
+### struct AgentMemory.AgentFramework.MemoryIdentity
+  .ctor(String UserId, String SessionId, String ConversationId, String ApplicationId)
+  String ApplicationId { get; set; }
+  String ConversationId { get; set; }
+  Void Deconstruct(String& UserId, String& SessionId, String& ConversationId, String& ApplicationId)
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryIdentity other)
+  Int32 GetHashCode()
+  String SessionId { get; set; }
+  String ToString()
+  String UserId { get; set; }
+
+### class AgentMemory.AgentFramework.MemoryOwnerScopingAgent
+  .ctor(AIAgent innerAgent, IWritableMemoryOwnerContext ownerContext, IWritableMemoryStoreContext storeContext, AgentFrameworkOptions options, ILogger`1 logger)
+
+### class AgentMemory.AgentFramework.Neo4jChatHistoryProvider
+  .ctor(IMemoryService memoryService, IClock clock, IIdGenerator idGenerator, AgentFrameworkOptions options, ILogger`1 logger, IMemoryStoreContext storeContext, IWritableMemoryOwnerContext ownerContext, IMemoryContextAdmissionPolicy admissionPolicy)
+  IReadOnlyList`1 StateKeys { get; }
+
+### class AgentMemory.AgentFramework.Neo4jChatMessageStore
+  .ctor(IMemoryService memoryService, IClock clock, IIdGenerator idGenerator, ILogger`1 logger, IOptions`1 formatOptions, IMemoryContextAdmissionPolicy admissionPolicy)
+  Task`1 AddMessageAsync(ChatMessage chatMessage, String sessionId, String conversationId, CancellationToken cancellationToken)
+  Task ClearSessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetMessagesAsync(String sessionId, Int32 limit, CancellationToken cancellationToken)
+
+### class AgentMemory.AgentFramework.Neo4jMemoryContextProvider
+  .ctor(IMemoryService memoryService, IEmbeddingOrchestrator embeddingOrchestrator, IClock clock, IIdGenerator idGenerator, IOptions`1 memoryOptions, IOptions`1 formatOptions, IOptions`1 agentOptions, ILogger`1 logger, IMemoryStoreContext storeContext, IWritableMemoryOwnerContext ownerContext, MemoryToolFactory toolFactory, IAutomaticRecallPolicy recallPolicy, IMemoryContextAdmissionPolicy admissionPolicy)
+  String StateKey { get; }
+
+### class AgentMemory.AgentFramework.Neo4jMicrosoftMemoryFacade
+  .ctor(IMemoryService memoryService, Neo4jChatMessageStore messageStore, IOptions`1 options, ILogger`1 logger, IMemoryContextAdmissionPolicy admissionPolicy)
+  Task ClearSessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task`1 GetContextForRunAsync(IReadOnlyList`1 messages, String sessionId, String conversationId, String userId, CancellationToken cancellationToken)
+  Task PersistAfterRunAsync(IReadOnlyList`1 messages, String sessionId, String conversationId, String userId, CancellationToken cancellationToken)
+  Task`1 StoreMessageAsync(ChatMessage msg, String sessionId, String conversationId, CancellationToken cancellationToken)
+
+### enum AgentMemory.AgentFramework.Recall.AutomaticRecallCategories
+  AutomaticRecallCategories All
+  AutomaticRecallCategories Default
+  AutomaticRecallCategories Entities
+  AutomaticRecallCategories Facts
+  AutomaticRecallCategories GraphRag
+  AutomaticRecallCategories None
+  AutomaticRecallCategories Preferences
+  AutomaticRecallCategories ReasoningTraces
+  AutomaticRecallCategories RecentMessages
+  AutomaticRecallCategories RelevantMessages
+  Int32 value__
+
+### class AgentMemory.AgentFramework.Recall.AutomaticRecallContext
+  .ctor()
+  AutomaticRecallContext <Clone>$()
+  String ConversationId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(AutomaticRecallContext other)
+  Int32 GetHashCode()
+  IReadOnlyList`1 Messages { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+  String UserId { get; set; }
+
+### class AgentMemory.AgentFramework.Recall.AutomaticRecallDecision
+  .ctor()
+  AutomaticRecallDecision <Clone>$()
+  AutomaticRecallCategories Categories { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(AutomaticRecallDecision other)
+  Int32 GetHashCode()
+  Nullable`1 Intent { get; set; }
+  AutomaticRecallDecision Recall { get; }
+  RecallOptions RecallOptions { get; set; }
+  Boolean ShouldRecall { get; set; }
+  AutomaticRecallDecision Skip { get; }
+  String ToString()
+
+### class AgentMemory.AgentFramework.Recall.ConfiguredAutomaticRecallPolicy
+  .ctor()
+  ValueTask`1 DecideAsync(AutomaticRecallContext context, CancellationToken cancellationToken)
+
+### class AgentMemory.AgentFramework.Recall.HeuristicAutomaticRecallPolicy
+  .ctor()
+  ValueTask`1 DecideAsync(AutomaticRecallContext context, CancellationToken cancellationToken)
+
+### interface AgentMemory.AgentFramework.Recall.IAutomaticRecallPolicy
+  ValueTask`1 DecideAsync(AutomaticRecallContext context, CancellationToken cancellationToken)
+
+### enum AgentMemory.AgentFramework.RecalledMemoryMessageRole
+  RecalledMemoryMessageRole System
+  RecalledMemoryMessageRole User
+  Int32 value__
+
+### class AgentMemory.AgentFramework.Security.DefaultMemoryContextAdmissionPolicy
+  .ctor()
+  MemoryAdmissionDecision Evaluate(MemoryAdmissionContext context)
+
+### interface AgentMemory.AgentFramework.Security.IMemoryContextAdmissionPolicy
+  MemoryAdmissionDecision Evaluate(MemoryAdmissionContext context)
+
+### class AgentMemory.AgentFramework.Security.MemoryAdmissionContext
+  .ctor()
+  MemoryAdmissionContext <Clone>$()
+  String Category { get; set; }
+  String Content { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryAdmissionContext other)
+  Int32 GetHashCode()
+  MemoryTrustLevel MinimumTrustForAdmissionBypass { get; set; }
+  MemoryContextSecurityMode Mode { get; set; }
+  String ToString()
+  MemoryTrustLevel TrustLevel { get; set; }
+
+### class AgentMemory.AgentFramework.Security.MemoryAdmissionDecision
+  .ctor()
+  MemoryAdmissionDecision <Clone>$()
+  Boolean Equals(Object obj)
+  Boolean Equals(MemoryAdmissionDecision other)
+  String ExclusionReason { get; set; }
+  Int32 GetHashCode()
+  Boolean Include { get; set; }
+  Boolean InstructionLikeContentDetected { get; set; }
+  String ToString()
+
+### enum AgentMemory.AgentFramework.Security.MemoryContextSecurityMode
+  MemoryContextSecurityMode Permissive
+  MemoryContextSecurityMode Strict
+  Int32 value__
+
+### class AgentMemory.AgentFramework.ServiceCollectionExtensions
+  IServiceCollection AddAgentMemoryFramework(IServiceCollection services, Action`1 configure)
+
+### class AgentMemory.AgentFramework.Tools.MemoryToolFactory
+  .ctor(IMemoryQueryFacade facade)
+  IReadOnlyList`1 CreateAIFunctions()
+
+## AgentMemory.Analytics (7 public types)
+
+### class AgentMemory.Analytics.EntityCommunity
+  .ctor(String EntityId, Int64 CommunityId)
+  EntityCommunity <Clone>$()
+  Int64 CommunityId { get; set; }
+  Void Deconstruct(String& EntityId, Int64& CommunityId)
+  String EntityId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntityCommunity other)
+  Int32 GetHashCode()
+  String ToString()
+
+### class AgentMemory.Analytics.EntityRank
+  .ctor(String EntityId, Double Score)
+  EntityRank <Clone>$()
+  Void Deconstruct(String& EntityId, Double& Score)
+  String EntityId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(EntityRank other)
+  Int32 GetHashCode()
+  Double Score { get; set; }
+  String ToString()
+
+### class AgentMemory.Analytics.GdsAnalyticsOptions
+  .ctor()
+  Int32 DefaultTopN { get; set; }
+
+### interface AgentMemory.Analytics.IGdsAvailability
+  Task`1 IsAvailableAsync(CancellationToken cancellationToken)
+
+### interface AgentMemory.Analytics.IMemoryCommunityService
+  Task`1 DetectCommunitiesAsync(MemoryScope scope, CancellationToken cancellationToken)
+
+### interface AgentMemory.Analytics.IMemoryPageRankService
+  Task`1 RankEntitiesAsync(Nullable`1 topN, MemoryScope scope, CancellationToken cancellationToken)
+
+### class AgentMemory.Analytics.ServiceCollectionExtensions
+  IServiceCollection AddGdsMemoryAnalytics(IServiceCollection services, Action`1 configure)
+
+## AgentMemory.Cli (13 public types)
+
+### class AgentMemory.Cli.CliArgs
+  String Command { get; }
+  String Get(String name)
+  Boolean HasFlag(String name)
+  IReadOnlyDictionary`2 Options { get; }
+  CliArgs Parse(String[] args)
+
+### class AgentMemory.Cli.CliHelp
+  Void Print(TextWriter output)
+
+### class AgentMemory.Cli.Commands.BootstrapCommand
+  .ctor(ISchemaBootstrapper bootstrapper, TextWriter output)
+  Task`1 ExecuteAsync(CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.ConflictsCommand
+  .ctor(IConflictDetectionService service, TextWriter output)
+  Task`1 ExecuteAsync(CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.ConsolidateCommand
+  .ctor(IConsolidationService service, TextWriter output)
+  Task`1 ExecuteAsync(Boolean apply, CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.DecayCommand
+  .ctor(IMemoryDecayService service, TextWriter output)
+  Task`1 ExecuteAsync(String ownerId, CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.EvaluationCommand
+  .ctor(ISchemaBootstrapper bootstrapper, INeo4jTransactionRunner txRunner, IOptions`1 neo4jOptions, IShortTermMemoryService shortTerm, ILongTermMemoryService longTerm, IReasoningMemoryService reasoning, IMemoryHistoryService history, IToolCallRepository toolCalls, TextWriter output)
+  Task`1 ExecuteAsync(String outputPath, String iterationsValue, String ownerValue)
+
+### class AgentMemory.Cli.Commands.HistoryCommand
+  .ctor(IMemoryHistoryService service, TextWriter output)
+  Task`1 ExecuteAsync(String type, String id, String owner, Boolean liveOnly, Boolean ownOnly, String limitValue, CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.InvalidateCommand
+  .ctor(IFactRepository facts, IEntityRepository entities, IPreferenceRepository preferences, TextWriter output)
+  Task`1 ExecuteAsync(String type, String id, String owner, CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.MigrateCommand
+  .ctor(IMigrationRunner runner, TextWriter output)
+  Task`1 ExecuteAsync(CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.SchemaCheckCommand
+  .ctor(INeo4jTransactionRunner txRunner, IOptions`1 options, TextWriter output)
+  Task`1 ExecuteAsync(CancellationToken cancellationToken)
+
+### class AgentMemory.Cli.Commands.SchemaParityCommand
+  .ctor(TextWriter output)
+  Int32 Execute(String upstreamVersion)
+
+### class AgentMemory.Cli.Commands.SupersedeCommand
+  .ctor(IFactRepository facts, IPreferenceRepository preferences, TextWriter output)
+  Task`1 ExecuteAsync(String type, String loser, String winner, String owner, CancellationToken cancellationToken)
+
+## AgentMemory.Core (6 public types)
+
+### class AgentMemory.Core.Extraction.ExtractorBase`1
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### class AgentMemory.Core.Extraction.PatternBasedPreferenceDetector
+  .ctor()
+  .ctor(IOptions`1 options)
+  Task`1 ExtractAsync(IReadOnlyList`1 messages, CancellationToken cancellationToken)
+
+### class AgentMemory.Core.ServiceCollectionExtensions
+  IServiceCollection AddAgentMemoryCore(IServiceCollection services, Action`1 configure)
+
+### class AgentMemory.Core.Stubs.GuidIdGenerator
+  .ctor()
+  String GenerateId()
+
+### class AgentMemory.Core.Stubs.StubEmbeddingGenerator
+  .ctor(ILogger`1 logger, Int32 dimensions)
+  Void Dispose()
+  Task`1 GenerateAsync(IEnumerable`1 values, EmbeddingGenerationOptions options, CancellationToken cancellationToken)
+  Object GetService(Type serviceType, Object serviceKey)
+  EmbeddingGeneratorMetadata Metadata { get; }
+
+### class AgentMemory.Core.Stubs.SystemClock
+  .ctor()
+  DateTimeOffset UtcNow { get; }
+
+## AgentMemory (1 public types)
+
+### class AgentMemory.ServiceCollectionExtensions
+  IServiceCollection AddNeo4jAgentMemory(IServiceCollection services, Action`1 configureMemory, Action`1 configureNeo4j, Action`1 configureLlm, Action`1 configureStore)
+  IServiceCollection WithAzureLanguageExtraction(IServiceCollection services, Action`1 configure)
+  IServiceCollection WithEnrichment(IServiceCollection services, Action`1 configureGeocoding, Action`1 configureEnrichment, Action`1 configureCaching)
+  IServiceCollection WithObservability(IServiceCollection services)
+
+## AgentMemory.Enrichment (5 public types)
+
+### class AgentMemory.Enrichment.EnrichmentCacheOptions
+  .ctor()
+  TimeSpan EnrichmentCacheDuration { get; set; }
+  TimeSpan GeocodingCacheDuration { get; set; }
+
+### class AgentMemory.Enrichment.EnrichmentServiceKeys
+  String Diffbot
+
+### class AgentMemory.Enrichment.GeocodingOptions
+  .ctor()
+  String BaseUrl { get; set; }
+  Int32 MaxRetries { get; set; }
+  Int32 RateLimitPerSecond { get; set; }
+  Int32 TimeoutSeconds { get; set; }
+  String UserAgent { get; set; }
+
+### class AgentMemory.Enrichment.ServiceCollectionExtensions
+  IServiceCollection AddDiffbotEnrichment(IServiceCollection services, Action`1 configure)
+  IServiceCollection AddEnrichmentServices(IServiceCollection services, Action`1 configureGeocoding, Action`1 configureEnrichment, Action`1 configureCaching)
+
+### class AgentMemory.Enrichment.WikimediaEnrichmentOptions
+  .ctor()
+  Int32 MaxRetries { get; set; }
+  Int32 TimeoutSeconds { get; set; }
+  String WikipediaBaseUrl { get; set; }
+  String WikipediaLanguage { get; set; }
+
+## AgentMemory.Extraction.AzureLanguage (2 public types)
+
+### class AgentMemory.Extraction.AzureLanguage.AzureLanguageOptions
+  .ctor()
+  String ApiKey { get; set; }
+  String DefaultLanguage { get; set; }
+  String Endpoint { get; set; }
+  Double KeyPhraseFactConfidence { get; set; }
+  Double LinkedEntityFactConfidence { get; set; }
+  Int32 MaxDocumentBatchSize { get; set; }
+  Double PreferenceSentimentThreshold { get; set; }
+
+### class AgentMemory.Extraction.AzureLanguage.ServiceCollectionExtensions
+  IServiceCollection AddAzureLanguageExtraction(IServiceCollection services, Action`1 configure)
+
+## AgentMemory.Extraction.Llm (2 public types)
+
+### class AgentMemory.Extraction.Llm.LlmExtractionOptions
+  .ctor()
+  String EntityExtractionPrompt { get; set; }
+  IReadOnlyList`1 EntityTypes { get; set; }
+  String FactExtractionPrompt { get; set; }
+  Int32 MaxRetries { get; set; }
+  String ModelId { get; set; }
+  String PreferenceExtractionPrompt { get; set; }
+  String RelationshipExtractionPrompt { get; set; }
+  Single Temperature { get; set; }
+
+### class AgentMemory.Extraction.Llm.ServiceCollectionExtensions
+  IServiceCollection AddLlmExtraction(IServiceCollection services, Action`1 configure)
+
+## AgentMemory.McpServer (2 public types)
+
+### class AgentMemory.McpServer.AgentMemoryMcpOptions
+  .ctor()
+  Double DefaultConfidence { get; set; }
+  String DefaultSessionId { get; set; }
+  Boolean EnableGraphQuery { get; set; }
+  String ServerName { get; set; }
+  String ServerVersion { get; set; }
+
+### class AgentMemory.McpServer.ServiceCollectionExtensions
+  IMcpServerBuilder AddAgentMemoryMcpPrompts(IMcpServerBuilder builder)
+  IMcpServerBuilder AddAgentMemoryMcpResources(IMcpServerBuilder builder)
+  IMcpServerBuilder AddAgentMemoryMcpTools(IMcpServerBuilder builder)
+  IMcpServerBuilder AddAgentMemoryMcpTools(IMcpServerBuilder builder, Action`1 configure)
+
+## AgentMemory.Neo4j (8 public types)
+
+### class AgentMemory.Neo4j.Infrastructure.GraphRagOptions
+  .ctor()
+  Boolean FilterStopWords { get; set; }
+  String FulltextIndexName { get; set; }
+  String IndexName { get; set; }
+  Int32 MaxTraversalHops { get; set; }
+  String RetrievalQuery { get; set; }
+  GraphRagSearchMode SearchMode { get; set; }
+  Int32 TopK { get; set; }
+
+### interface AgentMemory.Neo4j.Infrastructure.IMigrationRunner
+  Task RunMigrationsAsync(CancellationToken cancellationToken)
+
+### interface AgentMemory.Neo4j.Infrastructure.INeo4jTransactionRunner
+  Task`1 ReadAsync(Func`2 work, CancellationToken cancellationToken)
+  Task ReadAsync(Func`2 work, CancellationToken cancellationToken)
+  Task`1 WriteAsync(Func`2 work, CancellationToken cancellationToken)
+  Task WriteAsync(Func`2 work, CancellationToken cancellationToken)
+
+### interface AgentMemory.Neo4j.Infrastructure.ISchemaBootstrapper
+  Task BootstrapAsync(CancellationToken cancellationToken)
+
+### enum AgentMemory.Neo4j.Infrastructure.MemoryStorageStrategy
+  MemoryStorageStrategy DatabasePerApplication
+  MemoryStorageStrategy SharedDatabase
+  Int32 value__
+
+### class AgentMemory.Neo4j.Infrastructure.MemoryStoreOptions
+  .ctor()
+  Boolean AutoProvision { get; set; }
+  String DatabasePrefix { get; set; }
+  String DefaultDatabase { get; set; }
+  MemoryStorageStrategy Strategy { get; set; }
+
+### class AgentMemory.Neo4j.Infrastructure.Neo4jOptions
+  .ctor()
+  TimeSpan ConnectionAcquisitionTimeout { get; set; }
+  String Database { get; set; }
+  Int32 EmbeddingDimensions { get; set; }
+  Boolean EncryptionEnabled { get; set; }
+  Int32 MaxConnectionPoolSize { get; set; }
+  String Password { get; set; }
+  String Uri { get; set; }
+  String Username { get; set; }
+  Boolean ValidateVectorIndexDimensions { get; set; }
+
+### class AgentMemory.Neo4j.Infrastructure.ServiceCollectionExtensions
+  IServiceCollection AddGraphRagAdapter(IServiceCollection services, Action`1 configure)
+  IServiceCollection AddNeo4jAgentMemory(IServiceCollection services, Action`1 configure, Action`1 configureStore)
+
+## AgentMemory.Observability (3 public types)
+
+### class AgentMemory.Observability.MemoryActivitySource
+  ActivitySource Instance
+  String Name
+
+### class AgentMemory.Observability.MemoryMetrics
+  .ctor()
+  Void Dispose()
+  String MeterName
+
+### class AgentMemory.Observability.ServiceCollectionExtensions
+  IServiceCollection AddAgentMemoryObservability(IServiceCollection services)
+
+## AgentMemory.TckBridge (35 public types)
+
+### class AgentMemory.TckBridge.AddEntityRequest
+  .ctor(String Name, String EntityType, String Description)
+  AddEntityRequest <Clone>$()
+  Void Deconstruct(String& Name, String& EntityType, String& Description)
+  String Description { get; set; }
+  String EntityType { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(AddEntityRequest other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.AddFactRequest
+  .ctor(String Subject, String Predicate, String Obj)
+  AddFactRequest <Clone>$()
+  Void Deconstruct(String& Subject, String& Predicate, String& Obj)
+  Boolean Equals(Object obj)
+  Boolean Equals(AddFactRequest other)
+  Int32 GetHashCode()
+  String Obj { get; set; }
+  String Predicate { get; set; }
+  String Subject { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.AddMessageRequest
+  .ctor(String SessionId, String Role, String Content, IReadOnlyDictionary`2 Metadata)
+  AddMessageRequest <Clone>$()
+  String Content { get; set; }
+  Void Deconstruct(String& SessionId, String& Role, String& Content, IReadOnlyDictionary`2& Metadata)
+  Boolean Equals(Object obj)
+  Boolean Equals(AddMessageRequest other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Role { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.AddPreferenceRequest
+  .ctor(String Category, String Preference, String Context)
+  AddPreferenceRequest <Clone>$()
+  String Category { get; set; }
+  String Context { get; set; }
+  Void Deconstruct(String& Category, String& Preference, String& Context)
+  Boolean Equals(Object obj)
+  Boolean Equals(AddPreferenceRequest other)
+  Int32 GetHashCode()
+  String Preference { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.AddRelationshipRequest
+  .ctor(String SourceId, String TargetId, String RelationshipType, IReadOnlyDictionary`2 Properties)
+  AddRelationshipRequest <Clone>$()
+  Void Deconstruct(String& SourceId, String& TargetId, String& RelationshipType, IReadOnlyDictionary`2& Properties)
+  Boolean Equals(Object obj)
+  Boolean Equals(AddRelationshipRequest other)
+  Int32 GetHashCode()
+  IReadOnlyDictionary`2 Properties { get; set; }
+  String RelationshipType { get; set; }
+  String SourceId { get; set; }
+  String TargetId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.AddStepRequest
+  .ctor(String TraceId, String Thought, String Action, String Observation)
+  AddStepRequest <Clone>$()
+  String Action { get; set; }
+  Void Deconstruct(String& TraceId, String& Thought, String& Action, String& Observation)
+  Boolean Equals(Object obj)
+  Boolean Equals(AddStepRequest other)
+  Int32 GetHashCode()
+  String Observation { get; set; }
+  String Thought { get; set; }
+  String ToString()
+  String TraceId { get; set; }
+
+### class AgentMemory.TckBridge.ClearSessionRequest
+  .ctor(String SessionId)
+  ClearSessionRequest <Clone>$()
+  Void Deconstruct(String& SessionId)
+  Boolean Equals(Object obj)
+  Boolean Equals(ClearSessionRequest other)
+  Int32 GetHashCode()
+  String SessionId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.CompleteTraceRequest
+  .ctor(String TraceId, String Outcome, Nullable`1 Success)
+  CompleteTraceRequest <Clone>$()
+  Void Deconstruct(String& TraceId, String& Outcome, Nullable`1& Success)
+  Boolean Equals(Object obj)
+  Boolean Equals(CompleteTraceRequest other)
+  Int32 GetHashCode()
+  String Outcome { get; set; }
+  Nullable`1 Success { get; set; }
+  String ToString()
+  String TraceId { get; set; }
+
+### class AgentMemory.TckBridge.DeleteMessageRequest
+  .ctor(String MessageId)
+  DeleteMessageRequest <Clone>$()
+  Void Deconstruct(String& MessageId)
+  Boolean Equals(Object obj)
+  Boolean Equals(DeleteMessageRequest other)
+  Int32 GetHashCode()
+  String MessageId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.GetConversationRequest
+  .ctor(String SessionId, Nullable`1 Limit)
+  GetConversationRequest <Clone>$()
+  Void Deconstruct(String& SessionId, Nullable`1& Limit)
+  Boolean Equals(Object obj)
+  Boolean Equals(GetConversationRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.GetEntityByNameRequest
+  .ctor(String Name)
+  GetEntityByNameRequest <Clone>$()
+  Void Deconstruct(String& Name)
+  Boolean Equals(Object obj)
+  Boolean Equals(GetEntityByNameRequest other)
+  Int32 GetHashCode()
+  String Name { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.GetRelatedEntitiesRequest
+  .ctor(String EntityId, String RelationshipType, Nullable`1 Depth)
+  GetRelatedEntitiesRequest <Clone>$()
+  Void Deconstruct(String& EntityId, String& RelationshipType, Nullable`1& Depth)
+  Nullable`1 Depth { get; set; }
+  String EntityId { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(GetRelatedEntitiesRequest other)
+  Int32 GetHashCode()
+  String RelationshipType { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.GetSimilarTracesRequest
+  .ctor(String Task, Nullable`1 Limit, Nullable`1 SuccessOnly)
+  GetSimilarTracesRequest <Clone>$()
+  Void Deconstruct(String& Task, Nullable`1& Limit, Nullable`1& SuccessOnly)
+  Boolean Equals(Object obj)
+  Boolean Equals(GetSimilarTracesRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  Nullable`1 SuccessOnly { get; set; }
+  String Task { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.GetToolStatsRequest
+  .ctor(String ToolName)
+  GetToolStatsRequest <Clone>$()
+  Void Deconstruct(String& ToolName)
+  Boolean Equals(Object obj)
+  Boolean Equals(GetToolStatsRequest other)
+  Int32 GetHashCode()
+  String ToString()
+  String ToolName { get; set; }
+
+### class AgentMemory.TckBridge.GetTraceWithStepsRequest
+  .ctor(String TraceId)
+  GetTraceWithStepsRequest <Clone>$()
+  Void Deconstruct(String& TraceId)
+  Boolean Equals(Object obj)
+  Boolean Equals(GetTraceWithStepsRequest other)
+  Int32 GetHashCode()
+  String ToString()
+  String TraceId { get; set; }
+
+### class AgentMemory.TckBridge.ListSessionsRequest
+  .ctor(Nullable`1 Limit)
+  ListSessionsRequest <Clone>$()
+  Void Deconstruct(Nullable`1& Limit)
+  Boolean Equals(Object obj)
+  Boolean Equals(ListSessionsRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.ListTracesRequest
+  .ctor(String SessionId, Nullable`1 Limit)
+  ListTracesRequest <Clone>$()
+  Void Deconstruct(String& SessionId, Nullable`1& Limit)
+  Boolean Equals(Object obj)
+  Boolean Equals(ListTracesRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.MergeDuplicateEntitiesRequest
+  .ctor(String SourceId, String TargetId, String CanonicalName)
+  MergeDuplicateEntitiesRequest <Clone>$()
+  String CanonicalName { get; set; }
+  Void Deconstruct(String& SourceId, String& TargetId, String& CanonicalName)
+  Boolean Equals(Object obj)
+  Boolean Equals(MergeDuplicateEntitiesRequest other)
+  Int32 GetHashCode()
+  String SourceId { get; set; }
+  String TargetId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.RecordToolCallRequest
+  .ctor(String StepId, String ToolName, JsonElement Arguments, Nullable`1 Result, String Status, Nullable`1 DurationMs, String Error)
+  RecordToolCallRequest <Clone>$()
+  JsonElement Arguments { get; set; }
+  Void Deconstruct(String& StepId, String& ToolName, JsonElement& Arguments, Nullable`1& Result, String& Status, Nullable`1& DurationMs, String& Error)
+  Nullable`1 DurationMs { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(RecordToolCallRequest other)
+  String Error { get; set; }
+  Int32 GetHashCode()
+  Nullable`1 Result { get; set; }
+  String Status { get; set; }
+  String StepId { get; set; }
+  String ToString()
+  String ToolName { get; set; }
+
+### class AgentMemory.TckBridge.SearchEntitiesRequest
+  .ctor(String Query, Nullable`1 Limit)
+  SearchEntitiesRequest <Clone>$()
+  Void Deconstruct(String& Query, Nullable`1& Limit)
+  Boolean Equals(Object obj)
+  Boolean Equals(SearchEntitiesRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String Query { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.SearchMessagesRequest
+  .ctor(String Query, String SessionId, Nullable`1 Limit, Nullable`1 Threshold)
+  SearchMessagesRequest <Clone>$()
+  Void Deconstruct(String& Query, String& SessionId, Nullable`1& Limit, Nullable`1& Threshold)
+  Boolean Equals(Object obj)
+  Boolean Equals(SearchMessagesRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String Query { get; set; }
+  String SessionId { get; set; }
+  Nullable`1 Threshold { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.SearchPreferencesRequest
+  .ctor(String Query, String Category, Nullable`1 Limit)
+  SearchPreferencesRequest <Clone>$()
+  String Category { get; set; }
+  Void Deconstruct(String& Query, String& Category, Nullable`1& Limit)
+  Boolean Equals(Object obj)
+  Boolean Equals(SearchPreferencesRequest other)
+  Int32 GetHashCode()
+  Nullable`1 Limit { get; set; }
+  String Query { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.StartTraceRequest
+  .ctor(String SessionId, String Task)
+  StartTraceRequest <Clone>$()
+  Void Deconstruct(String& SessionId, String& Task)
+  Boolean Equals(Object obj)
+  Boolean Equals(StartTraceRequest other)
+  Int32 GetHashCode()
+  String SessionId { get; set; }
+  String Task { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckConversation
+  .ctor(String Id, String SessionId, IReadOnlyList`1 Messages, String Title, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt)
+  TckConversation <Clone>$()
+  DateTimeOffset CreatedAt { get; set; }
+  Void Deconstruct(String& Id, String& SessionId, IReadOnlyList`1& Messages, String& Title, DateTimeOffset& CreatedAt, DateTimeOffset& UpdatedAt)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckConversation other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  IReadOnlyList`1 Messages { get; set; }
+  String SessionId { get; set; }
+  String Title { get; set; }
+  String ToString()
+  DateTimeOffset UpdatedAt { get; set; }
+
+### class AgentMemory.TckBridge.TckEntity
+  .ctor(String Id, String Name, String Type, String Subtype, String Description, Single[] Embedding, String CanonicalName, DateTimeOffset CreatedAt)
+  TckEntity <Clone>$()
+  String CanonicalName { get; set; }
+  DateTimeOffset CreatedAt { get; set; }
+  Void Deconstruct(String& Id, String& Name, String& Type, String& Subtype, String& Description, Single[]& Embedding, String& CanonicalName, DateTimeOffset& CreatedAt)
+  String Description { get; set; }
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(TckEntity other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  String Name { get; set; }
+  String Subtype { get; set; }
+  String ToString()
+  String Type { get; set; }
+
+### class AgentMemory.TckBridge.TckFact
+  .ctor(String Id, String Subject, String Predicate, String Object, Single[] Embedding)
+  TckFact <Clone>$()
+  Void Deconstruct(String& Id, String& Subject, String& Predicate, String& Object, Single[]& Embedding)
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(TckFact other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  String Object { get; set; }
+  String Predicate { get; set; }
+  String Subject { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckMessage
+  .ctor(String Id, String Role, String Content, DateTimeOffset Timestamp, Single[] Embedding, IReadOnlyDictionary`2 Metadata)
+  TckMessage <Clone>$()
+  String Content { get; set; }
+  Void Deconstruct(String& Id, String& Role, String& Content, DateTimeOffset& Timestamp, Single[]& Embedding, IReadOnlyDictionary`2& Metadata)
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(TckMessage other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  IReadOnlyDictionary`2 Metadata { get; set; }
+  String Role { get; set; }
+  DateTimeOffset Timestamp { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckPreference
+  .ctor(String Id, String Category, String Preference, String Context, Single[] Embedding)
+  TckPreference <Clone>$()
+  String Category { get; set; }
+  String Context { get; set; }
+  Void Deconstruct(String& Id, String& Category, String& Preference, String& Context, Single[]& Embedding)
+  Single[] Embedding { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(TckPreference other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  String Preference { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckReasoningStep
+  .ctor(String Id, String TraceId, Int32 StepNumber, String Thought, String Action, String Observation, IReadOnlyList`1 ToolCalls)
+  TckReasoningStep <Clone>$()
+  String Action { get; set; }
+  Void Deconstruct(String& Id, String& TraceId, Int32& StepNumber, String& Thought, String& Action, String& Observation, IReadOnlyList`1& ToolCalls)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckReasoningStep other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  String Observation { get; set; }
+  Int32 StepNumber { get; set; }
+  String Thought { get; set; }
+  String ToString()
+  IReadOnlyList`1 ToolCalls { get; set; }
+  String TraceId { get; set; }
+
+### class AgentMemory.TckBridge.TckReasoningTrace
+  .ctor(String Id, String SessionId, String Task, IReadOnlyList`1 Steps, String Outcome, Nullable`1 Success, DateTimeOffset StartedAt, Nullable`1 CompletedAt)
+  TckReasoningTrace <Clone>$()
+  Nullable`1 CompletedAt { get; set; }
+  Void Deconstruct(String& Id, String& SessionId, String& Task, IReadOnlyList`1& Steps, String& Outcome, Nullable`1& Success, DateTimeOffset& StartedAt, Nullable`1& CompletedAt)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckReasoningTrace other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  String Outcome { get; set; }
+  String SessionId { get; set; }
+  DateTimeOffset StartedAt { get; set; }
+  IReadOnlyList`1 Steps { get; set; }
+  Nullable`1 Success { get; set; }
+  String Task { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckRelationship
+  .ctor(String Id, String SourceId, String TargetId, String RelationshipType, IReadOnlyDictionary`2 Properties)
+  TckRelationship <Clone>$()
+  Void Deconstruct(String& Id, String& SourceId, String& TargetId, String& RelationshipType, IReadOnlyDictionary`2& Properties)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckRelationship other)
+  Int32 GetHashCode()
+  String Id { get; set; }
+  IReadOnlyDictionary`2 Properties { get; set; }
+  String RelationshipType { get; set; }
+  String SourceId { get; set; }
+  String TargetId { get; set; }
+  String ToString()
+
+### class AgentMemory.TckBridge.TckSessionInfo
+  .ctor(String SessionId, Int32 MessageCount, Nullable`1 CreatedAt, Nullable`1 UpdatedAt)
+  TckSessionInfo <Clone>$()
+  Nullable`1 CreatedAt { get; set; }
+  Void Deconstruct(String& SessionId, Int32& MessageCount, Nullable`1& CreatedAt, Nullable`1& UpdatedAt)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckSessionInfo other)
+  Int32 GetHashCode()
+  Int32 MessageCount { get; set; }
+  String SessionId { get; set; }
+  String ToString()
+  Nullable`1 UpdatedAt { get; set; }
+
+### class AgentMemory.TckBridge.TckToolCall
+  .ctor(String Id, String ToolName, JsonElement Arguments, Nullable`1 Result, String Status, Nullable`1 DurationMs, String Error)
+  TckToolCall <Clone>$()
+  JsonElement Arguments { get; set; }
+  Void Deconstruct(String& Id, String& ToolName, JsonElement& Arguments, Nullable`1& Result, String& Status, Nullable`1& DurationMs, String& Error)
+  Nullable`1 DurationMs { get; set; }
+  Boolean Equals(Object obj)
+  Boolean Equals(TckToolCall other)
+  String Error { get; set; }
+  Int32 GetHashCode()
+  String Id { get; set; }
+  Nullable`1 Result { get; set; }
+  String Status { get; set; }
+  String ToString()
+  String ToolName { get; set; }
+
+### class AgentMemory.TckBridge.TckToolStats
+  .ctor(String Name, Int32 TotalCalls, Int32 SuccessfulCalls, Int32 FailedCalls, Double SuccessRate, Nullable`1 AvgDurationMs)
+  TckToolStats <Clone>$()
+  Nullable`1 AvgDurationMs { get; set; }
+  Void Deconstruct(String& Name, Int32& TotalCalls, Int32& SuccessfulCalls, Int32& FailedCalls, Double& SuccessRate, Nullable`1& AvgDurationMs)
+  Boolean Equals(Object obj)
+  Boolean Equals(TckToolStats other)
+  Int32 FailedCalls { get; set; }
+  Int32 GetHashCode()
+  String Name { get; set; }
+  Double SuccessRate { get; set; }
+  Int32 SuccessfulCalls { get; set; }
+  String ToString()
+  Int32 TotalCalls { get; set; }
+
+### class Program
+  .ctor()
+
+## AgentMemory.SemanticKernel (5 public types)
+
+### class AgentMemory.SemanticKernel.KernelMemoryExtensions
+  IKernelBuilder AddNeo4jMemoryPlugin(IKernelBuilder builder, Action`1 configureSecurity)
+  Kernel AddNeo4jMemoryPlugin(Kernel kernel, IMemoryService memoryService, MemoryRecallSecurityOptions securityOptions)
+  IKernelBuilder AddNeo4jTextSearch(IKernelBuilder builder, String sessionId, String userId, MemoryRecallSecurityOptions securityOptions)
+
+### enum AgentMemory.SemanticKernel.MemoryContextSecurityMode
+  MemoryContextSecurityMode Permissive
+  MemoryContextSecurityMode Strict
+  Int32 value__
+
+### class AgentMemory.SemanticKernel.MemoryRecallSecurityOptions
+  .ctor()
+  MemoryTrustLevel MinimumTrustForAdmissionBypass { get; set; }
+  MemoryTrustLevel MinimumTrustForSystemRole { get; set; }
+  MemoryContextSecurityMode SecurityMode { get; set; }
+
+### class AgentMemory.SemanticKernel.Neo4jMemoryPlugin
+  .ctor(IMemoryService memoryService, ILogger`1 logger, IOptions`1 securityOptions)
+  Task AddMessageAsync(String sessionId, String conversationId, String role, String content, CancellationToken cancellationToken)
+  Task ClearSessionAsync(String sessionId, CancellationToken cancellationToken)
+  Task ExtractFromConversationAsync(String conversationId, String userId, CancellationToken cancellationToken)
+  Task ExtractFromSessionAsync(String sessionId, String userId, CancellationToken cancellationToken)
+  Task`1 RecallAsync(String query, String sessionId, String userId, CancellationToken cancellationToken)
+
+### class AgentMemory.SemanticKernel.Neo4jTextSearch
+  .ctor(IMemoryService memoryService, String sessionId, String userId, MemoryRecallSecurityOptions securityOptions)
+  Task`1 GetSearchResultsAsync(String query, TextSearchOptions`1 searchOptions, CancellationToken cancellationToken)
+  Task`1 GetTextSearchResultsAsync(String query, TextSearchOptions`1 searchOptions, CancellationToken cancellationToken)
+  Task`1 SearchAsync(String query, TextSearchOptions`1 searchOptions, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Phase 1 of a 3-phase plan (stabilization → **this phase** → NAMS package skeleton). Executes the "Phase 0: Contract confirmation and baseline freeze" section of the NAMS backend engineering plan (`strategy/AgentMemory_NAMS_Backend_Engineering_Plan_V03.md`). **No source code changes** — documentation and data artifacts only.

Full plan and results: `docs/reviews/NAMS_Phase0_PlanningAndImplementationPlan.md`.

- Tagged `main` HEAD as `baseline/pre-nams-2026-07-17`.
- Archived a full build/test record (0 warnings, 3041+54+308 tests passing, all 12 packages dry-run packed).
- Generated a public API snapshot (no such tooling existed before; used `System.Reflection.MetadataLoadContext` from a scratchpad one-off tool, output committed).
- **Discovered a real, public, machine-readable NAMS OpenAPI spec** (`memory.neo4jlabs.com/openapi.json`, 80 paths/92 operations) that the engineering plan had treated as an open question — pinned as `docs/reviews/nams-openapi-snapshot-2026-07-17.json`. This resolves the plan's own flagged `SearchMessagesAsync` uncertainty (`POST /v1/conversations/{id}/search` exists) and confirms the idempotency gap is real (verified directly against the spec's parameter definitions, not just absent from docs).
- Opened tracking issue #128 with the plan's Section 11 questions, tiered for a time-boxed Neo4j meeting.

## Test plan

- [x] No source code changed — Release build/test suite unaffected (verified: 3041 unit + 54 SK + 308 integration all still passing at this baseline)
- [x] Verified doc/artifact factual accuracy via an independent review pass (all claims cross-checked against actual files, GitHub, and the fetched OpenAPI spec — no discrepancies found)
- [x] Confirmed no real secrets/tokens in the committed OpenAPI snapshot (it's a public schema document)

🤖 Generated with [Claude Code](https://claude.com/claude-code)