### PR TITLE
NAMS Phase 2: low-level REST client and error model (AgentMemory.Nams)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -931,7 +931,7 @@ These rules are inviolable. Violation of any rule is a blocking review finding.
 - ✅ Neo4j .csproj: Neo4j.Driver 6.0.0 + M.E.DI/Logging/Options (no Microsoft.Agents.*, no MCP SDK)
 - ✅ `grep` for `Microsoft.Agents` across `src/AgentMemory.Neo4j/` returns zero matches
 - ✅ GraphRAG retrieval (`Neo4jGraphRagContextSource`, `IRetriever`, `VectorRetriever`, `FulltextRetriever`, `HybridRetriever`) lives inside `AgentMemory.Neo4j` — no separate `GraphRagAdapter` package exists
-- ✅ `AgentMemory.Nams` .csproj: `Microsoft.Extensions.DependencyInjection.Abstractions` + `Microsoft.Extensions.Options` only, zero `<ProjectReference>` elements (B9) — a configuration-surface-only skeleton, listed in `eng/release-packages.txt` (mandatory for every `src/*` package) but with no client/HTTP-call behavior yet (see `docs/reviews/NAMS_Phase1_PackageSkeleton_PlanningAndImplementationPlan.md`)
+- ✅ `AgentMemory.Nams` .csproj: `Microsoft.Extensions.DependencyInjection.Abstractions` + `Microsoft.Extensions.Options` + `Microsoft.Extensions.Logging.Abstractions` + `Microsoft.Extensions.Http`, zero `<ProjectReference>` elements (B9) — as of Phase 2 it also has a low-level REST client, retry policy, and error model (its own `HttpClient`-based implementation, no dependency on the external `Neo4j.AgentMemory` TCK client — see `docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md`), listed in `eng/release-packages.txt` (mandatory for every `src/*` package), still with no recall/persistence integration into the memory pipeline
 
 ---
 

--- a/docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md
@@ -1,0 +1,208 @@
+# NAMS Phase 2 — Low-Level Client Adapter and Error Model: Planning and Implementation Plan
+
+**Prepared:** 2026-07-17
+**Branch:** `nams/phase2-client-adapter`
+**Purpose:** Continues the NAMS backend effort after Phase 0 (baseline freeze, #129) and Phase 1 (package
+skeleton, #130). Executes the "Phase 2: Low-level client adapter and error model" section of
+`strategy/NAMS/AgentMemory_NAMS_Backend_Engineering_Plan_V04.md` (§7), the version now canonical after the
+V03→V04 drift analysis (`strategy/NAMS/NAMS_V04_Alignment_Plan.md`).
+
+**Why now, without Neo4j's answers yet:** the plan's own Phase 0 no-code gate blocks a *production release*
+on unresolved unknowns, not a spike — *"a spike may proceed with explicit temporary assumptions, but it may
+not be released."* Issue #128 has zero replies so far. `strategy/NAMS/Neo4j_Questions.md` (new, this phase)
+breaks the 39 outstanding questions down by whether each one actually blocks release and whether it's
+self-serve-testable against the free NAMS sandbox — most of the ones that matter for Phase 2 are self-serve.
+Nothing in this phase depends on an unanswered question; where the plan's own text assumed an answer we
+don't have, this phase makes the more conservative choice instead (below).
+
+---
+
+## 1. Task and scope
+
+Build the internal, package-contained boundary between `AgentMemory.Nams` and the outside world: an
+HTTP-based client, a typed error model, and a credential-lifecycle abstraction. **No identity/conversation
+mapping, no recall/context formatting, no MAF integration** — those are Phases 3+ and out of scope here.
+
+| Plan requirement | Plan text (§7 Phase 2) | This implementation |
+|---|---|---|
+| Planned files | `Client/{INamsClient,Neo4jNamsClientAdapter,NamsClientFactory,NamsClientExceptionMapper}.cs`, `Domain/{NamsFailureKind,NamsOperationException,NamsOperationResult}.cs` | Same, plus the domain request/response records the interface needs (`NamsConversation`, `NamsContext`, `NamsMessage`, `NamsMessageInput`, `NamsEntity` — referenced by the plan's own interface example but not separately enumerated in its file list) and an `Authentication/` folder for the credential-lifecycle abstraction (new in V04, not in the original file list either) |
+| Rule: app/MAF code must not depend on `Neo4j.AgentMemory.MemoryClient` | — | **Satisfied more strongly than required**: we don't take a dependency on `Neo4j.AgentMemory` (the TCK C# client) at all. See §2 for why. |
+| `INamsClient` — 5 methods (incl. `SearchMessagesAsync`) | Interface example in §7 | **4 methods.** `SearchMessagesAsync` is dropped — the plan's own text already flags it as unconfirmed ("may not map to anything the API actually exposes... be prepared to drop or redesign"), and we have no live sandbox account yet to verify it. Building against a guessed endpoint shape would be worse than not building it; add it in a later phase once confirmed (`Neo4j_Questions.md` — this is self-serve-testable once we have an account). |
+| Retry matrix | Idempotent ops always retry transient failures; writes retry "only with idempotency" | Interpreted conservatively: **idempotency keys don't exist yet** (that's Neo4j-Questions #12-15, unanswered), so writes (`CreateConversationAsync`, `AddMessagesAsync`) get **zero** transient retries for now — a single attempt, fail closed. Reads (`GetContextAsync`, `SearchEntitiesAsync`) retry transient failures per the matrix. Revisit once #12-15 are answered (self-serve, once we have a sandbox account). |
+| Authentication and credential lifecycle (new in V04) | `INamsAccessTokenProvider`, refresh-before-expiry, stampede-safe, 401-vs-403 distinction | Implemented, but **API-key-only** for this phase. JWT/Auth0 support is explicitly deferred — its refresh/expiry contract is unconfirmed (Neo4j-Questions #30), and the plan itself says to "prefer the raw API key path... if refresh semantics are unclear." `NamsOptions.ApiKey` becomes a hard requirement (validated, not type-level — see §3). |
+| `Neo4jNamsClientAdapter` naming | Implies wrapping the external client | Repurposed: it's **our own** `HttpClient`-based implementation of `INamsClient`, calling the pinned OpenAPI endpoints directly (`docs/reviews/nams-openapi-snapshot-2026-07-17.json`). Name kept as-is since it still means "the Neo4j-NAMS-backed implementation of the client interface" — just not a wrapper around a third-party package. |
+
+### Explicitly out of scope for this phase
+
+- `SearchMessagesAsync` (unconfirmed endpoint — see above).
+- JWT/Auth0 token support (deferred pending confirmed refresh contract).
+- Idempotency keys on writes (nothing to key against yet — Phase 3's identity/conversation mapping and the
+  unanswered idempotency questions come first).
+- Any reference to the `Neo4j.AgentMemory` TCK C# client package — deliberately not taken as a dependency at
+  all in this plan revision (§2).
+- Identity/conversation mapping, recall/context formatting, MAF provider, MCP tools — Phases 3, 4, 6, 8.
+
+## 2. Design decision: build our own HTTP client, don't depend on the TCK C# client
+
+V04 §4.8's "Decision for this plan" gates depending on `Neo4j.AgentMemory` on Neo4j confirming it's the
+canonical SDK, that it's stably published, and that its API/license/extensibility are understood — none of
+which are answered (Neo4j-Questions #1-6). Waiting on that would block Phase 2 entirely for no
+technical reason: **NAMS is a free, self-serve, publicly documented REST API** (we already have its pinned
+OpenAPI spec from Phase 0). Building a small internal `HttpClient`-based implementation against that spec:
+
+- Removes the entire "is the TCK client stable/licensed/publishable" question from this phase's critical
+  path — it becomes purely a product-relationship/roadmap question for the Neo4j meeting, not an engineering
+  blocker.
+- Still satisfies the plan's actual *rule* (no app/MAF code depends on an external NAMS client type directly
+  — everything is contained inside `AgentMemory.Nams` behind `INamsClient`).
+- Costs slightly more code now (implementing 4 REST calls ourselves instead of wrapping an existing client),
+  which is a fair trade for zero dependency risk on an unversioned `0.x` external package.
+- Doesn't foreclose switching to the TCK client later if Neo4j confirms it's the right long-term dependency
+  — `INamsClient` is the seam either way; only `Neo4jNamsClientAdapter`'s internals would change.
+
+## 3. Detailed design
+
+### `Client/`
+
+- **`INamsClient`** (internal, matches the plan's own example) — `CreateConversationAsync`,
+  `GetContextAsync`, `AddMessagesAsync`, `SearchEntitiesAsync`. All take a `CancellationToken`.
+- **`Neo4jNamsClientAdapter`** — the `HttpClient`-based implementation. Serializes/deserializes with
+  `System.Text.Json`, builds requests against `NamsOptions.Endpoint`, delegates retry decisions to
+  `NamsRetryPolicy` (new, not separately named in the plan but required to implement the matrix), maps
+  non-success responses through `NamsClientExceptionMapper`.
+- **`NamsRetryPolicy`** (new) — internal helper taking an `isIdempotent` flag; idempotent calls retry
+  network/timeout/429/5xx with exponential backoff (honoring a `Retry-After` header when present on 429);
+  non-idempotent calls make one attempt only. Mirrors the dependency-free style of
+  `AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs` rather than adding a Polly dependency (no
+  precedent for Polly anywhere in this repo).
+- **`NamsClientFactory`** — DI wiring: a named/typed `HttpClient` (base address `NamsOptions.Endpoint`,
+  timeout `NamsOptions.RequestTimeout`) via `Microsoft.Extensions.Http`, with a `NamsAuthenticationHandler`
+  attached.
+- **`NamsClientExceptionMapper`** — maps an `HttpResponseMessage`/exception to a `NamsOperationResult`
+  (success or a typed failure), which the adapter then either returns or throws as `NamsOperationException`.
+
+### `Authentication/` (new folder, not in the plan's file list — required by its new §"Authentication and
+credential lifecycle")
+
+- **`INamsAccessTokenProvider`** — exact shape from the plan (`GetTokenAsync`, `InvalidateAsync`).
+- **`NamsAccessToken`** — value holder (token string + optional expiry); `ToString()`/logging never expose
+  the raw value, only a low-cardinality fingerprint/age, per the plan's explicit requirement.
+- **`StaticApiKeyNamsAccessTokenProvider`** — the only implementation registered for this phase. Wraps
+  `NamsOptions.ApiKey` as a non-expiring token. `InvalidateAsync` is a no-op (a static key can't be
+  refreshed; a 401 on this path is a hard failure, not a retry trigger).
+- **`NamsAuthenticationHandler`** (`DelegatingHandler`) — attaches `Authorization: Bearer <token>` per
+  request; on a 401, invalidates and re-fetches the token and retries the request exactly once (safe even
+  for writes: a 401 means the server never authenticated, so it never executed the operation); a 403 is
+  never retried and maps straight to `NamsFailureKind.Authorization`.
+
+### `Domain/`
+
+- **`NamsFailureKind`** (internal enum) — `Network`, `Timeout`, `RateLimited`, `ServerError`,
+  `Authentication`, `Authorization`, `Validation`, `NotFound`, `Unknown`.
+- **`NamsOperationException`** (internal) — carries a `NamsFailureKind` and the original status
+  code/message; derives directly from `System.Exception`, **not** `AgentMemory.Abstractions.MemoryException`
+  — `AgentMemory.Nams` has zero sibling-package references by design (B9), so it cannot share the
+  Abstractions exception hierarchy.
+- **`NamsOperationResult<T>`** (internal) — a success/failure envelope `NamsClientExceptionMapper` produces,
+  which `Neo4jNamsClientAdapter` unwraps into either a return value or a thrown `NamsOperationException`.
+  Keeps the "map a response" logic pure and separately testable from the "throw" side effect.
+- **`NamsConversation` / `NamsContext` / `NamsMessage` / `NamsMessageInput` / `NamsEntity`** (internal
+  records) — minimal shapes matching the confirmed REST responses for the 4 implemented operations only;
+  not an attempt to model the full NAMS schema.
+
+### Options change
+
+`NamsOptionValidator` gains `HasApiKey` (non-null, non-whitespace) — required because this phase's only
+supported auth mechanism is the static API key. `NamsOptions.ApiKey` stays `string?` at the type level (not
+`required`) since a future JWT-only mode may not need it; the runtime validation is where "required for now"
+actually lives, matching how `Endpoint`'s own `required` keyword is already enforced at runtime by
+`ValidateOnStart` in this package (Phase 1's own definition-of-done note on this exact point). Existing Phase
+1 tests that configured only `Endpoint` are updated to also set `ApiKey`, since a NAMS registration without
+any credential can no longer usefully validate successfully.
+
+### DI wiring
+
+`NamsServiceCollectionExtensions.AddNamsAgentMemory` (extended, not replaced) now also registers:
+`INamsAccessTokenProvider` → `StaticApiKeyNamsAccessTokenProvider`, an `HttpClient` for `INamsClient` via
+`AddHttpClient<INamsClient, Neo4jNamsClientAdapter>()` with `NamsAuthenticationHandler` attached.
+
+### Forward note on ADR-9 (ties to the V04 alignment plan)
+
+`INamsClient` stays `internal` per the plan's own example. Phase 6 (dedicated MAF provider) lands in a
+*separate* package per ADR-9 (`AgentMemory.AgentFramework.Nams`), which won't have compile-time access to
+`AgentMemory.Nams`'s internals by default. Deferred, not solved now: add
+`[InternalsVisibleTo("AgentMemory.AgentFramework.Nams")]` to `AgentMemory.Nams.csproj` when that package is
+created — a one-line addition, not a redesign.
+
+## 4. Tests
+
+Per the plan's own Phase 2 test list, using a fake `DelegatingHandler` (deterministic, no real network):
+
+| Plan requirement | Test coverage |
+|---|---|
+| Successful serialization/mapping | One test per `INamsClient` method, happy path |
+| All error classes map correctly | One test per `NamsFailureKind` (400→Validation, 401→Authentication, 403→Authorization, 404→NotFound, 429→RateLimited, 5xx→ServerError, network exception→Network) |
+| Timeout / caller cancellation | Distinct tests — a per-request timeout retries (idempotent ops); caller-token cancellation never retries and propagates `OperationCanceledException` |
+| 429 with `Retry-After` | Honors the header's delay before retrying (idempotent ops only) |
+| Transient 5xx then success | Retries then returns the eventual success (idempotent ops only) |
+| Retry exhaustion | Throws the mapped exception after the configured attempt budget |
+| Malformed JSON / missing required fields / unknown enum values | Each maps to a clean `NamsOperationException`, never an unhandled deserialization exception |
+| Redaction of tokens | No log line or exception message ever contains the raw API key |
+| No retry for permanent failures (4xx other than 429) | Single attempt, immediate throw |
+| No retry of unsafe writes without idempotency | `CreateConversationAsync`/`AddMessagesAsync` never retry on network/429/5xx |
+| Concurrent token requests perform one refresh | Stampede test: N parallel `GetTokenAsync` calls when a refresh is needed produce exactly one underlying fetch |
+| A 401 triggers exactly one bounded retry after refresh; a 403 never does | Both paths tested explicitly, including for a write operation (proving it's still safe) |
+
+## 5. Definition of done
+
+- [x] `src/AgentMemory.Nams/{Client,Authentication,Domain}/` populated per §3, builds clean (0 warnings) on
+  net8.0/net9.0/net10.0.
+- [x] `PackageBoundaryGuardTests`'s existing B9 rule for `AgentMemory.Nams` still passes unmodified (no new
+  sibling/framework-SDK references introduced — only `Microsoft.Extensions.Http`/`Logging.Abstractions`
+  package refs, consistent with `AgentMemory.Enrichment`'s existing pattern).
+- [x] All plan-mandated tests pass (46 new tests under `tests/AgentMemory.Tests.Unit/Nams/`: 7 retry-policy,
+  15 exception-mapper, 5 authentication-handler, 4 client-factory, 10 client-adapter, 5 DI-wiring/options).
+- [x] Full existing unit/SK/integration suites remain green: **3106 unit (+46) / 54 SK unit / 308
+  live-Neo4j integration**, 0 build warnings across the whole solution.
+- [x] Self-reviewed via parallel finder agents (real business logic this time, not a config-only skeleton —
+  full review applies).
+- [ ] PR opened, CI green, merged.
+
+## 6. Self-review findings and dispositions
+
+Ran 3 parallel finder agents (correctness / cross-file impact / cleanup-conventions) against the staged diff.
+
+- **Real bug, fixed:** `NamsRetryPolicy.RetryDelayFor` only read `Retry-After`'s delta-seconds form
+  (`RetryConditionHeaderValue.Delta`), never the absolute HTTP-date form (`.Date`) RFC 9110 §10.2.3 also
+  permits. If NAMS ever returns the date form on a 429, the code silently fell back to exponential backoff
+  instead of honoring the server-specified wait — a real (if minor) deviation from the plan's own "honors a
+  `Retry-After` header" requirement. Fixed to check both forms; added a regression test
+  (`Idempotent_RateLimitedWithRetryAfterDateForm_RetriesThenSucceeds`).
+- **Doc-hygiene gaps, fixed:** `docs/architecture.md`'s B9 verification bullet and `docs/specification.md`'s
+  package-count note both still described `AgentMemory.Nams` as "a configuration-surface-only skeleton...
+  with no client/HTTP-call behavior yet," pointing at the Phase 1 planning doc — stale the moment this PR's
+  own diff added a real client. Same mistake as Phase 1's own CI-caught lesson, this time caught by
+  self-review instead of CI. Both updated to describe the Phase 2 state and point at this doc.
+- **Cleanup, applied:** `NamsClientExceptionMapper.SafeReadBodyAsync` caught a bare `Exception` (guarded only
+  by "not `OperationCanceledException`"), broader than the specific-exception-type idiom used everywhere
+  else in this diff and in the `RetryHttpMessageHandler.cs` precedent it models itself on. Narrowed to
+  `HttpRequestException or IOException or ObjectDisposedException` — the actual exception types
+  `HttpContent.ReadAsStringAsync` can throw.
+- **Cleanup, clarified (no code change):** `Neo4jNamsClientAdapter`'s `PropertyNameCaseInsensitive = true` is
+  currently dead configuration (every `Domain/*.cs` record already carries an explicit `JsonPropertyName`
+  matching the pinned OpenAPI snapshot exactly). Kept as deliberate defense-in-depth against a future field
+  added without one; added a one-line comment saying so instead of removing it.
+- **Test-coverage gap, closed:** `AddNamsAgentMemory_CalledTwice_DoesNotThrow` proved the second
+  registration call didn't throw, but never actually resolved `INamsClient` — so it didn't prove the new
+  `AddHttpClient<INamsClient,...>` double-registration path was itself conflict-free. Added an
+  `INamsClient`-resolution assertion to close the gap.
+- **Assessed, not a defect:** the correctness reviewer flagged, then independently retracted after re-tracing,
+  a hypothetical content-buffering-order bug in `NamsAuthenticationHandler`'s 401-retry path — buffering
+  happens before either send attempt, so it's safe regardless of content type. No action needed.
+- **Assessed, not a defect:** the cross-file reviewer independently re-verified every `Domain/*.cs` record's
+  `JsonPropertyName` against `docs/reviews/nams-openapi-snapshot-2026-07-17.json`'s actual schemas
+  field-for-field (a second, independent pass beyond the one done during implementation) — all matched, no
+  drift.
+
+Final counts after fixes: 3107 unit (+1 regression test) / 54 Semantic Kernel unit, 0 build warnings across
+the whole solution. Package boundary (B9) and `dotnet pack` re-verified clean by the cross-file reviewer.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -38,7 +38,7 @@ The shipped source packages are:
 
 Supporting projects include `tools/AgentMemory.Cli`, samples, benchmarks, and unit/integration/performance tests.
 
-`AgentMemory.Nams` also exists under `src/` as of the NAMS backend engineering effort. It's listed in `eng/release-packages.txt` (a mandatory, CI-checked inventory of every `src/*` package, not an opt-in publish gate) but is a configuration-surface-only skeleton with no client and no HTTP calls yet — see `docs/reviews/NAMS_Phase1_PackageSkeleton_PlanningAndImplementationPlan.md`.
+`AgentMemory.Nams` also exists under `src/` as of the NAMS backend engineering effort. It's listed in `eng/release-packages.txt` (a mandatory, CI-checked inventory of every `src/*` package, not an opt-in publish gate). As of Phase 2 it has a configuration surface plus a low-level REST client, retry policy, and error model (its own `HttpClient`-based implementation calling the NAMS REST API directly — no dependency on the external `Neo4j.AgentMemory` TCK client), but still no recall/persistence integration into the memory pipeline — see `docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md`.
 
 ## Required Architecture
 

--- a/src/AgentMemory.Nams/AgentMemory.Nams.csproj
+++ b/src/AgentMemory.Nams/AgentMemory.Nams.csproj
@@ -3,13 +3,15 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Description>Additive NAMS (Neo4j Agent Memory as a Service) backend skeleton for AgentMemory for .NET. Configuration surface only -- no client, no HTTP calls, no recall/persistence logic yet. See docs/reviews/NAMS_Phase1_PackageSkeleton_PlanningAndImplementationPlan.md.</Description>
+    <Description>Additive NAMS (Neo4j Agent Memory as a Service) backend for AgentMemory for .NET. Configuration surface plus a low-level REST client and error model -- no recall/persistence integration into the memory pipeline yet. See docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md.</Description>
     <PackageTags>agent-memory;nams;neo4j</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AgentMemory.Nams/Authentication/INamsAccessTokenProvider.cs
+++ b/src/AgentMemory.Nams/Authentication/INamsAccessTokenProvider.cs
@@ -1,0 +1,19 @@
+namespace AgentMemory.Nams.Authentication;
+
+/// <summary>
+/// Supplies the bearer credential used to authenticate NAMS requests. Introduced instead of reading a static
+/// token at every call so a future JWT/Auth0 path can slot in behind the same seam without changing
+/// <see cref="Client.Neo4jNamsClientAdapter"/> (engineering plan §7 Phase 2, "Authentication and credential
+/// lifecycle").
+/// </summary>
+internal interface INamsAccessTokenProvider
+{
+    /// <summary>Returns a currently-valid token, refreshing ahead of expiry if needed. Concurrent callers during a
+    /// refresh must observe a single underlying refresh, not one each.</summary>
+    ValueTask<NamsAccessToken> GetTokenAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Signals that the given token was rejected by the server (a 401) so the provider discards it and
+    /// the next <see cref="GetTokenAsync"/> call fetches a fresh one. Never called for a 403 -- an authorization
+    /// failure is not evidence the token itself is invalid.</summary>
+    ValueTask InvalidateAsync(string rejectedTokenFingerprint, CancellationToken cancellationToken = default);
+}

--- a/src/AgentMemory.Nams/Authentication/NamsAccessToken.cs
+++ b/src/AgentMemory.Nams/Authentication/NamsAccessToken.cs
@@ -1,0 +1,28 @@
+namespace AgentMemory.Nams.Authentication;
+
+/// <summary>
+/// A credential handed to <see cref="NamsAuthenticationHandler"/> for the <c>Authorization: Bearer</c> header.
+/// <see cref="ToString"/> deliberately never exposes <see cref="Value"/> -- only a low-cardinality fingerprint,
+/// per the engineering plan's explicit "expose token age only as low-cardinality diagnostics, never the token or
+/// raw fingerprint" requirement (a truncated hash is a reasonable middle ground: enough to correlate log lines
+/// about "the same token", never enough to reconstruct or replay it).
+/// </summary>
+internal readonly struct NamsAccessToken
+{
+    public string Value { get; }
+
+    /// <summary>Absolute expiry, if the token is time-limited. <c>null</c> for a non-expiring static API key.</summary>
+    public DateTimeOffset? ExpiresAt { get; }
+
+    public NamsAccessToken(string value, DateTimeOffset? expiresAt = null)
+    {
+        Value = value;
+        ExpiresAt = expiresAt;
+    }
+
+    /// <summary>A short, non-reversible fingerprint safe to include in logs/diagnostics.</summary>
+    public string Fingerprint => Convert.ToHexString(
+        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(Value)))[..8];
+
+    public override string ToString() => $"NamsAccessToken[{Fingerprint}]";
+}

--- a/src/AgentMemory.Nams/Authentication/NamsAuthenticationHandler.cs
+++ b/src/AgentMemory.Nams/Authentication/NamsAuthenticationHandler.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace AgentMemory.Nams.Authentication;
+
+/// <summary>
+/// Attaches <c>Authorization: Bearer &lt;token&gt;</c> to every outgoing NAMS request. On a 401, invalidates the
+/// token, fetches a fresh one, and retries the request exactly once -- safe even for write operations, since a
+/// 401 means the server never authenticated the caller and therefore never executed the operation. A 403 is
+/// never retried here; it is a valid-credential authorization failure, not a token problem, and is left for
+/// <see cref="Client.NamsClientExceptionMapper"/> to classify.
+/// </summary>
+internal sealed class NamsAuthenticationHandler : DelegatingHandler
+{
+    private readonly INamsAccessTokenProvider _tokenProvider;
+
+    public NamsAuthenticationHandler(INamsAccessTokenProvider tokenProvider)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        var bufferedContent = request.Content is null ? null : await BufferAsync(request.Content, cancellationToken).ConfigureAwait(false);
+
+        var response = await SendWithTokenAsync(request, token, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+            return response;
+
+        response.Dispose();
+        await _tokenProvider.InvalidateAsync(token.Fingerprint, cancellationToken).ConfigureAwait(false);
+        var refreshedToken = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+
+        var retryRequest = Clone(request, bufferedContent);
+        return await SendWithTokenAsync(retryRequest, refreshedToken, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<HttpResponseMessage> SendWithTokenAsync(
+        HttpRequestMessage request, NamsAccessToken token, CancellationToken cancellationToken)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<byte[]> BufferAsync(HttpContent content, CancellationToken cancellationToken) =>
+        await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+
+    private static HttpRequestMessage Clone(HttpRequestMessage original, byte[]? bufferedContent)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri);
+        foreach (var header in original.Headers)
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+        if (bufferedContent is not null)
+        {
+            clone.Content = new ByteArrayContent(bufferedContent);
+            if (original.Content is not null)
+                foreach (var header in original.Content.Headers)
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        return clone;
+    }
+}

--- a/src/AgentMemory.Nams/Authentication/StaticApiKeyNamsAccessTokenProvider.cs
+++ b/src/AgentMemory.Nams/Authentication/StaticApiKeyNamsAccessTokenProvider.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Options;
+
+namespace AgentMemory.Nams.Authentication;
+
+/// <summary>
+/// The only <see cref="INamsAccessTokenProvider"/> implementation registered in this phase -- wraps
+/// <see cref="NamsOptions.ApiKey"/> as a non-expiring token. JWT/Auth0 support is deferred (its refresh/expiry
+/// contract is unconfirmed -- see <c>strategy/NAMS/Neo4j_Questions.md</c> #30); the engineering plan itself says
+/// to prefer the raw API key path when refresh semantics are unclear.
+/// </summary>
+internal sealed class StaticApiKeyNamsAccessTokenProvider : INamsAccessTokenProvider
+{
+    private readonly NamsAccessToken _token;
+
+    public StaticApiKeyNamsAccessTokenProvider(IOptions<NamsOptions> options)
+    {
+        // NamsOptionValidator.HasApiKey (ValidateOnStart) guarantees this is non-null/non-whitespace before this
+        // type is ever constructed.
+        _token = new NamsAccessToken(options.Value.ApiKey!);
+    }
+
+    public ValueTask<NamsAccessToken> GetTokenAsync(CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(_token);
+
+    /// <summary>No-op: a static API key cannot be refreshed. A 401 against this provider surfaces as a genuine,
+    /// non-retryable authentication failure after the single bounded retry <see cref="NamsAuthenticationHandler"/>
+    /// always attempts.</summary>
+    public ValueTask InvalidateAsync(string rejectedTokenFingerprint, CancellationToken cancellationToken = default) =>
+        ValueTask.CompletedTask;
+}

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -1,0 +1,37 @@
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Nams.Client;
+
+/// <summary>
+/// The low-level NAMS REST boundary. Application and (future) MAF provider code must never depend on an external
+/// NAMS SDK type directly -- everything crossing that boundary is contained inside <c>AgentMemory.Nams</c> behind
+/// this interface (engineering plan §7 Phase 2, "Rule").
+///
+/// Deliberately covers only the 4 operations confirmed against the pinned OpenAPI snapshot
+/// (<c>docs/reviews/nams-openapi-snapshot-2026-07-17.json</c>). A 5th method the engineering plan's own example
+/// included -- <c>SearchMessagesAsync</c> -- is dropped: the plan's own text already flags it as unconfirmed (no
+/// distinct search/query REST operation is documented), and building against a guessed endpoint shape would be
+/// worse than not building it. Add it once verified against a live sandbox (<c>strategy/NAMS/Neo4j_Questions.md</c>).
+/// </summary>
+internal interface INamsClient
+{
+    Task<NamsConversation> CreateConversationAsync(
+        string? userId,
+        IReadOnlyDictionary<string, string>? metadata,
+        CancellationToken cancellationToken);
+
+    Task<NamsContext> GetContextAsync(
+        string conversationId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<NamsMessage>> AddMessagesAsync(
+        string conversationId,
+        IReadOnlyList<NamsMessageInput> messages,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
+        string query,
+        string? type,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
+++ b/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Text.Json;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Nams.Client;
+
+/// <summary>
+/// Maps a NAMS HTTP response or transport-level exception into a <see cref="NamsOperationResult{T}"/> /
+/// <see cref="NamsOperationException"/>. Every failure message is redacted against the configured API key before
+/// it can propagate, per the Phase 2 test list's "redaction of tokens" requirement -- defense in depth in case a
+/// server-side error response ever echoes back request details.
+/// </summary>
+internal static class NamsClientExceptionMapper
+{
+    public static async Task<NamsOperationResult<T>> MapResponseAsync<T>(
+        HttpResponseMessage response,
+        Func<Stream, CancellationToken, Task<T>> deserialize,
+        string? secretToRedact,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            try
+            {
+                var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                var value = await deserialize(stream, cancellationToken).ConfigureAwait(false);
+                return NamsOperationResult<T>.Success(value);
+            }
+            catch (JsonException ex)
+            {
+                return NamsOperationResult<T>.Failure(
+                    NamsFailureKind.Validation,
+                    Redact($"NAMS returned a response that could not be parsed: {ex.Message}", secretToRedact),
+                    (int)response.StatusCode);
+            }
+        }
+
+        var kind = ClassifyStatusCode(response.StatusCode);
+        var body = await SafeReadBodyAsync(response, cancellationToken).ConfigureAwait(false);
+        var message = Redact(
+            $"NAMS request failed with {(int)response.StatusCode} {response.ReasonPhrase}: {body}", secretToRedact);
+        return NamsOperationResult<T>.Failure(kind, message, (int)response.StatusCode);
+    }
+
+    public static NamsOperationException ToException<T>(NamsOperationResult<T> failure) =>
+        new(failure.FailureKind, failure.FailureMessage ?? "NAMS request failed.", failure.StatusCode);
+
+    public static NamsOperationException FromTransportException(Exception ex, string? secretToRedact) => ex switch
+    {
+        HttpRequestException => new NamsOperationException(
+            NamsFailureKind.Network, Redact($"Network failure calling NAMS: {ex.Message}", secretToRedact), innerException: ex),
+        TaskCanceledException => new NamsOperationException(
+            NamsFailureKind.Timeout, "NAMS request timed out.", innerException: ex),
+        _ => new NamsOperationException(
+            NamsFailureKind.Unknown, Redact($"Unexpected failure calling NAMS: {ex.Message}", secretToRedact), innerException: ex)
+    };
+
+    private static NamsFailureKind ClassifyStatusCode(HttpStatusCode statusCode) => statusCode switch
+    {
+        HttpStatusCode.BadRequest or HttpStatusCode.UnprocessableEntity => NamsFailureKind.Validation,
+        HttpStatusCode.Unauthorized => NamsFailureKind.Authentication,
+        HttpStatusCode.Forbidden => NamsFailureKind.Authorization,
+        HttpStatusCode.NotFound => NamsFailureKind.NotFound,
+        HttpStatusCode.TooManyRequests => NamsFailureKind.RateLimited,
+        _ when (int)statusCode >= 500 => NamsFailureKind.ServerError,
+        _ => NamsFailureKind.Unknown
+    };
+
+    private static async Task<string> SafeReadBodyAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or ObjectDisposedException)
+        {
+            return "<unreadable body>";
+        }
+    }
+
+    private static string Redact(string text, string? secret) =>
+        string.IsNullOrEmpty(secret) ? text : text.Replace(secret, "[REDACTED]", StringComparison.Ordinal);
+}

--- a/src/AgentMemory.Nams/Client/NamsClientFactory.cs
+++ b/src/AgentMemory.Nams/Client/NamsClientFactory.cs
@@ -1,0 +1,22 @@
+namespace AgentMemory.Nams.Client;
+
+/// <summary>Configures the <see cref="HttpClient"/> used by <see cref="Neo4jNamsClientAdapter"/> from
+/// <see cref="NamsOptions"/>.</summary>
+internal static class NamsClientFactory
+{
+    public static void ConfigureHttpClient(HttpClient httpClient, NamsOptions options)
+    {
+        httpClient.BaseAddress = NormalizeBaseAddress(options.Endpoint);
+        httpClient.Timeout = options.RequestTimeout;
+    }
+
+    /// <summary>
+    /// Ensures the base address ends with a trailing <c>/</c> so relative request paths combine correctly.
+    /// <see cref="Uri"/> combination drops the last path segment of a base URI that doesn't end in <c>/</c> --
+    /// e.g. base <c>https://host/v1</c> + relative <c>conversations</c> resolves to <c>https://host/conversations</c>,
+    /// silently dropping <c>/v1</c>. <c>NamsOptionValidator.HasAbsoluteEndpoint</c> guarantees
+    /// <see cref="NamsOptions.Endpoint"/> is absolute before this runs.
+    /// </summary>
+    internal static Uri NormalizeBaseAddress(Uri endpoint) =>
+        endpoint.OriginalString.EndsWith('/') ? endpoint : new Uri(endpoint.OriginalString + "/");
+}

--- a/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace AgentMemory.Nams.Client;
+
+/// <summary>
+/// Implements the engineering plan's Phase 2 retry matrix (dependency-free, mirroring the style of
+/// <c>AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs</c> rather than taking a Polly dependency).
+/// Idempotent operations (reads) retry transient failures with exponential backoff, honoring a <c>Retry-After</c>
+/// header on 429. Non-idempotent operations (writes) make a single attempt -- <c>strategy/NAMS/Neo4j_Questions.md</c>
+/// #12-15 (does NAMS support idempotency keys?) are unanswered, so retrying a write risks a duplicate.
+/// </summary>
+internal sealed class NamsRetryPolicy
+{
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _baseDelay;
+    private readonly ILogger? _logger;
+
+    public NamsRetryPolicy(int maxAttempts, TimeSpan baseDelay, ILogger? logger = null)
+    {
+        _maxAttempts = Math.Max(0, maxAttempts);
+        _baseDelay = baseDelay;
+        _logger = logger;
+    }
+
+    /// <summary><paramref name="requestFactory"/> is invoked once per attempt -- an <see cref="HttpRequestMessage"/>
+    /// can only be sent once, so each retry needs a fresh instance.</summary>
+    public async Task<HttpResponseMessage> ExecuteAsync(
+        Func<HttpRequestMessage> requestFactory,
+        HttpClient httpClient,
+        bool isIdempotent,
+        CancellationToken cancellationToken)
+    {
+        if (!isIdempotent)
+            return await httpClient.SendAsync(requestFactory(), cancellationToken).ConfigureAwait(false);
+
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                var response = await httpClient.SendAsync(requestFactory(), cancellationToken).ConfigureAwait(false);
+                if (attempt >= _maxAttempts || !IsTransient(response.StatusCode))
+                    return response;
+
+                var delay = RetryDelayFor(response, attempt);
+                _logger?.LogDebug(
+                    "Transient NAMS response {Status}; retry {Next}/{Max} after {Delay}.",
+                    (int)response.StatusCode, attempt + 1, _maxAttempts, delay);
+                response.Dispose();
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw; // caller cancellation -- never retry
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException && attempt < _maxAttempts)
+            {
+                // Network failure, or a per-request timeout (a TaskCanceledException whose token was NOT the
+                // caller's -- caller cancellation is handled by the guarded catch above).
+                _logger?.LogDebug(ex, "Transient NAMS failure; retry {Next}/{Max}.", attempt + 1, _maxAttempts);
+                await Task.Delay(BackoffFor(attempt), cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsTransient(HttpStatusCode status) =>
+        status == HttpStatusCode.TooManyRequests || (int)status is >= 500 and < 600;
+
+    private TimeSpan RetryDelayFor(HttpResponseMessage response, int attempt)
+    {
+        // Retry-After has two legal forms (RFC 9110 §10.2.3): delta-seconds or an absolute HTTP-date. They're
+        // mutually exclusive on RetryConditionHeaderValue -- check both, since NAMS's use of one form over the
+        // other isn't confirmed (strategy/NAMS/Neo4j_Questions.md #24).
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            var retryAfter = response.Headers.RetryAfter;
+            if (retryAfter?.Delta is { } delta)
+                return delta;
+            if (retryAfter?.Date is { } date)
+            {
+                var untilDate = date - DateTimeOffset.UtcNow;
+                return untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero;
+            }
+        }
+
+        return BackoffFor(attempt);
+    }
+
+    private TimeSpan BackoffFor(int attempt) =>
+        TimeSpan.FromMilliseconds(_baseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+}

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -1,0 +1,131 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Nams.Client;
+
+/// <summary>
+/// <see cref="INamsClient"/> implementation calling the NAMS REST API directly (no dependency on the
+/// <c>Neo4j.AgentMemory</c> TCK C# client -- see the Phase 2 planning doc §2 for why). Request paths are built
+/// relative to <see cref="NamsOptions.Endpoint"/> without a leading <c>/</c>: <see cref="NamsClientFactory"/>
+/// normalizes the endpoint to end with a trailing <c>/</c>, and a leading <c>/</c> on the relative path would
+/// make it host-root-relative per <see cref="Uri"/> combination rules, silently dropping any path segment
+/// (e.g. <c>/v1</c>) the configured endpoint carries.
+/// </summary>
+internal sealed class Neo4jNamsClientAdapter : INamsClient
+{
+    // Every Domain record already carries an explicit [JsonPropertyName] matching the pinned OpenAPI snapshot,
+    // so this isn't load-bearing today -- it's defense-in-depth against a future field added without one.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly NamsRetryPolicy _retryPolicy;
+    private readonly string? _apiKeyForRedaction;
+
+    public Neo4jNamsClientAdapter(HttpClient httpClient, IOptions<NamsOptions> options, ILogger<Neo4jNamsClientAdapter> logger)
+    {
+        _httpClient = httpClient;
+        var namsOptions = options.Value;
+        _retryPolicy = new NamsRetryPolicy(namsOptions.MaxRetryAttempts, namsOptions.InitialRetryDelay, logger);
+        _apiKeyForRedaction = namsOptions.ApiKey;
+    }
+
+    public Task<NamsConversation> CreateConversationAsync(
+        string? userId, IReadOnlyDictionary<string, string>? metadata, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            () => BuildJsonRequest(HttpMethod.Post, "conversations", new CreateConversationRequestBody(userId, metadata)),
+            isIdempotent: false,
+            DeserializeAsync<NamsConversation>,
+            cancellationToken);
+
+    public Task<NamsContext> GetContextAsync(string conversationId, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, $"conversations/{Uri.EscapeDataString(conversationId)}/context"),
+            isIdempotent: true,
+            DeserializeAsync<NamsContext>,
+            cancellationToken);
+
+    public async Task<IReadOnlyList<NamsMessage>> AddMessagesAsync(
+        string conversationId, IReadOnlyList<NamsMessageInput> messages, CancellationToken cancellationToken)
+    {
+        var path = $"conversations/{Uri.EscapeDataString(conversationId)}/messages/bulk";
+        var response = await InvokeAsync(
+            () => BuildJsonRequest(HttpMethod.Post, path, new AddMessagesBulkRequestBody(messages)),
+            isIdempotent: false,
+            DeserializeAsync<AddMessagesBatchResponseBody>,
+            cancellationToken).ConfigureAwait(false);
+        return response.Messages;
+    }
+
+    public async Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
+        string query, string? type, int limit, CancellationToken cancellationToken)
+    {
+        // A POST verb, but a pure read-only query with no server-side side effects -- safe to treat as
+        // idempotent for retry purposes (matches the engineering plan's retry matrix, which lists "Search" as
+        // always-retryable regardless of the verb it happens to use).
+        var response = await InvokeAsync(
+            () => BuildJsonRequest(HttpMethod.Post, "entities/search", new SearchEntitiesRequestBody(query, type, limit)),
+            isIdempotent: true,
+            DeserializeAsync<SearchEntitiesResponseBody>,
+            cancellationToken).ConfigureAwait(false);
+        return response.Entities;
+    }
+
+    private async Task<T> InvokeAsync<T>(
+        Func<HttpRequestMessage> requestFactory,
+        bool isIdempotent,
+        Func<Stream, CancellationToken, Task<T>> deserialize,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await _retryPolicy.ExecuteAsync(requestFactory, _httpClient, isIdempotent, cancellationToken)
+                .ConfigureAwait(false);
+            var result = await NamsClientExceptionMapper.MapResponseAsync(response, deserialize, _apiKeyForRedaction, cancellationToken)
+                .ConfigureAwait(false);
+            return result.IsSuccess ? result.Value! : throw NamsClientExceptionMapper.ToException(result);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // caller cancellation -- never wrap
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            throw NamsClientExceptionMapper.FromTransportException(ex, _apiKeyForRedaction);
+        }
+    }
+
+    private static HttpRequestMessage BuildJsonRequest<TBody>(HttpMethod method, string relativePath, TBody body) =>
+        new(method, relativePath) { Content = JsonContent.Create(body, options: JsonOptions) };
+
+    private static async Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken) =>
+        await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new JsonException($"NAMS response deserialized to null for {typeof(T).Name}.");
+
+    // ---- Wire-only request/response envelopes (not part of the public interface's domain shapes) ----
+
+    private sealed record CreateConversationRequestBody(
+        [property: JsonPropertyName("userId")] string? UserId,
+        [property: JsonPropertyName("metadata")] IReadOnlyDictionary<string, string>? Metadata);
+
+    private sealed record AddMessagesBulkRequestBody(
+        [property: JsonPropertyName("messages")] IReadOnlyList<NamsMessageInput> Messages);
+
+    private sealed record AddMessagesBatchResponseBody(
+        [property: JsonPropertyName("messages")] IReadOnlyList<NamsMessage> Messages);
+
+    private sealed record SearchEntitiesRequestBody(
+        [property: JsonPropertyName("query")] string Query,
+        [property: JsonPropertyName("type")] string? Type,
+        [property: JsonPropertyName("limit")] int Limit);
+
+    private sealed record SearchEntitiesResponseBody(
+        [property: JsonPropertyName("entities")] IReadOnlyList<NamsEntity> Entities,
+        [property: JsonPropertyName("searchType")] string? SearchType);
+}

--- a/src/AgentMemory.Nams/Domain/NamsContext.cs
+++ b/src/AgentMemory.Nams/Domain/NamsContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result of <c>GET /v1/conversations/{id}/context</c> -- matches <c>handlers.ContextResponse</c> in the
+/// pinned OpenAPI snapshot. Three tiers: reflections (highest-level), observations (mid-level), recent messages
+/// (raw).</summary>
+internal sealed record NamsContext(
+    [property: JsonPropertyName("reflections")] IReadOnlyList<NamsReflection> Reflections,
+    [property: JsonPropertyName("observations")] IReadOnlyList<NamsObservation> Observations,
+    [property: JsonPropertyName("recentMessages")] IReadOnlyList<NamsMessage> RecentMessages);

--- a/src/AgentMemory.Nams/Domain/NamsConversation.cs
+++ b/src/AgentMemory.Nams/Domain/NamsConversation.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result of <c>POST /v1/conversations</c> -- matches <c>handlers.CreateConversationResponse</c> in the
+/// pinned OpenAPI snapshot (<c>docs/reviews/nams-openapi-snapshot-2026-07-17.json</c>).</summary>
+internal sealed record NamsConversation(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("workspaceId")] string WorkspaceId,
+    [property: JsonPropertyName("userId")] string? UserId,
+    [property: JsonPropertyName("metadata")] IReadOnlyDictionary<string, string>? Metadata);

--- a/src/AgentMemory.Nams/Domain/NamsEntity.cs
+++ b/src/AgentMemory.Nams/Domain/NamsEntity.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result element of <c>POST /v1/entities/search</c> -- matches <c>handlers.Entity</c> in the pinned
+/// OpenAPI snapshot.</summary>
+internal sealed record NamsEntity(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("type")] string? Type,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("confidence")] double? Confidence,
+    [property: JsonPropertyName("score")] double? Score,
+    [property: JsonPropertyName("sourceStage")] string? SourceStage,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt,
+    [property: JsonPropertyName("updatedAt")] string? UpdatedAt);

--- a/src/AgentMemory.Nams/Domain/NamsFailureKind.cs
+++ b/src/AgentMemory.Nams/Domain/NamsFailureKind.cs
@@ -1,0 +1,32 @@
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Coarse classification of a failed NAMS operation, independent of the HTTP status code that produced it.</summary>
+internal enum NamsFailureKind
+{
+    /// <summary>A network-level failure (connection reset, DNS, etc.) with no HTTP response.</summary>
+    Network,
+
+    /// <summary>The request timed out before a response was received.</summary>
+    Timeout,
+
+    /// <summary>The server responded 429 Too Many Requests.</summary>
+    RateLimited,
+
+    /// <summary>The server responded with a 5xx status.</summary>
+    ServerError,
+
+    /// <summary>The server responded 401 Unauthorized (missing/expired/invalid credential).</summary>
+    Authentication,
+
+    /// <summary>The server responded 403 Forbidden (credential valid, operation not permitted).</summary>
+    Authorization,
+
+    /// <summary>The server responded 400/422 or the response body failed to parse into the expected shape.</summary>
+    Validation,
+
+    /// <summary>The server responded 404 Not Found.</summary>
+    NotFound,
+
+    /// <summary>Any other, unclassified failure.</summary>
+    Unknown
+}

--- a/src/AgentMemory.Nams/Domain/NamsMessage.cs
+++ b/src/AgentMemory.Nams/Domain/NamsMessage.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>A message as returned by NAMS -- covers both <c>handlers.Message</c> (context's <c>recentMessages</c>,
+/// which carries a relevance <see cref="Score"/> and <see cref="TokenCount"/> but no conversation id) and
+/// <c>handlers.AddMessageResponse</c> (the bulk-add result, which carries <see cref="ConversationId"/> but neither
+/// of those). One shape covers both rather than two near-duplicate records.</summary>
+internal sealed record NamsMessage(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("role")] string Role,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt,
+    [property: JsonPropertyName("conversationId")] string? ConversationId,
+    [property: JsonPropertyName("score")] double? Score,
+    [property: JsonPropertyName("tokenCount")] int? TokenCount);

--- a/src/AgentMemory.Nams/Domain/NamsMessageInput.cs
+++ b/src/AgentMemory.Nams/Domain/NamsMessageInput.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>A message to submit via <c>POST /v1/conversations/{id}/messages/bulk</c> -- matches
+/// <c>handlers.addMessageRequest</c> in the pinned OpenAPI snapshot. Doubles as the wire shape serialized into the
+/// bulk request (its wire shape is identical to the caller-facing domain input).</summary>
+internal sealed record NamsMessageInput(
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("role")] string Role);

--- a/src/AgentMemory.Nams/Domain/NamsObservation.cs
+++ b/src/AgentMemory.Nams/Domain/NamsObservation.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Mid-level context summary -- matches <c>handlers.Observation</c> in the pinned OpenAPI snapshot.</summary>
+internal sealed record NamsObservation(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("conversationId")] string? ConversationId,
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt,
+    [property: JsonPropertyName("sourceMsgIds")] IReadOnlyList<string>? SourceMessageIds);

--- a/src/AgentMemory.Nams/Domain/NamsOperationException.cs
+++ b/src/AgentMemory.Nams/Domain/NamsOperationException.cs
@@ -1,0 +1,22 @@
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// Thrown when a NAMS REST operation fails. Deliberately does not derive from
+/// <c>AgentMemory.Abstractions.Exceptions.MemoryException</c> -- <c>AgentMemory.Nams</c> has zero sibling-package
+/// references by design (see <c>docs/architecture.md</c> §5, rule B9).
+/// </summary>
+internal sealed class NamsOperationException : Exception
+{
+    public NamsFailureKind FailureKind { get; }
+
+    /// <summary>The HTTP status code that produced this failure, if the failure originated from a response
+    /// (as opposed to a network-level exception).</summary>
+    public int? StatusCode { get; }
+
+    public NamsOperationException(NamsFailureKind failureKind, string message, int? statusCode = null, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        FailureKind = failureKind;
+        StatusCode = statusCode;
+    }
+}

--- a/src/AgentMemory.Nams/Domain/NamsOperationResult.cs
+++ b/src/AgentMemory.Nams/Domain/NamsOperationResult.cs
@@ -1,0 +1,29 @@
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// A pure success/failure envelope produced by <see cref="Client.NamsClientExceptionMapper"/>. Keeps response
+/// mapping testable independently of the "throw on failure" behavior <c>Neo4jNamsClientAdapter</c> applies on top.
+/// </summary>
+internal readonly struct NamsOperationResult<T>
+{
+    public bool IsSuccess { get; }
+    public T? Value { get; }
+    public NamsFailureKind FailureKind { get; }
+    public string? FailureMessage { get; }
+    public int? StatusCode { get; }
+
+    private NamsOperationResult(bool isSuccess, T? value, NamsFailureKind failureKind, string? failureMessage, int? statusCode)
+    {
+        IsSuccess = isSuccess;
+        Value = value;
+        FailureKind = failureKind;
+        FailureMessage = failureMessage;
+        StatusCode = statusCode;
+    }
+
+    public static NamsOperationResult<T> Success(T value) =>
+        new(isSuccess: true, value, failureKind: default, failureMessage: null, statusCode: null);
+
+    public static NamsOperationResult<T> Failure(NamsFailureKind failureKind, string failureMessage, int? statusCode = null) =>
+        new(isSuccess: false, value: default, failureKind, failureMessage, statusCode);
+}

--- a/src/AgentMemory.Nams/Domain/NamsReflection.cs
+++ b/src/AgentMemory.Nams/Domain/NamsReflection.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Highest-level compressed insight -- matches <c>handlers.Reflection</c> in the pinned OpenAPI snapshot.</summary>
+internal sealed record NamsReflection(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("conversationId")] string? ConversationId,
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt,
+    [property: JsonPropertyName("sourceObsIds")] IReadOnlyList<string>? SourceObservationIds,
+    [property: JsonPropertyName("supersededById")] string? SupersededById);

--- a/src/AgentMemory.Nams/Internal/NamsOptionValidator.cs
+++ b/src/AgentMemory.Nams/Internal/NamsOptionValidator.cs
@@ -43,4 +43,12 @@ internal static class NamsOptionValidator
     public static bool HasNonNegativeMaxRetryAttempts(NamsOptions options) => options.MaxRetryAttempts >= 0;
 
     public static bool HasNonNegativeInitialRetryDelay(NamsOptions options) => options.InitialRetryDelay >= TimeSpan.Zero;
+
+    /// <summary>
+    /// True when <see cref="NamsOptions.ApiKey"/> is set. The only authentication mechanism this phase's client
+    /// implements is a static API key -- JWT/Auth0 support is deferred (its refresh/expiry contract is
+    /// unconfirmed; see <c>strategy/NAMS/Neo4j_Questions.md</c> #30) -- so a registration with no credential at
+    /// all can never successfully authenticate a request.
+    /// </summary>
+    public static bool HasApiKey(NamsOptions options) => !string.IsNullOrWhiteSpace(options.ApiKey);
 }

--- a/src/AgentMemory.Nams/NamsServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Nams/NamsServiceCollectionExtensions.cs
@@ -1,19 +1,24 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams.Authentication;
+using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Internal;
 
 namespace AgentMemory.Nams;
 
 /// <summary>
-/// DI registration for the additive NAMS backend skeleton. Registers only <see cref="NamsOptions"/>
-/// (configured, validated, <c>ValidateOnStart</c>) and a <see cref="NamsBackendDescriptor"/> singleton --
-/// nothing else exists yet in this phase (no client, no recall/persistence). Calling this method is the
-/// ONLY way anything NAMS-related gets registered; no other package in this repository references
-/// <c>AgentMemory.Nams</c>, so an application that never calls this method is completely unaffected.
+/// DI registration for the NAMS backend. Registers <see cref="NamsOptions"/> (configured, validated,
+/// <c>ValidateOnStart</c>), a <see cref="NamsBackendDescriptor"/> singleton, and (as of Phase 2) the
+/// low-level REST client (<see cref="INamsClient"/>) plus its credential provider and authentication
+/// handler -- no recall/persistence integration into the memory pipeline yet (that's Phases 3+). Calling
+/// this method is the ONLY way anything NAMS-related gets registered; no other package in this repository
+/// references <c>AgentMemory.Nams</c>, so an application that never calls this method is completely
+/// unaffected.
 /// </summary>
 public static class NamsServiceCollectionExtensions
 {
-    /// <summary>Registers the NAMS backend's configuration surface.</summary>
+    /// <summary>Registers the NAMS backend's configuration surface and low-level REST client.</summary>
     public static IServiceCollection AddNamsAgentMemory(
         this IServiceCollection services, Action<NamsOptions> configure)
     {
@@ -30,12 +35,22 @@ public static class NamsServiceCollectionExtensions
             .Validate(NamsOptionValidator.HasPositiveRequestTimeout, "NamsOptions.RequestTimeout must be positive.")
             .Validate(NamsOptionValidator.HasNonNegativeMaxRetryAttempts, "NamsOptions.MaxRetryAttempts must be non-negative.")
             .Validate(NamsOptionValidator.HasNonNegativeInitialRetryDelay, "NamsOptions.InitialRetryDelay must be non-negative.")
+            .Validate(NamsOptionValidator.HasApiKey, "NamsOptions.ApiKey must be provided (JWT/Auth0 authentication is not yet supported).")
             .ValidateOnStart();
 
         // Idempotent by construction: TryAddSingleton means a second AddNamsAgentMemory call is a
         // harmless no-op for this registration (the options registration above is likewise safe to call
         // more than once -- each call just adds another equivalent configure/validate step).
         services.TryAddSingleton<NamsBackendDescriptor>();
+
+        services.TryAddSingleton<INamsAccessTokenProvider, StaticApiKeyNamsAccessTokenProvider>();
+        services.TryAddTransient<NamsAuthenticationHandler>();
+        services.AddHttpClient<INamsClient, Neo4jNamsClientAdapter>((serviceProvider, httpClient) =>
+            {
+                var options = serviceProvider.GetRequiredService<IOptions<NamsOptions>>().Value;
+                NamsClientFactory.ConfigureHttpClient(httpClient, options);
+            })
+            .AddHttpMessageHandler<NamsAuthenticationHandler>();
 
         return services;
     }

--- a/tests/AgentMemory.Tests.Unit/Nams/FakeHttpMessageHandler.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/FakeHttpMessageHandler.cs
@@ -1,0 +1,29 @@
+namespace AgentMemory.Tests.Unit.Nams;
+
+/// <summary>A deterministic, network-free <see cref="HttpMessageHandler"/> for NAMS client tests -- every test in
+/// this folder uses this instead of a real network call.</summary>
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, int, Task<HttpResponseMessage>> _responder;
+    public List<HttpRequestMessage> Requests { get; } = [];
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, int, Task<HttpResponseMessage>> responder)
+    {
+        _responder = responder;
+    }
+
+    /// <summary>Convenience constructor for a fixed sequence of responses, one per call (the last is reused for
+    /// any call beyond the sequence's length).</summary>
+    public FakeHttpMessageHandler(params Func<HttpResponseMessage>[] responses)
+        : this((_, callIndex) => Task.FromResult(responses[Math.Min(callIndex, responses.Length - 1)]()))
+    {
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var callIndex = Requests.Count;
+        Requests.Add(request);
+        return await _responder(request, callIndex).ConfigureAwait(false);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsAuthenticationHandlerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsAuthenticationHandlerTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using AgentMemory.Nams.Authentication;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsAuthenticationHandlerTests
+{
+    private sealed class FakeTokenProvider : INamsAccessTokenProvider
+    {
+        private int _generation;
+        public List<string> InvalidatedFingerprints { get; } = [];
+
+        public ValueTask<NamsAccessToken> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new NamsAccessToken($"token-{_generation}"));
+
+        public ValueTask InvalidateAsync(string rejectedTokenFingerprint, CancellationToken cancellationToken = default)
+        {
+            InvalidatedFingerprints.Add(rejectedTokenFingerprint);
+            _generation++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static HttpClient CreateClient(FakeHttpMessageHandler fake, FakeTokenProvider tokenProvider)
+    {
+        var authHandler = new NamsAuthenticationHandler(tokenProvider) { InnerHandler = fake };
+        return new HttpClient(authHandler) { BaseAddress = new Uri("https://nams.test/") };
+    }
+
+    [Fact]
+    public async Task AttachesBearerTokenFromProvider()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));
+        var tokenProvider = new FakeTokenProvider();
+        using var client = CreateClient(fake, tokenProvider);
+
+        await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "x"));
+
+        fake.Requests.Single().Headers.Authorization.Should().BeEquivalentTo(new AuthenticationHeaderValue("Bearer", "token-0"));
+    }
+
+    [Fact]
+    public async Task On401_InvalidatesAndRetriesOnceWithFreshToken()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            () => new HttpResponseMessage(HttpStatusCode.OK));
+        var tokenProvider = new FakeTokenProvider();
+        using var client = CreateClient(fake, tokenProvider);
+
+        using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "x"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fake.Requests.Should().HaveCount(2);
+        fake.Requests[0].Headers.Authorization!.Parameter.Should().Be("token-0");
+        fake.Requests[1].Headers.Authorization!.Parameter.Should().Be("token-1");
+        tokenProvider.InvalidatedFingerprints.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task On401Twice_StopsAfterOneRetry_ReturnsSecondFailure()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        var tokenProvider = new FakeTokenProvider();
+        using var client = CreateClient(fake, tokenProvider);
+
+        using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "x"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        fake.Requests.Should().HaveCount(2); // one attempt + exactly one bounded retry, never loops
+    }
+
+    [Fact]
+    public async Task On403_DoesNotInvalidateOrRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.Forbidden));
+        var tokenProvider = new FakeTokenProvider();
+        using var client = CreateClient(fake, tokenProvider);
+
+        using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "x"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        fake.Requests.Should().HaveCount(1);
+        tokenProvider.InvalidatedFingerprints.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task On401ForWriteWithBody_RetriesWithSameBody()
+    {
+        // Safe even for a write: a 401 means the server never authenticated the caller, so it never executed
+        // the operation the first time.
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            () => new HttpResponseMessage(HttpStatusCode.Created));
+        var tokenProvider = new FakeTokenProvider();
+        using var client = CreateClient(fake, tokenProvider);
+
+        using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "x")
+        {
+            Content = new StringContent("{\"content\":\"hello\"}")
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        fake.Requests.Should().HaveCount(2);
+        var secondBody = await fake.Requests[1].Content!.ReadAsStringAsync();
+        secondBody.Should().Be("{\"content\":\"hello\"}");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsClientExceptionMapperTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsClientExceptionMapperTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsClientExceptionMapperTests
+{
+    private static Task<int> DeserializeInt(Stream stream, CancellationToken cancellationToken) =>
+        System.Text.Json.JsonSerializer.DeserializeAsync<int>(stream, cancellationToken: cancellationToken).AsTask();
+
+    [Fact]
+    public async Task MapResponseAsync_Success_ReturnsDeserializedValue()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("42") };
+
+        var result = await NamsClientExceptionMapper.MapResponseAsync(response, DeserializeInt, secretToRedact: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(42);
+    }
+
+    // InlineData values must be public/constant-friendly types -- NamsFailureKind is internal, so the expected
+    // kind is passed by name and parsed inside the (necessarily public) theory method.
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, nameof(NamsFailureKind.Validation))]
+    [InlineData(HttpStatusCode.UnprocessableEntity, nameof(NamsFailureKind.Validation))]
+    [InlineData(HttpStatusCode.Unauthorized, nameof(NamsFailureKind.Authentication))]
+    [InlineData(HttpStatusCode.Forbidden, nameof(NamsFailureKind.Authorization))]
+    [InlineData(HttpStatusCode.NotFound, nameof(NamsFailureKind.NotFound))]
+    [InlineData(HttpStatusCode.TooManyRequests, nameof(NamsFailureKind.RateLimited))]
+    [InlineData(HttpStatusCode.InternalServerError, nameof(NamsFailureKind.ServerError))]
+    [InlineData(HttpStatusCode.BadGateway, nameof(NamsFailureKind.ServerError))]
+    public async Task MapResponseAsync_ErrorStatusCode_ClassifiesFailureKind(HttpStatusCode statusCode, string expectedKindName)
+    {
+        var expectedKind = Enum.Parse<NamsFailureKind>(expectedKindName);
+        using var response = new HttpResponseMessage(statusCode) { Content = new StringContent("{\"error\":\"nope\"}") };
+
+        var result = await NamsClientExceptionMapper.MapResponseAsync(response, DeserializeInt, secretToRedact: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(expectedKind);
+        result.StatusCode.Should().Be((int)statusCode);
+    }
+
+    [Fact]
+    public async Task MapResponseAsync_MalformedJson_ReturnsValidationFailure_DoesNotThrow()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{not valid json") };
+
+        var result = await NamsClientExceptionMapper.MapResponseAsync(response, DeserializeInt, secretToRedact: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(NamsFailureKind.Validation);
+    }
+
+    [Fact]
+    public async Task MapResponseAsync_ErrorBodyContainsApiKey_RedactsIt()
+    {
+        const string secretApiKey = "nams_super_secret_12345";
+        using var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent($"{{\"error\":\"failed for key {secretApiKey}\"}}")
+        };
+
+        var result = await NamsClientExceptionMapper.MapResponseAsync(response, DeserializeInt, secretApiKey, CancellationToken.None);
+
+        result.FailureMessage.Should().NotContain(secretApiKey);
+        result.FailureMessage.Should().Contain("[REDACTED]");
+    }
+
+    [Fact]
+    public void FromTransportException_HttpRequestException_MapsToNetwork()
+    {
+        var exception = NamsClientExceptionMapper.FromTransportException(new HttpRequestException("boom"), secretToRedact: null);
+
+        exception.FailureKind.Should().Be(NamsFailureKind.Network);
+    }
+
+    [Fact]
+    public void FromTransportException_TaskCanceledException_MapsToTimeout()
+    {
+        var exception = NamsClientExceptionMapper.FromTransportException(new TaskCanceledException(), secretToRedact: null);
+
+        exception.FailureKind.Should().Be(NamsFailureKind.Timeout);
+    }
+
+    [Fact]
+    public void FromTransportException_RedactsApiKeyFromMessage()
+    {
+        const string secretApiKey = "nams_super_secret_12345";
+        var exception = NamsClientExceptionMapper.FromTransportException(
+            new HttpRequestException($"connection to host with key {secretApiKey} failed"), secretApiKey);
+
+        exception.Message.Should().NotContain(secretApiKey);
+    }
+
+    [Fact]
+    public async Task ToException_BuildsExceptionWithFailureKindAndStatusCode()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{}") };
+        var result = await NamsClientExceptionMapper.MapResponseAsync(response, DeserializeInt, secretToRedact: null, CancellationToken.None);
+
+        var exception = NamsClientExceptionMapper.ToException(result);
+
+        exception.FailureKind.Should().Be(NamsFailureKind.NotFound);
+        exception.StatusCode.Should().Be(404);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsClientFactoryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsClientFactoryTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsClientFactoryTests
+{
+    [Fact]
+    public void NormalizeBaseAddress_NoTrailingSlash_AddsOne()
+    {
+        var normalized = NamsClientFactory.NormalizeBaseAddress(new Uri("https://memory.neo4jlabs.com/v1"));
+
+        normalized.OriginalString.Should().Be("https://memory.neo4jlabs.com/v1/");
+    }
+
+    [Fact]
+    public void NormalizeBaseAddress_AlreadyHasTrailingSlash_Unchanged()
+    {
+        var endpoint = new Uri("https://memory.neo4jlabs.com/v1/");
+
+        var normalized = NamsClientFactory.NormalizeBaseAddress(endpoint);
+
+        normalized.Should().Be(endpoint);
+    }
+
+    [Fact]
+    public void NormalizeBaseAddress_CombinedWithRelativePath_PreservesVersionSegment()
+    {
+        // This is the actual bug the normalization guards against: a base URI without a trailing '/' drops its
+        // last path segment when combined with a relative Uri.
+        var normalized = NamsClientFactory.NormalizeBaseAddress(new Uri("https://memory.neo4jlabs.com/v1"));
+
+        var combined = new Uri(normalized, "conversations");
+
+        combined.Should().Be(new Uri("https://memory.neo4jlabs.com/v1/conversations"));
+    }
+
+    [Fact]
+    public void ConfigureHttpClient_SetsBaseAddressAndTimeout()
+    {
+        using var client = new HttpClient();
+        var options = new NamsOptions
+        {
+            Endpoint = new Uri("https://memory.neo4jlabs.com/v1"),
+            ApiKey = "nams_key",
+            RequestTimeout = TimeSpan.FromSeconds(7)
+        };
+
+        NamsClientFactory.ConfigureHttpClient(client, options);
+
+        client.BaseAddress.Should().Be(new Uri("https://memory.neo4jlabs.com/v1/"));
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(7));
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using FluentAssertions;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsRetryPolicyTests
+{
+    private static readonly Uri BaseAddress = new("https://nams.test/");
+
+    private static NamsRetryPolicy CreatePolicy(int maxAttempts = 3) =>
+        new(maxAttempts, TimeSpan.FromMilliseconds(1));
+
+    [Fact]
+    public async Task Idempotent_TransientServerErrorThenSuccess_Retries()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Idempotent_RetryExhaustion_ReturnsFinalFailureResponse()
+    {
+        var fake = new FakeHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy(maxAttempts: 2).ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        fake.Requests.Should().HaveCount(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task Idempotent_RateLimitedWithRetryAfterHeader_RetriesThenSucceeds()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.Zero);
+                return response;
+            },
+            () => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Idempotent_RateLimitedWithRetryAfterDateForm_RetriesThenSucceeds()
+    {
+        // Retry-After has two legal forms (RFC 9110 §10.2.3): delta-seconds or an absolute HTTP-date.
+        // RetryConditionHeaderValue exposes these as mutually-exclusive Delta/Date properties -- this covers
+        // the Date form, which reading only .Delta would silently ignore in favor of exponential backoff.
+        var fake = new FakeHttpMessageHandler(
+            () =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(DateTimeOffset.UtcNow);
+                return response;
+            },
+            () => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Idempotent_PermanentFailure_DoesNotRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        fake.Requests.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task NonIdempotent_TransientServerError_NeverRetries()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Post, "x"), client, isIdempotent: false, CancellationToken.None);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        fake.Requests.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_PropagatesWithoutRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Idempotent_NetworkExceptionExhaustsRetries_Throws()
+    {
+        var fake = new FakeHttpMessageHandler((_, _) => throw new HttpRequestException("boom"));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+
+        var act = () => CreatePolicy(maxAttempts: 2).ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        fake.Requests.Should().HaveCount(3); // initial attempt + 2 retries
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsServiceCollectionExtensionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsServiceCollectionExtensionsTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Nams;
+using AgentMemory.Nams.Authentication;
+using AgentMemory.Nams.Client;
 
 namespace AgentMemory.Tests.Unit.Nams;
 
@@ -30,7 +32,11 @@ public sealed class NamsServiceCollectionExtensionsTests
     public void AddNamsAgentMemory_ValidConfig_PassesValidation()
     {
         var services = new ServiceCollection();
-        services.AddNamsAgentMemory(o => o.Endpoint = ValidEndpoint);
+        services.AddNamsAgentMemory(o =>
+        {
+            o.Endpoint = ValidEndpoint;
+            o.ApiKey = "nams_key";
+        });
         using var provider = services.BuildServiceProvider();
 
         var act = () => _ = provider.GetRequiredService<IOptions<NamsOptions>>().Value;
@@ -45,6 +51,18 @@ public sealed class NamsServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddNamsAgentMemory(o => o.ApiKey = "nams_key");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => _ = provider.GetRequiredService<IOptions<NamsOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void AddNamsAgentMemory_MissingApiKey_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddNamsAgentMemory(o => o.Endpoint = ValidEndpoint);
         using var provider = services.BuildServiceProvider();
 
         var act = () => _ = provider.GetRequiredService<IOptions<NamsOptions>>().Value;
@@ -89,6 +107,7 @@ public sealed class NamsServiceCollectionExtensionsTests
         {
             o.Endpoint = new Uri("http://localhost:8080/v1");
             o.AllowInsecureEndpointForLocalDevelopment = true;
+            o.ApiKey = "nams_key";
         });
         using var provider = services.BuildServiceProvider();
 
@@ -160,6 +179,9 @@ public sealed class NamsServiceCollectionExtensionsTests
         // NamsBackendDescriptor -- both resolutions from the same provider return the one singleton.
         provider.GetRequiredService<NamsBackendDescriptor>()
             .Should().BeSameAs(provider.GetRequiredService<NamsBackendDescriptor>());
+        // Also proves the second AddHttpClient<INamsClient,...> call doesn't leave a conflicting/broken
+        // registration -- not just that BuildServiceProvider() didn't throw.
+        provider.GetRequiredService<INamsClient>().Should().NotBeNull();
     }
 
     [Fact]
@@ -217,5 +239,49 @@ public sealed class NamsServiceCollectionExtensionsTests
             failure.Should().NotContain(secretApiKey);
             failure.Should().NotContain(secretWorkspace);
         }
+    }
+
+    // ── Phase 2: low-level client adapter DI wiring ──────────────────────────
+
+    [Fact]
+    public void AddNamsAgentMemory_ResolvesINamsClient_WiredToConfiguredEndpoint()
+    {
+        var services = new ServiceCollection();
+        services.AddNamsAgentMemory(o =>
+        {
+            o.Endpoint = ValidEndpoint;
+            o.ApiKey = "nams_key";
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<INamsClient>();
+
+        client.Should().BeOfType<Neo4jNamsClientAdapter>();
+    }
+
+    [Fact]
+    public void AddNamsAgentMemory_ResolvesSingleStaticApiKeyTokenProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddNamsAgentMemory(o =>
+        {
+            o.Endpoint = ValidEndpoint;
+            o.ApiKey = "nams_key";
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var tokenProvider = provider.GetRequiredService<INamsAccessTokenProvider>();
+
+        tokenProvider.Should().BeOfType<StaticApiKeyNamsAccessTokenProvider>();
+        provider.GetRequiredService<INamsAccessTokenProvider>().Should().BeSameAs(tokenProvider);
+    }
+
+    [Fact]
+    public void AddNamsAgentMemory_DoesNotRegisterINamsClient_WithoutOptIn()
+    {
+        var services = new ServiceCollection();
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<INamsClient>().Should().BeNull();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -1,0 +1,174 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class Neo4jNamsClientAdapterTests
+{
+    private static Neo4jNamsClientAdapter CreateAdapter(FakeHttpMessageHandler fake, string? apiKey = "nams_key")
+    {
+        var httpClient = new HttpClient(fake) { BaseAddress = new Uri("https://nams.test/v1/") };
+        var options = Options.Create(new NamsOptions
+        {
+            Endpoint = new Uri("https://nams.test/v1/"),
+            ApiKey = apiKey,
+            MaxRetryAttempts = 2,
+            InitialRetryDelay = TimeSpan.FromMilliseconds(1)
+        });
+        return new Neo4jNamsClientAdapter(httpClient, options, NullLogger<Neo4jNamsClientAdapter>.Instance);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode statusCode, string json) =>
+        new(statusCode) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    [Fact]
+    public async Task CreateConversationAsync_Success_DeserializesConversation()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created,
+            """{"id":"conv-1","workspaceId":"ws-1","userId":"user-1","metadata":{"title":"hi"}}"""));
+        var adapter = CreateAdapter(fake);
+
+        var conversation = await adapter.CreateConversationAsync("user-1", null, CancellationToken.None);
+
+        conversation.Id.Should().Be("conv-1");
+        conversation.WorkspaceId.Should().Be("ws-1");
+        conversation.UserId.Should().Be("user-1");
+        conversation.Metadata!["title"].Should().Be("hi");
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/conversations"));
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_ServerError_DoesNotRetry_ThrowsMappedException()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.CreateConversationAsync("user-1", null, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.FailureKind.Should().Be(NamsFailureKind.ServerError);
+        fake.Requests.Should().HaveCount(1); // write -- no idempotency key mechanism yet, so no retry
+    }
+
+    [Fact]
+    public async Task GetContextAsync_Success_DeserializesAllThreeTiers()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {
+              "reflections": [{"id":"r1","content":"insight","sourceObsIds":["o1"]}],
+              "observations": [{"id":"o1","content":"summary","sourceMsgIds":["m1"]}],
+              "recentMessages": [{"id":"m1","content":"hello","role":"user","score":0.9,"tokenCount":2}]
+            }
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var context = await adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        context.Reflections.Single().Content.Should().Be("insight");
+        context.Observations.Single().SourceMessageIds.Should().ContainSingle("o1");
+        context.RecentMessages.Single().Score.Should().Be(0.9);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/conversations/conv-1/context"));
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Get);
+    }
+
+    [Fact]
+    public async Task GetContextAsync_TransientFailureThenSuccess_Retries()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => Json(HttpStatusCode.OK, """{"reflections":[],"observations":[],"recentMessages":[]}"""));
+        var adapter = CreateAdapter(fake);
+
+        var context = await adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        context.RecentMessages.Should().BeEmpty();
+        fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddMessagesAsync_Success_ReturnsMessagesWithIds()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"messages":[{"id":"m1","conversationId":"conv-1","content":"hello","role":"user"}]}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var messages = await adapter.AddMessagesAsync(
+            "conv-1", [new NamsMessageInput("hello", "user")], CancellationToken.None);
+
+        messages.Single().Id.Should().Be("m1");
+        messages.Single().ConversationId.Should().Be("conv-1");
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        requestBody.Should().Contain("\"content\":\"hello\"");
+    }
+
+    [Fact]
+    public async Task AddMessagesAsync_ServerError_DoesNotRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.AddMessagesAsync("conv-1", [new NamsMessageInput("hello", "user")], CancellationToken.None);
+
+        await act.Should().ThrowAsync<NamsOperationException>();
+        fake.Requests.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SearchEntitiesAsync_Success_UsesRetryDespitePostVerb()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => Json(HttpStatusCode.OK, """{"entities":[{"id":"e1","name":"Acme"}],"searchType":"vector"}"""));
+        var adapter = CreateAdapter(fake);
+
+        var entities = await adapter.SearchEntitiesAsync("acme", null, 10, CancellationToken.None);
+
+        entities.Single().Name.Should().Be("Acme");
+        fake.Requests.Should().HaveCount(2); // search is a read despite the POST verb -- retries like other reads
+    }
+
+    [Fact]
+    public async Task AnyOperation_CallerCancellation_PropagatesOperationCanceledException()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));
+        var adapter = CreateAdapter(fake);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => adapter.GetContextAsync("conv-1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ServerError_RedactsApiKeyFromExceptionMessage()
+    {
+        const string apiKey = "nams_super_secret_12345";
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.InternalServerError, $$"""{"error":"bad key {{apiKey}}"}"""));
+        var adapter = CreateAdapter(fake, apiKey);
+
+        var act = () => adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.Message.Should().NotContain(apiKey);
+    }
+
+    [Fact]
+    public async Task NetworkFailure_MapsToNetworkFailureKind()
+    {
+        var fake = new FakeHttpMessageHandler((_, _) => throw new HttpRequestException("connection refused"));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.FailureKind.Should().Be(NamsFailureKind.Network);
+    }
+}


### PR DESCRIPTION
## Summary

Continues the NAMS backend effort after Phase 0 (baseline freeze, #129) and Phase 1 (package skeleton, #130). Executes "Phase 2: Low-level client adapter and error model" from the NAMS engineering plan (now on `V04` after a drift analysis vs the `V03` this branch's predecessors were built against — no retroactive changes needed, see `strategy/NAMS/NAMS_V04_Alignment_Plan.md`, gitignored).

- `INamsClient` + `Neo4jNamsClientAdapter`: a self-contained `HttpClient`-based implementation calling the NAMS REST API directly. Deliberately does **not** depend on the external `Neo4j.AgentMemory` TCK client — its stability/publication status is unconfirmed (Neo4j hasn't answered issue #128 yet), and NAMS is a free, self-serve, publicly documented REST API, so there's no technical reason to wait on that confirmation for this phase.
- Typed error model: `NamsFailureKind` / `NamsOperationException` / `NamsOperationResult<T>`, mapped from HTTP status codes via `NamsClientExceptionMapper`.
- `NamsRetryPolicy`: idempotent reads (`GetContextAsync`, `SearchEntitiesAsync`) retry transient failures (network/timeout/429/5xx) with backoff, honoring `Retry-After` in both its delta-seconds and HTTP-date forms; non-idempotent writes (`CreateConversationAsync`, `AddMessagesAsync`) make a single attempt, since NAMS's idempotency semantics are still unconfirmed.
- `INamsAccessTokenProvider` credential-lifecycle abstraction, API-key-only for this phase (JWT/Auth0 deferred — its refresh contract is unconfirmed); `NamsAuthenticationHandler` retries exactly once after a 401 (safe even for writes, since a 401 means the operation never executed), never retries a 403.
- `SearchMessagesAsync` intentionally dropped from the interface — the plan's own text flags it as an unconfirmed REST mapping; adding it needs a live sandbox check first.

Self-reviewed via 3 parallel finder agents (correctness / cross-file impact / cleanup-conventions). Fixed: a `Retry-After` date-form gap, two stale doc references (`docs/architecture.md`/`docs/specification.md` still described the Phase 1 config-only state), and two minor cleanup items. Full write-up: `docs/reviews/NAMS_Phase2_LowLevelClientAdapter_PlanningAndImplementationPlan.md`.

## Test plan

- [x] 46 new unit tests under `tests/AgentMemory.Tests.Unit/Nams/` (retry policy, exception mapper, auth handler, client factory, client adapter, DI wiring) — all against a deterministic fake HTTP handler, no live network.
- [x] Full unit suite green: 3107 tests.
- [x] Full Semantic Kernel unit suite green: 54 tests.
- [x] Full Release build: 0 warnings, all target frameworks (net8.0/9.0/10.0).
- [x] `PackageBoundaryGuardTests` B9 rule for `AgentMemory.Nams` still passes (no forbidden references introduced — only `Microsoft.Extensions.Http`/`Logging.Abstractions`, matching `AgentMemory.Enrichment`'s existing pattern).
- [x] `dotnet pack` for the package still succeeds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)