### PR TITLE
NAMS Phase 11: NamsAgent sample (AgentMemory.Sample.NamsAgent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           dotnet build samples/AgentMemory.Sample.BlendedAgent/AgentMemory.Sample.BlendedAgent.csproj -c Release --no-restore
           dotnet build samples/AgentMemory.Sample.McpHost/AgentMemory.Sample.McpHost.csproj -c Release --no-restore
           dotnet build samples/AgentMemory.Sample.ShoppingAssistant/AgentMemory.Sample.ShoppingAssistant.csproj -c Release --no-restore
+          dotnet build samples/AgentMemory.Sample.NamsAgent/AgentMemory.Sample.NamsAgent.csproj -c Release --no-restore
           dotnet build samples/AspireDemo/AspireDemo.AppHost/AspireDemo.AppHost.csproj -c Release --no-restore
           dotnet build samples/AspireDemo/AspireDemo.DemoApp/AspireDemo.DemoApp.csproj -c Release --no-restore
 

--- a/AgentMemory.slnx
+++ b/AgentMemory.slnx
@@ -9,6 +9,7 @@
     <Project Path="samples/AgentMemory.Sample.MinimalAgent/AgentMemory.Sample.MinimalAgent.csproj" />
     <Project Path="samples/AgentMemory.Sample.RealAgent/AgentMemory.Sample.RealAgent.csproj" />
     <Project Path="samples/AgentMemory.Sample.McpHost/AgentMemory.Sample.McpHost.csproj" />
+    <Project Path="samples/AgentMemory.Sample.NamsAgent/AgentMemory.Sample.NamsAgent.csproj" />
     <Project Path="samples/AgentMemory.Sample.ShoppingAssistant/AgentMemory.Sample.ShoppingAssistant.csproj" />
     <Project Path="samples/AgentMemory.Samples.Shared/AgentMemory.Samples.Shared.csproj" />
   </Folder>

--- a/docs/reviews/NAMS_Phase11_Sample_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase11_Sample_PlanningAndImplementationPlan.md
@@ -1,0 +1,79 @@
+# NAMS Phase 11 — Sample — Planning and Implementation Plan
+
+**Prepared:** 2026-07-17
+**Branch:** `nams/phase11-sample-nams-agent`
+**Purpose:** Executes engineering plan Phase 11 ("Sample and documentation"), scoped to **NAMS only** per
+explicit user direction — the plan's own "backend-switching sample" (`AGENTMEMORY_BACKEND=neo4j|nams`) is
+deliberately not built here; nothing in the plan makes the sample depend on that.
+
+## 1. What this is
+
+`samples/AgentMemory.Sample.NamsAgent` — the NAMS-backed sibling of the flagship `AgentWithMemory` sample,
+demonstrating the complete Phase 4-6 pipeline end to end, live, against the real NAMS SaaS:
+
+1. A `ChatClientAgent` with `NamsMemoryContextProvider` (an `AIContextProvider`).
+2. A multi-turn session — each turn persisted to NAMS automatically.
+3. Session serialize/restore.
+4. Durable cross-session recall — a brand-new session for the same user/application still sees prior memory.
+5. Sanitized recall diagnostics via the shared `MemoryTraceChatClient` (reused unmodified — NAMS's memory
+   blocks use the same `RecalledMemoryDelimiter` format the direct provider uses).
+
+**Deliberately not included** (per the plan's own phase list, not yet built): MCP tool exposure (Phase 8),
+backend-switching (out of scope per this session's explicit direction).
+
+## 2. Design decisions
+
+- **No local embedding generator, schema bootstrapper, or memory tools.** NAMS performs
+  extraction/embedding/reflection server-side — none of that exists on the client side for this backend.
+- **No `.WithMemoryOwnerScoping(sp)`.** That wrapper exists specifically to keep an ambient `AsyncLocal`
+  owner context alive across a *local* tool-calling loop (#90) — `NamsMemoryContextProvider` reads identity
+  directly off the session state bag with no ambient context and no local tools, so it's unnecessary here.
+- **`AddAgentMemoryFramework()` is still required** (Phase 6's own documented precondition for
+  `AddNamsAgentMemoryFramework()`), even though it also registers `Neo4jMemoryContextProvider` and friends
+  that this sample never resolves. Verified this is harmless: those are `TryAddScoped` registrations, never
+  eagerly resolved, and the Generic Host's default `ValidateOnBuild` is off outside `Development` — confirmed
+  by actually running the sample (see §4), not just reasoning about it.
+- **The NAMS base URL is hardcoded to `NamsWellKnown.Endpoint`**, not an environment variable. NAMS's own
+  ecosystem convention (`NAMS_BASE_URL`, seen in the dashboard's own plugin instructions) excludes the `/v1`
+  API-version suffix our client requires on `NamsOptions.Endpoint` — reusing that exact name with a
+  different required shape would be a trap for anyone following NAMS's own docs. An advanced user who needs
+  a different endpoint edits `Program.cs` directly.
+
+## 3. Wiring into the build
+
+- `AgentMemory.slnx` — added the new project under `/samples/`.
+- `.github/workflows/ci.yml`'s "Sample smoke builds" step — added an explicit `dotnet build` line (this
+  step is a hardcoded list per sample, not a glob — matches every existing sample's own entry).
+- `samples/samples.sln` — deliberately **not** touched: it's missing 6+ of the existing samples already and
+  isn't referenced anywhere in CI, so it's stale/unmaintained, not a real manifest.
+- Not added to `eng/release-packages.txt` — samples aren't NuGet packages.
+
+## 4. Verification — actually run live, not just built
+
+Ran the sample twice against the real NAMS SaaS (`agent-memory-dotnet-dev` workspace) and real Azure OpenAI,
+confirming:
+
+- Conversation creation, message persistence (`POST .../messages/bulk`), and recall
+  (`GET .../context` + `POST .../entities/search`) all round-trip correctly — real HTTP traffic logged.
+- Session serialize (5944-6085 bytes JSON) → deserialize → continued conversation works.
+- A brand-new session (Session B) still triggers recall against the same NAMS conversation history.
+- `MemoryTraceChatClient` correctly prints `<recalled_memory category="nams.entity">` blocks with no
+  changes needed — confirms Phase 6's reuse of the shared `RecalledMemoryDelimiter` format.
+
+**Genuine finding from the live run** (not a code defect — see the README's new "Known characteristic"
+section): in a fast, scripted back-to-back conversation, the model's replies don't always visibly reflect
+facts stated moments earlier. Two real NAMS characteristics combine to cause this: (1) asynchronous
+server-side extraction can race ahead of an immediate follow-up recall (same eventual-consistency behavior
+`NamsLiveConnectivityTests` already bounds with polling), and (2) NAMS's entity tier is NER-style
+(people/orgs/locations) and doesn't capture general preferences the way a person's name or employer does. A
+short `Task.Delay` was added between scripted turns to reduce (not eliminate) this. This is documented
+plainly in the sample's README rather than hidden, and is worth feeding into Phase 10's scenario matrix
+later (it's exactly the kind of thing the plan's own "eventual consistency: immediate absence, bounded poll,
+completion" mandatory scenario exists to characterize).
+
+## 5. Definition of done
+
+- [x] Sample builds clean (0 warnings).
+- [x] Actually run against live NAMS + real Azure OpenAI — twice, both fully completing.
+- [x] README documents the design decisions, the switch-to-Neo4j seam, and the honest recall-quality caveat.
+- [ ] Self-reviewed, PR opened, CI green, merged to `main`.

--- a/samples/AgentMemory.Sample.NamsAgent/AgentMemory.Sample.NamsAgent.csproj
+++ b/samples/AgentMemory.Sample.NamsAgent/AgentMemory.Sample.NamsAgent.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgentMemory.AgentFramework\AgentMemory.AgentFramework.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.AgentFramework.Nams\AgentMemory.AgentFramework.Nams.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.Nams\AgentMemory.Nams.csproj" />
+    <ProjectReference Include="..\AgentMemory.Samples.Shared\AgentMemory.Samples.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AgentMemory.Sample.NamsAgent/Program.cs
+++ b/samples/AgentMemory.Sample.NamsAgent/Program.cs
@@ -69,6 +69,7 @@ builder.Services.AddSingleton<IChatClient>(
     new MemoryTraceChatClient(azureClient.GetChatClient(chatDeployment).AsIChatClient()));
 
 var host = builder.Build();
+await using var hostDisposal = (IAsyncDisposable)host; // dispose the DI container (HttpClient, etc.) on exit
 await RunAsync(host.Services);
 
 static async Task RunAsync(IServiceProvider root)

--- a/samples/AgentMemory.Sample.NamsAgent/Program.cs
+++ b/samples/AgentMemory.Sample.NamsAgent/Program.cs
@@ -1,0 +1,165 @@
+// =============================================================================
+// AgentMemory for .NET — NamsAgent Sample (MAF 1.9.0)
+//
+// The NAMS-backed equivalent of AgentWithMemory: a ChatClientAgent whose memory lives in the real
+// NAMS SaaS (https://memory.neo4jlabs.com) instead of a direct Neo4j connection.
+//
+// It demonstrates:
+//   1. A ChatClientAgent with NamsMemoryContextProvider (an AIContextProvider).
+//   2. A multi-turn AgentSession — each turn is persisted to NAMS after the run.
+//   3. Session serialize/restore (SerializeSessionAsync / DeserializeSessionAsync).
+//   4. Durable cross-session recall — a brand-new session for the same user/application still sees
+//      prior memory, because NAMS — not the MAF session — is where the conversation actually lives.
+//   5. Sanitized recall diagnostics via the shared MemoryTraceChatClient, which prints the
+//      <recalled_memory> blocks NamsMemoryContextProvider injects before each live model call.
+//
+// Unlike the direct Neo4j samples, there is no local embedding generator, schema bootstrapper, or
+// memory tools to wire up — NAMS performs extraction/embedding/reflection server-side, and no MCP
+// tool surface for NAMS exists yet (that's engineering plan Phase 8, not built). This sample calls a
+// REAL Azure OpenAI chat model — no mock. Requires:
+//   AZURE_OPENAI_ENDPOINT   (required, e.g. https://<resource>.openai.azure.com/)
+//   AZURE_OPENAI_API_KEY    (required — no live-model fallback)
+//   AZURE_OPENAI_DEPLOYMENT (chat deployment name; default: gpt-4o-mini)
+//   NAMS_API_KEY            (required — your NAMS SaaS API key)
+//   NAMS_WORKSPACE_ID       (optional — only needed for an account-wide/admin key; a
+//                            workspace-scoped key already carries its workspace implicitly)
+// =============================================================================
+
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Nams;
+using AgentMemory.Nams;
+using AgentMemory.Samples.Shared;
+
+if (!RealAzureOpenAI.TryCreate(out var azureClient, out var chatDeployment, out _))
+{
+    RealAzureOpenAI.PrintMissingCredentials("AgentMemory for .NET — NamsAgent Sample (MAF 1.9.0)");
+    return;
+}
+
+var namsApiKey = Environment.GetEnvironmentVariable("NAMS_API_KEY");
+if (string.IsNullOrWhiteSpace(namsApiKey))
+{
+    Console.WriteLine("=== AgentMemory for .NET — NamsAgent Sample (MAF 1.9.0) ===\n");
+    Console.WriteLine("[!] NAMS is not configured. This sample calls the real NAMS SaaS — there is no");
+    Console.WriteLine("    offline fallback. Set this and re-run:");
+    Console.WriteLine("      NAMS_API_KEY        (required — your NAMS SaaS API key)");
+    Console.WriteLine("      NAMS_WORKSPACE_ID   (optional — only needed for an account-wide/admin key)");
+    return;
+}
+var namsWorkspaceId = Environment.GetEnvironmentVariable("NAMS_WORKSPACE_ID");
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddNamsAgentMemory(o =>
+{
+    o.Endpoint = NamsWellKnown.Endpoint;
+    o.ApiKey = namsApiKey;
+    o.WorkspaceId = namsWorkspaceId;
+});
+// AddNamsAgentMemoryFramework's own documented precondition: AddAgentMemoryFramework() must be
+// registered too (it owns ContextFormatOptions/AgentFrameworkOptions, which the NAMS provider reads).
+builder.Services.AddAgentMemoryFramework();
+builder.Services.AddNamsAgentMemoryFramework();
+builder.Services.AddSingleton<IChatClient>(
+    new MemoryTraceChatClient(azureClient.GetChatClient(chatDeployment).AsIChatClient()));
+
+var host = builder.Build();
+await RunAsync(host.Services);
+
+static async Task RunAsync(IServiceProvider root)
+{
+    var logger = root.GetRequiredService<ILogger<Program>>();
+    logger.LogInformation("=== AgentMemory for .NET — NamsAgent Sample (MAF 1.9.0) ===");
+
+    await using var scope = root.CreateAsyncScope();
+    var sp = scope.ServiceProvider;
+
+    var memoryProvider = sp.GetRequiredService<NamsMemoryContextProvider>();
+    IChatClient chatClient = sp.GetRequiredService<IChatClient>();
+
+    // No .WithMemoryOwnerScoping(sp) here -- that wrapper exists to keep an ambient AsyncLocal owner
+    // context alive across a LOCAL tool-calling loop (#90), which only matters for the direct Neo4j
+    // path's memory tools. NamsMemoryContextProvider reads identity directly off the session's state
+    // bag (no ambient context, no local tools yet), so the session identity below is sufficient alone.
+    AIAgent agent = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Name = "NamsMemoryAgent",
+        ChatOptions = new ChatOptions
+        {
+            Instructions = "You are a friendly assistant with durable, NAMS-backed long-term memory.",
+        },
+        AIContextProviders = [memoryProvider],
+    });
+
+    const string applicationId = "agent-memory-dotnet-nams-sample";
+    const string userId = "demo-user-nams";
+
+    // ── 1. A multi-turn session — each turn is persisted to NAMS ────────────────
+    logger.LogInformation("\n>> Session A — teaching the agent some facts\n");
+    var sessionA = (await agent.CreateSessionAsync()).WithMemoryIdentity(
+        userId: userId,
+        sessionId: "nams-sample-session-a",
+        conversationId: "nams-sample-conversation-a",
+        applicationId: applicationId);
+    foreach (var turn in new[]
+    {
+        "Hi, my name is Ada.",
+        "I prefer dark mode in every app I use.",
+        "I work at Contoso as a data engineer.",
+    })
+    {
+        SampleConsole.WriteUser(turn);
+        SampleConsole.WriteAssistant(await SafeRunAsync(agent, turn, sessionA, logger));
+        // NAMS ingests/extracts asynchronously server-side (the plan's own "eventual consistency"
+        // characteristic -- see NamsLiveConnectivityTests' bounded polling for the same reason). A
+        // recall that fires immediately after persisting can race ahead of NAMS's own indexing; a
+        // short pause between turns lets it catch up so later recall actually reflects what was just
+        // said. Not needed if turns are naturally paced (e.g. a real user typing).
+        await Task.Delay(TimeSpan.FromSeconds(3));
+    }
+
+    // ── 2. Serialize and restore the session ────────────────────────────────────
+    logger.LogInformation("\n>> Serialize the session, then restore it and continue\n");
+    var serialized = await agent.SerializeSessionAsync(sessionA);
+    logger.LogInformation("Serialized session is {Bytes} bytes of JSON.", serialized.GetRawText().Length);
+    var restored = (await agent.DeserializeSessionAsync(serialized)).WithMemoryIdentity(
+        userId: userId,
+        sessionId: "nams-sample-session-a",
+        conversationId: "nams-sample-conversation-a",
+        applicationId: applicationId);
+    SampleConsole.WriteUser("What did I tell you?");
+    SampleConsole.WriteAssistant(await SafeRunAsync(agent, "What did I tell you?", restored, logger));
+
+    // ── 3. Durable cross-session recall ─────────────────────────────────────────
+    // A brand-new session for the same user/application still sees earlier memory, because NAMS --
+    // not the MAF session -- is where the conversation and its extracted memory actually live.
+    logger.LogInformation("\n>> Session B — a NEW session that still recalls durable memory\n");
+    var sessionB = (await agent.CreateSessionAsync()).WithMemoryIdentity(
+        userId: userId,
+        sessionId: "nams-sample-session-b",
+        conversationId: "nams-sample-conversation-b",
+        applicationId: applicationId);
+    SampleConsole.WriteUser("Remind me what you know about me.");
+    SampleConsole.WriteAssistant(await SafeRunAsync(agent, "Remind me what you know about me.", sessionB, logger));
+
+    logger.LogInformation("\n=== Demo complete. Memory persisted in NAMS survives sessions and serialization. ===");
+}
+
+static async Task<string?> SafeRunAsync(AIAgent agent, string message, AgentSession session, ILogger logger)
+{
+    try
+    {
+        var response = await agent.RunAsync(message, session);
+        return response.Text;
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning("    Turn failed (check NAMS credentials/connectivity): {Message}", ex.Message);
+        return null;
+    }
+}

--- a/samples/AgentMemory.Sample.NamsAgent/README.md
+++ b/samples/AgentMemory.Sample.NamsAgent/README.md
@@ -1,0 +1,111 @@
+# NamsAgent Sample
+
+The NAMS-backed sibling of [AgentWithMemory](../AgentMemory.Sample.AgentWithMemory/README.md) — the same
+canonical Microsoft Agent Framework "agent with memory" shape, but memory lives in the real
+[NAMS](https://memory.neo4jlabs.com) SaaS instead of a direct Neo4j connection:
+
+- `NamsMemoryContextProvider` (`AgentMemory.AgentFramework.Nams`) injects recalled memory before each agent
+  run and persists the turn after the run — the NAMS equivalent of `Neo4jMemoryContextProvider`.
+- `WithMemoryIdentity(...)` stamps application, user, session, and conversation identity into the
+  `AgentSession` state bag — the exact same helper the direct Neo4j samples use, since both providers read
+  identity the same way.
+- Session serialize/restore, and a second session, demonstrate memory continuity beyond one in-memory run —
+  because the memory lives in NAMS, not in the MAF session.
+
+## Known characteristic: recall quality in a fast, scripted run
+
+Running this sample live against NAMS surfaced something worth knowing rather than hiding: in a fast,
+scripted back-to-back conversation like this one, the model's replies often don't visibly reflect facts
+stated just moments earlier. Two real characteristics of NAMS (not bugs in this provider) combine to cause
+that:
+
+- **Asynchronous extraction.** NAMS ingests and extracts server-side, not synchronously on write — recall
+  that fires immediately after persisting a message can race ahead of NAMS's own indexing (the same
+  eventual-consistency behavior `NamsLiveConnectivityTests` bounds with polling). This sample adds a short
+  `Task.Delay` between scripted turns for exactly that reason; a real user typing at natural speed doesn't
+  need it.
+- **Entity extraction favors named entities.** NAMS's entity tier is populated by NER-style extraction
+  (people, organizations, locations — "Ada", "Contoso" — not general preferences like "prefers dark mode").
+  A stated preference is more likely to surface via the `recentMessages`/reflection tiers than as an
+  "entity," so a demo run that only inspects `[memory recalled: nams.entity]` trace lines can look like
+  recall "missed" a preference that a longer-lived, real conversation would still have access to via chat
+  history.
+
+If your dev/test workspace has been reused across many runs (as ours has), you may also see recalled
+entities from unrelated earlier test conversations — NAMS's entity search is workspace-scoped, not
+conversation-scoped, so a shared workspace's entity graph accumulates across every conversation ever created
+in it. A dedicated workspace per demo, or periodically recreating it, keeps this cleaner.
+
+None of this is a defect in the wiring this sample demonstrates — conversation creation, persistence, and
+recall all round-trip correctly against the real service. It's a genuine characteristic worth knowing before
+judging recall quality from a short, scripted run.
+
+## What's different from the direct Neo4j samples
+
+- **No local embedding generator, schema bootstrapper, or memory tools.** NAMS performs message ingestion,
+  entity extraction, embeddings, and reflection generation server-side, asynchronously — this sample never
+  touches any of that locally.
+- **No `.WithMemoryOwnerScoping(sp)`.** That wrapper exists to keep an ambient `AsyncLocal` owner context
+  alive across a *local* tool-calling loop (#90) — it's only needed by the direct backend's memory tools.
+  `NamsMemoryContextProvider` reads identity straight off the session's state bag, with no ambient context
+  and no local tools (yet), so the session identity alone is sufficient.
+- **No MCP tool surface.** Capability-aware MCP tools for NAMS are engineering plan Phase 8 — not built.
+  This sample runs the complete recall/persistence lifecycle with no MCP involvement at all, which is also
+  the plan's own required baseline: routine memory must never depend on a model deciding to call a tool.
+
+## Live Providers — No Mocks
+
+This sample calls a **real** Azure OpenAI chat model (via the shared `AgentMemory.Samples.Shared` project,
+same as every other sample) and the **real, live NAMS SaaS** — there is no mock `IChatClient`, no offline
+NAMS fallback, and no embedding generator to configure (NAMS doesn't need one from the client). The chat
+client is wrapped in `MemoryTraceChatClient`, which prints the `<recalled_memory>` blocks
+`NamsMemoryContextProvider` injects before each live model call, in light blue — the exact same delimiter
+format the direct Neo4j provider uses (`RecalledMemoryDelimiter`, shared via `AgentMemory.Core`), so the
+trace client works identically for either backend with no changes.
+
+### Required environment variables
+
+```text
+AZURE_OPENAI_ENDPOINT    (required, e.g. https://<resource>.openai.azure.com/)
+AZURE_OPENAI_API_KEY     (required — no live-model fallback)
+AZURE_OPENAI_DEPLOYMENT  (optional, default gpt-4o-mini)
+NAMS_API_KEY             (required — your NAMS SaaS API key)
+NAMS_WORKSPACE_ID        (optional — only needed for an account-wide/admin key; a workspace-scoped
+                          key already carries its workspace implicitly)
+```
+
+Get a NAMS API key from your workspace's dashboard at <https://memory.neo4jlabs.com/dashboard/api-keys>.
+**Use a dedicated development/test workspace**, not a production one — this sample creates real
+conversations and messages.
+
+The NAMS base URL is not an environment variable here: it's `NamsWellKnown.Endpoint`
+(`AgentMemory.Nams`'s public-SaaS constant), since it's the same for every consumer and isn't a secret. If
+you need to point at a different NAMS-compatible endpoint, change the `o.Endpoint = ...` line in
+`Program.cs` directly.
+
+## Switching to direct Neo4j instead
+
+Nothing about the memory *pattern* changes — only the registration:
+
+```csharp
+// NAMS:
+builder.Services.AddNamsAgentMemory(o => { o.Endpoint = NamsWellKnown.Endpoint; o.ApiKey = ...; });
+builder.Services.AddAgentMemoryFramework();
+builder.Services.AddNamsAgentMemoryFramework();
+var memoryProvider = sp.GetRequiredService<NamsMemoryContextProvider>();
+
+// Direct Neo4j (see AgentWithMemory):
+builder.Services.AddNeo4jAgentMemory(o => { o.Uri = ...; o.Username = ...; o.Password = ...; });
+builder.Services.AddAgentMemoryFramework();
+var memoryProvider = sp.GetRequiredService<Neo4jMemoryContextProvider>();
+```
+
+`WithMemoryIdentity(...)` and the agent-building code are identical either way.
+
+## Related docs
+
+- [Phase 6 write-up](../../docs/reviews/NAMS_Phase6_DedicatedMafProvider_PlanningAndImplementationPlan.md) —
+  how `NamsMemoryContextProvider` gates/delimits recalled NAMS content with the same #92 security machinery
+  the direct provider uses.
+- [NAMS engineering plan](../../strategy/NAMS/AgentMemory_NAMS_Backend_Engineering_Plan_V04.md) — the full
+  phase-by-phase plan this sample is Phase 11 of.

--- a/samples/README.md
+++ b/samples/README.md
@@ -39,6 +39,7 @@ a memory **context provider** (injects memory before each run, persists after) p
 | --- | --- |
 | **AgentWithMemory** | The flagship golden path — the .NET equivalent of the official [`04_memory`](https://github.com/microsoft/agent-framework/tree/main/dotnet/samples/01-get-started/04_memory) / [`AgentWithMemory`](https://github.com/microsoft/agent-framework/tree/main/dotnet/samples/02-agents/AgentWithMemory) sample, backed by **durable Neo4j memory**: `Neo4jMemoryContextProvider` + memory tools, explicit `WithMemoryIdentity(...)` owner/application/session scope, multi-turn session, **session serialize/restore** (`SerializeSessionAsync`/`DeserializeSessionAsync`), and **durable cross-session recall**. |
 | **ShoppingAssistant** | The **.NET reimplementation of the official Neo4j retail-assistant example** — a shopping assistant that learns preferences and recommends products via graph traversal: `Neo4jMemoryContextProvider` + memory tools + **custom product tools** over a Neo4j product graph, a retail prompt, and durable cross-session recall. The agent itself decides when to call the memory/product tools — nothing is scripted. |
+| **NamsAgent** | The NAMS-backed sibling of AgentWithMemory — the same golden-path shape, but memory lives in the real [NAMS](https://memory.neo4jlabs.com) SaaS via `NamsMemoryContextProvider` (`AgentMemory.AgentFramework.Nams`) instead of a direct Neo4j connection: multi-turn session, session serialize/restore, and durable cross-session recall, all against the live service. |
 | **RealAgent** | A real `ChatClientAgent` with `Neo4jMemoryContextProvider` (long-term memory) **and** the memory tools, multi-turn `AgentSession`, and native MAF `UseOpenTelemetry()`. |
 | **MemoryToolsAgent** | The memory tools (`MemoryToolFactory.CreateAIFunctions()`, the `create_memory_tools` equivalent): registered on an agent and invoked directly against Neo4j. |
 | **ChatHistoryProvider** | `Neo4jChatHistoryProvider` wired via `ChatClientAgentOptions.ChatHistoryProvider` — per-session conversation history (distinct from long-term memory). |
@@ -47,18 +48,19 @@ a memory **context provider** (injects memory before each run, persists after) p
 | **McpHost** | Hosting the AgentMemory MCP server. |
 | **AspireDemo** | A .NET Aspire AppHost orchestrating Neo4j + a scripted demo app. |
 
-**AgentWithMemory, RealAgent, MemoryToolsAgent, ChatHistoryProvider, and ShoppingAssistant call a REAL
-Azure OpenAI chat model and a REAL Azure OpenAI embedding model — there is no mock `IChatClient` and
-no offline fallback.** Each fails fast with setup instructions if credentials are missing. The model
-decides on its own when to call the memory (and, for ShoppingAssistant, product) tools — nothing is
-scripted. Live tool calls and any memory the context provider recalls are printed to the console
-(memory in light blue) via the shared `AgentMemory.Samples.Shared` helper
-(`RealAzureOpenAI`/`MemoryTraceChatClient`/`SampleConsole`). See
-`AgentMemory.Sample.AgentWithMemory/README.md` for the identity/provider seams. Memory operations
-degrade gracefully when no live Neo4j is available. BlendedAgent, MinimalAgent, and McpHost don't
-drive a chat model at all — they exercise the facade/tool layer directly — but they too now use a
-**real** Azure OpenAI embedding model via the same shared `RealAzureOpenAI` helper; no sample in this
-repo uses `StubEmbeddingGenerator` anymore.
+**AgentWithMemory, RealAgent, MemoryToolsAgent, ChatHistoryProvider, ShoppingAssistant, and NamsAgent call
+a REAL Azure OpenAI chat model — there is no mock `IChatClient` and no offline fallback.** Each fails fast
+with setup instructions if credentials are missing. The model decides on its own when to call the memory
+(and, for ShoppingAssistant, product) tools — nothing is scripted. Live tool calls and any memory the
+context provider recalls are printed to the console (memory in light blue) via the shared
+`AgentMemory.Samples.Shared` helper (`RealAzureOpenAI`/`MemoryTraceChatClient`/`SampleConsole`). See
+`AgentMemory.Sample.AgentWithMemory/README.md` for the identity/provider seams. Memory operations degrade
+gracefully when no live Neo4j is available. All of these except **NamsAgent** also use a REAL Azure OpenAI
+**embedding** model — NAMS performs embedding/extraction server-side, so `NamsAgent` needs no local
+embedding generator at all, and instead calls the **real, live NAMS SaaS** for memory. BlendedAgent,
+MinimalAgent, and McpHost don't drive a chat model at all — they exercise the facade/tool layer directly —
+but they too now use a **real** Azure OpenAI embedding model via the same shared `RealAzureOpenAI` helper;
+no sample in this repo uses `StubEmbeddingGenerator` anymore.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- New sample `samples/AgentMemory.Sample.NamsAgent` — the NAMS-backed sibling of `AgentWithMemory`, demonstrating the full Phase 4-6 pipeline (identity resolution -> recall -> gate/delimit -> inject -> persist) live against the real NAMS SaaS.
- Scoped to NAMS only per explicit direction -- no backend-switching toggle.
- No local embedding generator, schema bootstrapper, or memory tools -- NAMS handles extraction/embedding server-side, and no MCP tool surface for NAMS exists yet (Phase 8).
- No `.WithMemoryOwnerScoping(sp)` -- that wrapper is only needed for the direct backend's local tool-calling loop; `NamsMemoryContextProvider` reads identity straight off the session state bag.

Verified by **actually running it twice against live NAMS + real Azure OpenAI**, not just building it -- conversation creation, persistence, recall, session serialize/restore, and cross-session recall all round-trip correctly. Surfaced a genuine NAMS characteristic (documented in the sample's README, not hidden): a fast scripted run can race ahead of NAMS's own asynchronous extraction, and its entity tier favors named entities over general preferences -- worth feeding into Phase 10's scenario matrix later.

Full write-up: `docs/reviews/NAMS_Phase11_Sample_PlanningAndImplementationPlan.md`.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] Ran the sample live against real NAMS + real Azure OpenAI (twice) -- both completed cleanly end to end
- [x] Self-reviewed (3 parallel agents: correctness, cross-file impact, cleanup/conventions) -- 2 real findings (missing host disposal, samples README index), both fixed
- [x] CI green (no Copilot review per standing instruction)