### PR TITLE
NAMS Phase 9: observability (spans, metrics, health checks)

### DIFF
--- a/docs/reviews/NAMS_Phase9_Observability_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase9_Observability_PlanningAndImplementationPlan.md
@@ -1,0 +1,92 @@
+# NAMS Phase 9 — Observability — Planning and Implementation Plan
+
+**Prepared:** 2026-07-17
+**Branch:** `nams/phase9-observability`
+**Purpose:** Executes engineering plan Phase 9 ("Observability and operations"). Per §12's recommended
+delivery sequence, this comes right after "Live sandbox proof" (today's earlier live validation +
+`NamsAgent` sample) and before the optional Phase 7 convergence.
+
+## 1. Design decisions
+
+- **BCL diagnostics directly, no `AgentMemory.Observability` dependency.** That package decorates the
+  direct backend's Core interfaces (`IMemoryService`, extractors) via `TryAddScoped` wrapping -- none of
+  which exist on the NAMS path. `AgentMemory.Nams` (B9) stays at zero sibling references by using
+  `System.Diagnostics.ActivitySource`/`System.Diagnostics.Metrics.Meter` directly -- pure BCL, not an
+  external package, so B9's boundary rule is untouched.
+- **Spans/metrics live at two layers.** `Neo4jNamsClientAdapter` (the actual HTTP-call boundary) emits
+  `memory.backend.operations`/`.duration`/`.failures`/`.retries`/`.rate_limited`, one per real REST call
+  (`resolve_conversation`, `get_context`, `store_turn`, `search_entities`, `list_entities`). `.context_items`/
+  `.context_truncated` are emitted from `NamsRecallService` (it alone knows about budget truncation) and
+  `.unknown_write_outcomes` from `NamsPersistenceService` (it alone classifies that outcome). All metric
+  tags are the plan's own low-cardinality set (`backend`, `operation`, `status`, `failure_kind`) -- never an
+  owner/workspace/conversation ID, memory text, or a prompt.
+- **Cancellation is not counted as a failure**, per the plan's own test list -- `Neo4jNamsClientAdapter`
+  records a distinct `status=cancelled` on the operations counter and never touches the failures counter for
+  caller-requested cancellation.
+- **A new `INamsClient.ListEntitiesAsync`** (`GET /v1/entities`, confirmed live) was added specifically to
+  give the health check a safe, side-effect-free, no-precondition probe -- `SearchEntitiesAsync` requires a
+  non-empty query (confirmed live: an empty query returns 400) and `GetContextAsync` requires an existing
+  conversation, so neither works as a default connectivity probe.
+- **Health check is a small, framework-agnostic interface** (`INamsHealthCheck`/`NamsHealthCheckResult`/
+  `NamsHealthStatus`), not an ASP.NET Core `IHealthCheck` -- avoids a new package dependency for every
+  consumer; a host that wants the ASP.NET Core shape adapts this thin result itself. Distinguishes
+  `Unhealthy` (auth/network/timeout/unexpected) from `Degraded` (rate-limited) per the plan's own
+  requirement ("status distinction between unhealthy and degraded/rate-limited"). Never performs a
+  destructive write, by construction (only ever calls the new read-only `ListEntitiesAsync`).
+- **Retry counting via a callback, not a metrics dependency in `NamsRetryPolicy`.** `ExecuteAsync` gained an
+  optional `Action? onRetry` parameter, invoked once per actual retry -- keeps the retry policy itself free
+  of any metrics-type dependency; the adapter supplies the callback.
+
+## 2. Explicitly out of scope
+
+- **Data-governance verification** (conversation/user deletion behavior, export, region/classification
+  restrictions) -- the plan's own list requires either live testing against real deletion behavior or an
+  organizational decision neither of which this PR can make alone.
+- **`docs/security/production-checklist.md`** -- reviewed, deliberately left untouched. It's entirely
+  direct-Neo4j-backend-scoped (threat-model TT-01 through TT-11) and NAMS isn't released yet (no preview,
+  Phase 12 not started) -- grafting a half-formed NAMS item onto it now would be premature.
+- **Phase 8 (MCP tools)** and further **Phase 10 test-matrix expansion** -- separate phases, next in this
+  session's queue.
+
+## 3. Log review (plan's own checklist item)
+
+Reviewed every `_logger.Log*` call site in `AgentMemory.Nams` and `AgentMemory.AgentFramework.Nams`
+(`grep` across both packages). None log an API key, recalled memory content, or a raw message body --
+only conversation/session/application IDs and static messages. `NamsClientExceptionMapper.Redact()` already
+scrubs the configured API key from any exception message before it can reach a log call (a Phase 2
+guarantee, unchanged here). No changes needed -- clean by design, not clean by omission.
+
+## 4. New/changed files
+
+- `src/AgentMemory.Nams/Observability/` (new folder): `NamsActivitySource.cs`, `NamsMetrics.cs`,
+  `NamsMetricTags.cs`, `NamsHealthStatus.cs`, `NamsHealthCheckResult.cs`, `INamsHealthCheck.cs`,
+  `NamsHealthCheck.cs`.
+- `src/AgentMemory.Nams/Client/INamsClient.cs` / `Neo4jNamsClientAdapter.cs` -- new `ListEntitiesAsync`;
+  `InvokeAsync` instrumented with spans/metrics per operation.
+- `src/AgentMemory.Nams/Client/NamsRetryPolicy.cs` -- new optional `onRetry` callback parameter.
+- `src/AgentMemory.Nams/Recall/NamsRecallService.cs` -- records `context_items`/`context_truncated`.
+- `src/AgentMemory.Nams/Persistence/NamsPersistenceService.cs` -- records `unknown_write_outcomes`.
+- `src/AgentMemory.Nams/NamsServiceCollectionExtensions.cs` -- registers `NamsMetrics`, `INamsHealthCheck`.
+- Test updates: every existing `INamsClient` test fake gained `ListEntitiesAsync`; every direct
+  `NamsRecallService`/`NamsPersistenceService`/`Neo4jNamsClientAdapter` construction site gained a
+  `NamsMetrics` argument.
+- New tests: `NamsMetricsTests.cs`, `NamsMetricTagsTests.cs`, `NamsHealthCheckTests.cs`,
+  `NamsObservabilityTests.cs` (+ `NamsObservabilityCollection.cs`, mirroring the existing
+  `AgentMemory.Tests.Unit.Observability.ObservabilityCollection` pattern for tests that attach a
+  process-wide `MeterListener`) -- verifies actual metric recording, not just that construction doesn't
+  throw: success/duration, failure+failure_kind, rate-limited, retries, cancellation-not-a-failure,
+  context items/truncation, unknown write outcomes. Plus 2 new `NamsRetryPolicy` tests for the `onRetry`
+  callback itself.
+
+## 5. Verification
+
+- `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors.
+- `dotnet test tests/AgentMemory.Tests.Unit` -- full suite green (189 Nams-filtered, ~30 net new).
+
+## 6. Definition of done
+
+- [x] Spans + metrics instrumented at the client/recall/persistence layers.
+- [x] Health check built and covered.
+- [x] Log review complete, no changes needed.
+- [x] Full unit suite green.
+- [ ] Self-reviewed, PR opened, CI green, merged to `main`.

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -34,4 +34,13 @@ internal interface INamsClient
         string? type,
         int limit,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists entities in the workspace with no query -- confirmed against the live NAMS REST API
+    /// (<c>GET /v1/entities</c>) as part of Phase 9. Unlike <see cref="SearchEntitiesAsync"/> (which requires
+    /// a non-empty query -- NAMS returns 400 for an empty one), this needs no precondition and no existing
+    /// conversation, making it the one safe, side-effect-free read this client can use for a connectivity
+    /// health probe.
+    /// </summary>
+    Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
@@ -24,12 +24,16 @@ internal sealed class NamsRetryPolicy
     }
 
     /// <summary><paramref name="requestFactory"/> is invoked once per attempt -- an <see cref="HttpRequestMessage"/>
-    /// can only be sent once, so each retry needs a fresh instance.</summary>
+    /// can only be sent once, so each retry needs a fresh instance. <paramref name="onRetry"/> (Phase 9), if
+    /// supplied, is invoked once per actual retry -- after the transient response/exception is observed, right
+    /// before the retry delay -- so a caller can record a metric without this policy taking a hard dependency
+    /// on any metrics type.</summary>
     public async Task<HttpResponseMessage> ExecuteAsync(
         Func<HttpRequestMessage> requestFactory,
         HttpClient httpClient,
         bool isIdempotent,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action? onRetry = null)
     {
         if (!isIdempotent)
             return await httpClient.SendAsync(requestFactory(), cancellationToken).ConfigureAwait(false);
@@ -47,6 +51,7 @@ internal sealed class NamsRetryPolicy
                     "Transient NAMS response {Status}; retry {Next}/{Max} after {Delay}.",
                     (int)response.StatusCode, attempt + 1, _maxAttempts, delay);
                 response.Dispose();
+                onRetry?.Invoke();
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -58,6 +63,7 @@ internal sealed class NamsRetryPolicy
                 // Network failure, or a per-request timeout (a TaskCanceledException whose token was NOT the
                 // caller's -- caller cancellation is handled by the guarded catch above).
                 _logger?.LogDebug(ex, "Transient NAMS failure; retry {Next}/{Max}.", attempt + 1, _maxAttempts);
+                onRetry?.Invoke();
                 await Task.Delay(BackoffFor(attempt), cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 
 namespace AgentMemory.Nams.Client;
 
@@ -27,18 +29,22 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     private readonly HttpClient _httpClient;
     private readonly NamsRetryPolicy _retryPolicy;
     private readonly string? _apiKeyForRedaction;
+    private readonly NamsMetrics _metrics;
 
-    public Neo4jNamsClientAdapter(HttpClient httpClient, IOptions<NamsOptions> options, ILogger<Neo4jNamsClientAdapter> logger)
+    public Neo4jNamsClientAdapter(
+        HttpClient httpClient, IOptions<NamsOptions> options, ILogger<Neo4jNamsClientAdapter> logger, NamsMetrics metrics)
     {
         _httpClient = httpClient;
         var namsOptions = options.Value;
         _retryPolicy = new NamsRetryPolicy(namsOptions.MaxRetryAttempts, namsOptions.InitialRetryDelay, logger);
         _apiKeyForRedaction = namsOptions.ApiKey;
+        _metrics = metrics;
     }
 
     public Task<NamsConversation> CreateConversationAsync(
         string? userId, IReadOnlyDictionary<string, string>? metadata, CancellationToken cancellationToken) =>
         InvokeAsync(
+            "resolve_conversation",
             () => BuildJsonRequest(HttpMethod.Post, "conversations", new CreateConversationRequestBody(userId, metadata)),
             isIdempotent: false,
             DeserializeAsync<NamsConversation>,
@@ -46,6 +52,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
 
     public Task<NamsContext> GetContextAsync(string conversationId, CancellationToken cancellationToken) =>
         InvokeAsync(
+            "get_context",
             () => new HttpRequestMessage(HttpMethod.Get, $"conversations/{Uri.EscapeDataString(conversationId)}/context"),
             isIdempotent: true,
             DeserializeAsync<NamsContext>,
@@ -56,6 +63,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     {
         var path = $"conversations/{Uri.EscapeDataString(conversationId)}/messages/bulk";
         var response = await InvokeAsync(
+            "store_turn",
             () => BuildJsonRequest(HttpMethod.Post, path, new AddMessagesBulkRequestBody(messages)),
             isIdempotent: false,
             DeserializeAsync<AddMessagesBatchResponseBody>,
@@ -70,6 +78,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         // idempotent for retry purposes (matches the engineering plan's retry matrix, which lists "Search" as
         // always-retryable regardless of the verb it happens to use).
         var response = await InvokeAsync(
+            "search_entities",
             () => BuildJsonRequest(HttpMethod.Post, "entities/search", new SearchEntitiesRequestBody(query, type, limit)),
             isIdempotent: true,
             DeserializeAsync<SearchEntitiesResponseBody>,
@@ -77,28 +86,72 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         return response.Entities;
     }
 
+    public async Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken)
+    {
+        var response = await InvokeAsync(
+            "list_entities",
+            () => new HttpRequestMessage(HttpMethod.Get, $"entities?limit={limit}"),
+            isIdempotent: true,
+            DeserializeAsync<ListEntitiesResponseBody>,
+            cancellationToken).ConfigureAwait(false);
+        return response.Entities;
+    }
+
     private async Task<T> InvokeAsync<T>(
+        string operationName,
         Func<HttpRequestMessage> requestFactory,
         bool isIdempotent,
         Func<Stream, CancellationToken, Task<T>> deserialize,
         CancellationToken cancellationToken)
     {
+        using var activity = NamsActivitySource.Instance.StartActivity($"agentmemory.nams.{operationName}");
+        var stopwatch = Stopwatch.StartNew();
         try
         {
-            using var response = await _retryPolicy.ExecuteAsync(requestFactory, _httpClient, isIdempotent, cancellationToken)
+            using var response = await _retryPolicy.ExecuteAsync(
+                requestFactory, _httpClient, isIdempotent, cancellationToken,
+                onRetry: () => _metrics.BackendRetries.Add(1, NamsMetricTags.Operation(operationName)))
                 .ConfigureAwait(false);
             var result = await NamsClientExceptionMapper.MapResponseAsync(response, deserialize, _apiKeyForRedaction, cancellationToken)
                 .ConfigureAwait(false);
-            return result.IsSuccess ? result.Value! : throw NamsClientExceptionMapper.ToException(result);
+            if (result.IsSuccess)
+            {
+                RecordOutcome(operationName, stopwatch.Elapsed, activity, status: "succeeded");
+                return result.Value!;
+            }
+
+            var failure = NamsClientExceptionMapper.ToException(result);
+            RecordFailure(operationName, stopwatch.Elapsed, activity, failure.FailureKind);
+            throw failure;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            throw; // caller cancellation -- never wrap
+            // Cancellation is not counted as a service failure (Phase 9's own test list).
+            RecordOutcome(operationName, stopwatch.Elapsed, activity, status: "cancelled");
+            throw;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            throw NamsClientExceptionMapper.FromTransportException(ex, _apiKeyForRedaction);
+            var failure = NamsClientExceptionMapper.FromTransportException(ex, _apiKeyForRedaction);
+            RecordFailure(operationName, stopwatch.Elapsed, activity, failure.FailureKind);
+            throw failure;
         }
+    }
+
+    private void RecordOutcome(string operationName, TimeSpan elapsed, Activity? activity, string status)
+    {
+        _metrics.BackendOperations.Add(1, NamsMetricTags.OperationStatus(operationName, status));
+        _metrics.BackendDurationMs.Record(elapsed.TotalMilliseconds, NamsMetricTags.Operation(operationName));
+        activity?.SetStatus(status == "succeeded" || status == "cancelled" ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+    }
+
+    private void RecordFailure(string operationName, TimeSpan elapsed, Activity? activity, NamsFailureKind failureKind)
+    {
+        RecordOutcome(operationName, elapsed, activity, status: "failed");
+        _metrics.BackendFailures.Add(1, NamsMetricTags.OperationFailureKind(operationName, failureKind));
+        if (failureKind == NamsFailureKind.RateLimited)
+            _metrics.BackendRateLimited.Add(1, NamsMetricTags.Operation(operationName));
+        activity?.SetStatus(ActivityStatusCode.Error, failureKind.ToString());
     }
 
     private static HttpRequestMessage BuildJsonRequest<TBody>(HttpMethod method, string relativePath, TBody body) =>
@@ -128,4 +181,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     private sealed record SearchEntitiesResponseBody(
         [property: JsonPropertyName("entities")] IReadOnlyList<NamsEntity> Entities,
         [property: JsonPropertyName("searchType")] string? SearchType);
+
+    private sealed record ListEntitiesResponseBody(
+        [property: JsonPropertyName("entities")] IReadOnlyList<NamsEntity> Entities);
 }

--- a/src/AgentMemory.Nams/NamsServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Nams/NamsServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using AgentMemory.Nams.Authentication;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Identity;
 using AgentMemory.Nams.Internal;
+using AgentMemory.Nams.Observability;
 using AgentMemory.Nams.Persistence;
 using AgentMemory.Nams.Recall;
 
@@ -46,6 +47,9 @@ public static class NamsServiceCollectionExtensions
         // harmless no-op for this registration (the options registration above is likewise safe to call
         // more than once -- each call just adds another equivalent configure/validate step).
         services.TryAddSingleton<NamsBackendDescriptor>();
+
+        services.TryAddSingleton<NamsMetrics>();
+        services.TryAddSingleton<INamsHealthCheck, NamsHealthCheck>();
 
         services.TryAddSingleton<INamsAccessTokenProvider, StaticApiKeyNamsAccessTokenProvider>();
         services.TryAddTransient<NamsAuthenticationHandler>();

--- a/src/AgentMemory.Nams/Observability/INamsHealthCheck.cs
+++ b/src/AgentMemory.Nams/Observability/INamsHealthCheck.cs
@@ -1,0 +1,12 @@
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>
+/// A lightweight, host-agnostic health probe for the NAMS backend (engineering plan Phase 9). Deliberately
+/// not an ASP.NET Core <c>IHealthCheck</c> -- this package takes no dependency on
+/// <c>Microsoft.Extensions.Diagnostics.HealthChecks</c>, so a host that wants one adapts this thin result
+/// itself. Never performs a destructive write (plan: "no destructive write probe by default").
+/// </summary>
+public interface INamsHealthCheck
+{
+    Task<NamsHealthCheckResult> CheckAsync(CancellationToken cancellationToken);
+}

--- a/src/AgentMemory.Nams/Observability/NamsActivitySource.cs
+++ b/src/AgentMemory.Nams/Observability/NamsActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>
+/// Centralized <see cref="ActivitySource"/> for distributed tracing across NAMS backend operations
+/// (engineering plan Phase 9). Uses the BCL diagnostics APIs directly rather than taking a dependency on
+/// <c>AgentMemory.Observability</c> -- that package decorates the direct-Neo4j-backend's Core interfaces
+/// (<c>IMemoryService</c>, extractors, etc.), none of which this package can reference (B9: zero sibling
+/// <c>AgentMemory.*</c> references).
+/// </summary>
+public static class NamsActivitySource
+{
+    /// <summary>The name used when registering the activity source with OpenTelemetry.</summary>
+    public const string Name = "AgentMemory.Nams";
+
+    /// <summary>Shared instance for all NAMS backend operation spans.</summary>
+    public static readonly ActivitySource Instance = new(Name, "1.0.0");
+}

--- a/src/AgentMemory.Nams/Observability/NamsHealthCheck.cs
+++ b/src/AgentMemory.Nams/Observability/NamsHealthCheck.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>See <see cref="INamsHealthCheck"/>.</summary>
+internal sealed class NamsHealthCheck : INamsHealthCheck
+{
+    private readonly INamsClient _namsClient;
+    private readonly NamsOptions _options;
+
+    public NamsHealthCheck(INamsClient namsClient, IOptions<NamsOptions> options)
+    {
+        _namsClient = namsClient;
+        _options = options.Value;
+    }
+
+    public async Task<NamsHealthCheckResult> CheckAsync(CancellationToken cancellationToken)
+    {
+        // Configuration health: by the time this runs, AddNamsAgentMemory's ValidateOnStart has already
+        // guaranteed Endpoint/ApiKey are present -- this is defense-in-depth for a host that catches that
+        // startup exception and still exposes health probes, not the primary guarantee.
+        if (_options.Endpoint is null || string.IsNullOrWhiteSpace(_options.ApiKey))
+            return new NamsHealthCheckResult { Status = NamsHealthStatus.Unhealthy, Description = "NAMS is not configured (missing Endpoint or ApiKey)." };
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            // The one safe, side-effect-free, no-precondition read this client exposes -- see
+            // INamsClient.ListEntitiesAsync's own doc for why SearchEntitiesAsync/GetContextAsync don't work
+            // as a probe (a required non-empty query, and a pre-existing conversation, respectively).
+            await _namsClient.ListEntitiesAsync(1, cancellationToken).ConfigureAwait(false);
+            return new NamsHealthCheckResult
+            {
+                Status = NamsHealthStatus.Healthy,
+                Description = "NAMS is reachable and authenticated.",
+                Latency = stopwatch.Elapsed
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // caller cancellation -- never reported as a health result
+        }
+        catch (NamsOperationException ex)
+        {
+            return new NamsHealthCheckResult { Status = ClassifyFailure(ex.FailureKind), Description = Describe(ex.FailureKind), Latency = stopwatch.Elapsed };
+        }
+    }
+
+    private static NamsHealthStatus ClassifyFailure(NamsFailureKind failureKind) => failureKind switch
+    {
+        NamsFailureKind.RateLimited => NamsHealthStatus.Degraded,
+        _ => NamsHealthStatus.Unhealthy
+    };
+
+    private static string Describe(NamsFailureKind failureKind) => failureKind switch
+    {
+        NamsFailureKind.Authentication => "NAMS rejected the configured API key.",
+        NamsFailureKind.Authorization => "NAMS accepted the API key but denied access to this workspace.",
+        NamsFailureKind.RateLimited => "NAMS is currently rate-limiting requests.",
+        NamsFailureKind.Network => "NAMS is unreachable (network failure).",
+        NamsFailureKind.Timeout => "NAMS did not respond within the configured timeout.",
+        _ => $"NAMS returned an unexpected error ({failureKind})."
+    };
+}

--- a/src/AgentMemory.Nams/Observability/NamsHealthCheckResult.cs
+++ b/src/AgentMemory.Nams/Observability/NamsHealthCheckResult.cs
@@ -1,0 +1,15 @@
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>The result of an <see cref="INamsHealthCheck"/> probe.</summary>
+public sealed record NamsHealthCheckResult
+{
+    public required NamsHealthStatus Status { get; init; }
+
+    /// <summary>A short, human-readable description -- never the raw exception message (which may echo
+    /// request/response details); see <see cref="INamsHealthCheck"/> for the redaction rule this follows.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>How long the probe took, when it performed a network call (<see langword="null"/> for the
+    /// configuration-only check, which never touches the network).</summary>
+    public TimeSpan? Latency { get; init; }
+}

--- a/src/AgentMemory.Nams/Observability/NamsHealthStatus.cs
+++ b/src/AgentMemory.Nams/Observability/NamsHealthStatus.cs
@@ -1,0 +1,19 @@
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>
+/// The outcome of an <see cref="INamsHealthCheck"/> probe. Deliberately distinguishes <see cref="Unhealthy"/>
+/// from <see cref="Degraded"/> (engineering plan Phase 9: "status distinction between unhealthy and
+/// degraded/rate-limited") -- rate limiting means the service is reachable and authenticated, just
+/// throttled, which calls for a different operational response than an outage or bad credentials.
+/// </summary>
+public enum NamsHealthStatus
+{
+    /// <summary>The backend is reachable and authenticated.</summary>
+    Healthy,
+
+    /// <summary>The backend is reachable but currently rate-limiting requests.</summary>
+    Degraded,
+
+    /// <summary>The backend is unreachable, or credentials are invalid/insufficient.</summary>
+    Unhealthy
+}

--- a/src/AgentMemory.Nams/Observability/NamsMetricTags.cs
+++ b/src/AgentMemory.Nams/Observability/NamsMetricTags.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>
+/// Builds the low-cardinality tag sets <see cref="NamsMetrics"/> instruments are recorded with. Every tag
+/// value here is an enum-shaped string (backend name, operation name, status, failure kind) -- centralizing
+/// construction keeps every call site tagging with the exact same key names, and keeps "never tag owner
+/// IDs/memory text/prompts" (the plan's own rule) impossible to violate by accident at a call site.
+/// </summary>
+internal static class NamsMetricTags
+{
+    private const string Backend = "nams";
+
+    public static TagList Operation(string operationName) => new()
+    {
+        { "backend", Backend },
+        { "operation", operationName }
+    };
+
+    public static TagList OperationStatus(string operationName, string status) => new()
+    {
+        { "backend", Backend },
+        { "operation", operationName },
+        { "status", status }
+    };
+
+    public static TagList OperationFailureKind(string operationName, NamsFailureKind failureKind) => new()
+    {
+        { "backend", Backend },
+        { "operation", operationName },
+        { "failure_kind", failureKind.ToString() }
+    };
+}

--- a/src/AgentMemory.Nams/Observability/NamsMetrics.cs
+++ b/src/AgentMemory.Nams/Observability/NamsMetrics.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics.Metrics;
+
+namespace AgentMemory.Nams.Observability;
+
+/// <summary>
+/// Centralized <see cref="Meter"/> with counters and histograms for NAMS backend operations (engineering
+/// plan Phase 9). Every tag is a low-cardinality enum-shaped value (operation name, status, failure kind) --
+/// never an owner/workspace/conversation/entity ID, memory text, or a prompt, matching the plan's own
+/// "never tag" list.
+/// </summary>
+public sealed class NamsMetrics : IDisposable
+{
+    /// <summary>The meter name used when registering with OpenTelemetry.</summary>
+    public const string MeterName = "AgentMemory.Nams";
+
+    private readonly Meter _meter;
+
+    public NamsMetrics()
+    {
+        _meter = new Meter(MeterName, "1.0.0");
+
+        BackendOperations = _meter.CreateCounter<long>(
+            "memory.backend.operations",
+            description: "Number of NAMS backend operations, tagged by backend/operation/status");
+
+        BackendDurationMs = _meter.CreateHistogram<double>(
+            "memory.backend.duration",
+            unit: "ms",
+            description: "Duration of NAMS backend operations in milliseconds, tagged by backend/operation");
+
+        BackendFailures = _meter.CreateCounter<long>(
+            "memory.backend.failures",
+            description: "Number of failed NAMS backend operations, tagged by backend/operation/failure_kind");
+
+        BackendRetries = _meter.CreateCounter<long>(
+            "memory.backend.retries",
+            description: "Number of retry attempts against the NAMS backend, tagged by backend/operation");
+
+        BackendRateLimited = _meter.CreateCounter<long>(
+            "memory.backend.rate_limited",
+            description: "Number of NAMS backend operations that ultimately failed as rate-limited, tagged by backend/operation");
+
+        UnknownWriteOutcomes = _meter.CreateCounter<long>(
+            "memory.backend.unknown_write_outcomes",
+            description: "Number of persistence operations whose outcome was genuinely ambiguous (network/timeout failure with no confirmed NAMS idempotency to retry against)");
+
+        ContextItems = _meter.CreateHistogram<long>(
+            "memory.backend.context_items",
+            description: "Number of items returned by a recall operation");
+
+        ContextTruncated = _meter.CreateCounter<long>(
+            "memory.backend.context_truncated",
+            description: "Number of recall operations whose result was truncated or otherwise degraded/partial");
+    }
+
+    /// <summary>Disposes the underlying <see cref="Meter"/>.</summary>
+    public void Dispose() => _meter.Dispose();
+
+    /// <summary>Number of NAMS backend operations, tagged by backend/operation/status.</summary>
+    internal Counter<long> BackendOperations { get; }
+
+    /// <summary>Duration of NAMS backend operations in milliseconds, tagged by backend/operation.</summary>
+    internal Histogram<double> BackendDurationMs { get; }
+
+    /// <summary>Number of failed NAMS backend operations, tagged by backend/operation/failure_kind.</summary>
+    internal Counter<long> BackendFailures { get; }
+
+    /// <summary>Number of retry attempts against the NAMS backend, tagged by backend/operation.</summary>
+    internal Counter<long> BackendRetries { get; }
+
+    /// <summary>Number of NAMS backend operations that ultimately failed as rate-limited.</summary>
+    internal Counter<long> BackendRateLimited { get; }
+
+    /// <summary>Number of persistence operations with a genuinely ambiguous outcome.</summary>
+    internal Counter<long> UnknownWriteOutcomes { get; }
+
+    /// <summary>Number of items returned by a recall operation.</summary>
+    internal Histogram<long> ContextItems { get; }
+
+    /// <summary>Number of recall operations whose result was truncated or otherwise degraded/partial.</summary>
+    internal Counter<long> ContextTruncated { get; }
+}

--- a/src/AgentMemory.Nams/Persistence/NamsPersistenceService.cs
+++ b/src/AgentMemory.Nams/Persistence/NamsPersistenceService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 
 namespace AgentMemory.Nams.Persistence;
 
@@ -16,12 +17,15 @@ internal sealed class NamsPersistenceService : INamsPersistenceService
     private readonly INamsClient _namsClient;
     private readonly NamsOptions _options;
     private readonly ILogger<NamsPersistenceService> _logger;
+    private readonly NamsMetrics _metrics;
 
-    public NamsPersistenceService(INamsClient namsClient, IOptions<NamsOptions> options, ILogger<NamsPersistenceService> logger)
+    public NamsPersistenceService(
+        INamsClient namsClient, IOptions<NamsOptions> options, ILogger<NamsPersistenceService> logger, NamsMetrics metrics)
     {
         _namsClient = namsClient;
         _options = options.Value;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task<NamsPersistenceResult> PersistTurnAsync(
@@ -58,6 +62,7 @@ internal sealed class NamsPersistenceService : INamsPersistenceService
         catch (NamsOperationException ex) when (ex.FailureKind is NamsFailureKind.Network or NamsFailureKind.Timeout)
         {
             _logger.LogWarning(ex, "NAMS message persistence for conversation {ConversationId} timed out or lost network connectivity; write outcome is unknown.", namsConversationId);
+            _metrics.UnknownWriteOutcomes.Add(1, NamsMetricTags.Operation("store_turn"));
             result = new NamsPersistenceResult
             {
                 Outcome = NamsPersistenceOutcome.UnknownWriteOutcome,

--- a/src/AgentMemory.Nams/Recall/NamsRecallService.cs
+++ b/src/AgentMemory.Nams/Recall/NamsRecallService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 
 namespace AgentMemory.Nams.Recall;
 
@@ -18,12 +19,15 @@ internal sealed class NamsRecallService : INamsRecallService
     private readonly INamsClient _namsClient;
     private readonly NamsRecallOptions _options;
     private readonly ILogger<NamsRecallService> _logger;
+    private readonly NamsMetrics _metrics;
 
-    public NamsRecallService(INamsClient namsClient, IOptions<NamsRecallOptions> options, ILogger<NamsRecallService> logger)
+    public NamsRecallService(
+        INamsClient namsClient, IOptions<NamsRecallOptions> options, ILogger<NamsRecallService> logger, NamsMetrics metrics)
     {
         _namsClient = namsClient;
         _options = options.Value;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task<NamsRecallResult> RecallAsync(string namsConversationId, string? queryText, CancellationToken cancellationToken)
@@ -80,11 +84,16 @@ internal sealed class NamsRecallService : INamsRecallService
 
         var deduplicated = items.DistinctBy(item => item.SourceId).ToList();
         var (budgeted, truncated) = ApplyCharacterBudget(deduplicated, _options.MaxTotalCharacters);
+        var isPartialOverall = isPartial || truncated;
+
+        _metrics.ContextItems.Record(budgeted.Count, NamsMetricTags.Operation("recall"));
+        if (isPartialOverall)
+            _metrics.ContextTruncated.Add(1, NamsMetricTags.Operation("recall"));
 
         return new NamsRecallResult
         {
             Items = budgeted,
-            IsPartial = isPartial || truncated,
+            IsPartial = isPartialOverall,
             Warnings = warnings
         };
     }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
@@ -43,6 +43,9 @@ public sealed class NamsConversationResolverTests
         public Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
             string query, string? type, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsConversationIdentity Identity(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsHealthCheckTests
+{
+    private sealed class FakeNamsClient : INamsClient
+    {
+        public Func<int, CancellationToken, Task<IReadOnlyList<NamsEntity>>>? OnListEntities { get; set; }
+
+        public Task<NamsConversation> CreateConversationAsync(
+            string? userId, IReadOnlyDictionary<string, string>? metadata, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsContext> GetContextAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsMessage>> AddMessagesAsync(
+            string conversationId, IReadOnlyList<NamsMessageInput> messages, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
+            string query, string? type, int limit, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return (OnListEntities ?? ((_, _) => Task.FromResult<IReadOnlyList<NamsEntity>>([])))(limit, cancellationToken);
+        }
+    }
+
+    private static NamsOptions ValidOptions() => new() { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = "nams_key" };
+
+    private static NamsHealthCheck CreateCheck(FakeNamsClient client, NamsOptions? options = null) =>
+        new(client, Options.Create(options ?? ValidOptions()));
+
+    [Fact]
+    public async Task CheckAsync_MissingApiKey_ReturnsUnhealthyWithoutCallingClient()
+    {
+        var client = new FakeNamsClient { OnListEntities = (_, _) => throw new InvalidOperationException("should not be called") };
+        var check = CreateCheck(client, new NamsOptions { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = null });
+
+        var result = await check.CheckAsync(CancellationToken.None);
+
+        result.Status.Should().Be(NamsHealthStatus.Unhealthy);
+        result.Latency.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_Success_ReturnsHealthy()
+    {
+        var client = new FakeNamsClient { OnListEntities = (_, _) => Task.FromResult<IReadOnlyList<NamsEntity>>([]) };
+        var check = CreateCheck(client);
+
+        var result = await check.CheckAsync(CancellationToken.None);
+
+        result.Status.Should().Be(NamsHealthStatus.Healthy);
+        result.Latency.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(nameof(NamsFailureKind.Authentication), NamsHealthStatus.Unhealthy)]
+    [InlineData(nameof(NamsFailureKind.Authorization), NamsHealthStatus.Unhealthy)]
+    [InlineData(nameof(NamsFailureKind.Network), NamsHealthStatus.Unhealthy)]
+    [InlineData(nameof(NamsFailureKind.Timeout), NamsHealthStatus.Unhealthy)]
+    [InlineData(nameof(NamsFailureKind.RateLimited), NamsHealthStatus.Degraded)]
+    public async Task CheckAsync_FailureKind_MapsToExpectedStatus(string failureKindName, NamsHealthStatus expected)
+    {
+        var failureKind = Enum.Parse<NamsFailureKind>(failureKindName);
+        var client = new FakeNamsClient
+        {
+            OnListEntities = (_, _) => throw new NamsOperationException(failureKind, "probe failed")
+        };
+        var check = CreateCheck(client);
+
+        var result = await check.CheckAsync(CancellationToken.None);
+
+        result.Status.Should().Be(expected);
+        result.Latency.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_CallerCancellation_PropagatesOperationCanceledException()
+    {
+        var client = new FakeNamsClient();
+        var check = CreateCheck(client);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => check.CheckAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsMetricTagsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsMetricTagsTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using FluentAssertions;
+using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsMetricTagsTests
+{
+    [Fact]
+    public void Operation_IncludesBackendAndOperation()
+    {
+        var tags = NamsMetricTags.Operation("get_context");
+
+        var dict = ToDictionary(tags);
+        dict["backend"].Should().Be("nams");
+        dict["operation"].Should().Be("get_context");
+        dict.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void OperationStatus_IncludesBackendOperationAndStatus()
+    {
+        var tags = NamsMetricTags.OperationStatus("store_turn", "succeeded");
+
+        var dict = ToDictionary(tags);
+        dict["backend"].Should().Be("nams");
+        dict["operation"].Should().Be("store_turn");
+        dict["status"].Should().Be("succeeded");
+        dict.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void OperationFailureKind_IncludesBackendOperationAndFailureKind()
+    {
+        var tags = NamsMetricTags.OperationFailureKind("search_entities", NamsFailureKind.RateLimited);
+
+        var dict = ToDictionary(tags);
+        dict["backend"].Should().Be("nams");
+        dict["operation"].Should().Be("search_entities");
+        dict["failure_kind"].Should().Be("RateLimited");
+        dict.Should().HaveCount(3);
+    }
+
+    private static Dictionary<string, object?> ToDictionary(TagList tags)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var tag in tags)
+            dict[tag.Key] = tag.Value;
+        return dict;
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsMetricsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsMetricsTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using AgentMemory.Nams.Observability;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+public sealed class NamsMetricsTests
+{
+    [Fact]
+    public void MeterName_IsAgentMemoryNams()
+    {
+        NamsMetrics.MeterName.Should().Be("AgentMemory.Nams");
+    }
+
+    [Fact]
+    public void Construction_DoesNotThrow()
+    {
+        var act = () => new NamsMetrics();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_AndIsIdempotent()
+    {
+        var metrics = new NamsMetrics();
+
+        var act = () => { metrics.Dispose(); metrics.Dispose(); };
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityCollection.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityCollection.cs
@@ -1,0 +1,11 @@
+namespace AgentMemory.Tests.Unit.Nams;
+
+/// <summary>
+/// Collection definition for every test that attaches a process-wide <see cref="System.Diagnostics.Metrics.MeterListener"/>
+/// filtered by <see cref="AgentMemory.Nams.Observability.NamsMetrics.MeterName"/>. Mirrors
+/// <c>AgentMemory.Tests.Unit.Observability.ObservabilityCollection</c>'s exact rationale: these tests share
+/// process-global OpenTelemetry state, so they must not run concurrently with each other, or one test's
+/// listener captures another's measurements.
+/// </summary>
+[CollectionDefinition("Nams Observability", DisableParallelization = true)]
+public sealed class NamsObservabilityCollection;

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
@@ -1,0 +1,262 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
+using AgentMemory.Nams.Persistence;
+using AgentMemory.Nams.Recall;
+
+namespace AgentMemory.Tests.Unit.Nams;
+
+/// <summary>
+/// Verifies NAMS backend operations actually record the Phase 9 metrics. Runs serialized (see
+/// <see cref="NamsObservabilityCollection"/>) since every test here attaches a process-wide
+/// <see cref="MeterListener"/> filtered by <see cref="NamsMetrics.MeterName"/>.
+/// </summary>
+[Collection("Nams Observability")]
+public sealed class NamsObservabilityTests
+{
+    private static HttpResponseMessage Json(HttpStatusCode statusCode, string json) =>
+        new(statusCode) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static Neo4jNamsClientAdapter CreateAdapter(FakeHttpMessageHandler fake, NamsMetrics metrics, int maxRetryAttempts = 2) =>
+        new(new HttpClient(fake) { BaseAddress = new Uri("https://nams.test/v1/") },
+            Options.Create(new NamsOptions
+            {
+                Endpoint = new Uri("https://nams.test/v1/"),
+                ApiKey = "nams_key",
+                MaxRetryAttempts = maxRetryAttempts,
+                InitialRetryDelay = TimeSpan.FromMilliseconds(1)
+            }),
+            NullLogger<Neo4jNamsClientAdapter>.Instance, metrics);
+
+    private static string? Tag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    {
+        foreach (var tag in tags)
+            if (tag.Key == key) return tag.Value?.ToString();
+        return null;
+    }
+
+    private static MeterListener StartListener(
+        Action<Instrument, long, ReadOnlySpan<KeyValuePair<string, object?>>>? onLong = null,
+        Action<Instrument, double, ReadOnlySpan<KeyValuePair<string, object?>>>? onDouble = null)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) => { if (instrument.Meter.Name == NamsMetrics.MeterName) l.EnableMeasurementEvents(instrument); }
+        };
+        if (onLong is not null)
+            listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => onLong(instrument, value, tags));
+        if (onDouble is not null)
+            listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => onDouble(instrument, value, tags));
+        listener.Start();
+        return listener;
+    }
+
+    [Fact]
+    public async Task GetContextAsync_Success_RecordsSucceededOperationAndDuration()
+    {
+        using var metrics = new NamsMetrics();
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """{"reflections":[],"observations":[],"recentMessages":[]}"""));
+        var adapter = CreateAdapter(fake, metrics);
+
+        var operations = new List<(string? Status, string? Operation)>();
+        double? duration = null;
+        using var listener = StartListener(
+            onLong: (i, value, tags) => { if (i.Name == "memory.backend.operations") operations.Add((Tag(tags, "status"), Tag(tags, "operation"))); },
+            onDouble: (i, value, _) => { if (i.Name == "memory.backend.duration") duration = value; });
+
+        await adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        operations.Should().ContainSingle(o => o.Status == "succeeded" && o.Operation == "get_context");
+        duration.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateConversationAsync_ServerError_RecordsFailedOperationAndFailureKind()
+    {
+        using var metrics = new NamsMetrics();
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var adapter = CreateAdapter(fake, metrics);
+
+        var failures = new List<(string? Operation, string? FailureKind)>();
+        using var listener = StartListener(onLong: (i, _, tags) =>
+        {
+            if (i.Name == "memory.backend.failures") failures.Add((Tag(tags, "operation"), Tag(tags, "failure_kind")));
+        });
+
+        var act = () => adapter.CreateConversationAsync("user-1", null, CancellationToken.None);
+        await act.Should().ThrowAsync<NamsOperationException>();
+
+        failures.Should().ContainSingle(f => f.Operation == "resolve_conversation" && f.FailureKind == nameof(NamsFailureKind.ServerError));
+    }
+
+    [Fact]
+    public async Task SearchEntitiesAsync_RateLimitedExhaustsRetries_RecordsRateLimited()
+    {
+        using var metrics = new NamsMetrics();
+        var fake = new FakeHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)));
+        var adapter = CreateAdapter(fake, metrics, maxRetryAttempts: 1);
+
+        var rateLimitedCount = 0L;
+        using var listener = StartListener(onLong: (i, value, _) =>
+        {
+            if (i.Name == "memory.backend.rate_limited") rateLimitedCount += value;
+        });
+
+        var act = () => adapter.SearchEntitiesAsync("acme", null, 10, CancellationToken.None);
+        await act.Should().ThrowAsync<NamsOperationException>();
+
+        rateLimitedCount.Should().Be(1); // one final classified outcome, not one per retried 429
+    }
+
+    [Fact]
+    public async Task GetContextAsync_TransientFailureThenSuccess_RecordsOneRetry()
+    {
+        using var metrics = new NamsMetrics();
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => Json(HttpStatusCode.OK, """{"reflections":[],"observations":[],"recentMessages":[]}"""));
+        var adapter = CreateAdapter(fake, metrics);
+
+        var retryCount = 0L;
+        using var listener = StartListener(onLong: (i, value, _) =>
+        {
+            if (i.Name == "memory.backend.retries") retryCount += value;
+        });
+
+        await adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        retryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetContextAsync_CallerCancellation_RecordsCancelledStatus_NotAFailure()
+    {
+        using var metrics = new NamsMetrics();
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));
+        var adapter = CreateAdapter(fake, metrics);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var operations = new List<string?>();
+        var failureCount = 0L;
+        using var listener = StartListener(onLong: (i, value, tags) =>
+        {
+            if (i.Name == "memory.backend.operations") operations.Add(Tag(tags, "status"));
+            if (i.Name == "memory.backend.failures") failureCount += value;
+        });
+
+        var act = () => adapter.GetContextAsync("conv-1", cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        operations.Should().ContainSingle(s => s == "cancelled");
+        failureCount.Should().Be(0, "cancellation must never be counted as a service failure");
+    }
+
+    [Fact]
+    public async Task RecallAsync_NoTruncation_RecordsItemCount_DoesNotRecordTruncated()
+    {
+        var namsClient = new StubNamsClient
+        {
+            Context = new NamsContext([], [], [new NamsMessage("m1", "hi", "user", null, "conv-1", 1.0, null)])
+        };
+        using var metrics = new NamsMetrics();
+        var service = new NamsRecallService(namsClient, Options.Create(new NamsRecallOptions { IncludeEntitySearch = false }),
+            NullLogger<NamsRecallService>.Instance, metrics);
+
+        long? itemCount = null;
+        var truncatedCount = 0L;
+        using var listener = StartListener(onLong: (i, value, tags) =>
+        {
+            if (i.Name == "memory.backend.context_items") itemCount = value;
+            if (i.Name == "memory.backend.context_truncated") truncatedCount += value;
+        });
+
+        await service.RecallAsync("conv-1", null, CancellationToken.None);
+
+        itemCount.Should().Be(1);
+        truncatedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecallAsync_BudgetTruncates_RecordsContextTruncated()
+    {
+        var namsClient = new StubNamsClient
+        {
+            Context = new NamsContext([], [],
+                [new NamsMessage("m1", "a much longer message than the tiny budget allows", "user", null, "conv-1", 1.0, null)])
+        };
+        using var metrics = new NamsMetrics();
+        var service = new NamsRecallService(
+            namsClient, Options.Create(new NamsRecallOptions { IncludeEntitySearch = false, MaxTotalCharacters = 1 }),
+            NullLogger<NamsRecallService>.Instance, metrics);
+
+        var truncatedCount = 0L;
+        using var listener = StartListener(onLong: (i, value, _) =>
+        {
+            if (i.Name == "memory.backend.context_truncated") truncatedCount += value;
+        });
+
+        await service.RecallAsync("conv-1", null, CancellationToken.None);
+
+        truncatedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PersistTurnAsync_NetworkFailure_RecordsUnknownWriteOutcome()
+    {
+        var namsClient = new StubNamsClient
+        {
+            OnAddMessages = _ => throw new NamsOperationException(NamsFailureKind.Network, "connection reset")
+        };
+        using var metrics = new NamsMetrics();
+        var service = new NamsPersistenceService(
+            namsClient,
+            Options.Create(new NamsOptions { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = "nams_key" }),
+            NullLogger<NamsPersistenceService>.Instance, metrics);
+
+        var unknownCount = 0L;
+        using var listener = StartListener(onLong: (i, value, _) =>
+        {
+            if (i.Name == "memory.backend.unknown_write_outcomes") unknownCount += value;
+        });
+
+        await service.PersistTurnAsync("conv-1", [new NamsMessageToPersist("hi")], [], CancellationToken.None);
+
+        unknownCount.Should().Be(1);
+    }
+
+    /// <summary>Minimal <see cref="INamsClient"/> stub shared by the recall/persistence metric tests above --
+    /// deliberately separate from the other test files' own fakes to avoid coupling this file's setup to
+    /// their unrelated test-specific configuration knobs.</summary>
+    private sealed class StubNamsClient : INamsClient
+    {
+        public NamsContext Context { get; set; } = new([], [], []);
+        public Func<IReadOnlyList<NamsMessageInput>, Task<IReadOnlyList<NamsMessage>>>? OnAddMessages { get; set; }
+
+        public Task<NamsConversation> CreateConversationAsync(
+            string? userId, IReadOnlyDictionary<string, string>? metadata, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsContext> GetContextAsync(string conversationId, CancellationToken cancellationToken) =>
+            Task.FromResult(Context);
+
+        public Task<IReadOnlyList<NamsMessage>> AddMessagesAsync(
+            string conversationId, IReadOnlyList<NamsMessageInput> messages, CancellationToken cancellationToken) =>
+            (OnAddMessages ?? (msgs => Task.FromResult<IReadOnlyList<NamsMessage>>(
+                msgs.Select((m, i) => new NamsMessage($"m{i}", m.Content, m.Role, null, conversationId, null, null)).ToList())))(messages);
+
+        public Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
+            string query, string? type, int limit, CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<NamsEntity>>([]);
+
+        public Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using AgentMemory.Nams;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 using AgentMemory.Nams.Persistence;
 
 namespace AgentMemory.Tests.Unit.Nams;
@@ -34,6 +35,9 @@ public sealed class NamsPersistenceServiceTests
         public Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
             string query, string? type, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsPersistenceService CreateService(
@@ -43,7 +47,7 @@ public sealed class NamsPersistenceServiceTests
             Endpoint = new Uri("https://nams.test/v1/"),
             ApiKey = "nams_key",
             PersistenceFailureMode = mode
-        }), NullLogger<NamsPersistenceService>.Instance);
+        }), NullLogger<NamsPersistenceService>.Instance, new NamsMetrics());
 
     [Fact]
     public async Task PersistTurnAsync_BothListsEmpty_ReturnsPersistedWithNoIds_DoesNotCallClient()
@@ -233,7 +237,7 @@ public sealed class NamsPersistenceServiceTests
         {
             Endpoint = new Uri("https://nams.test/v1/"),
             ApiKey = apiKey
-        }), NullLogger<NamsPersistenceService>.Instance);
+        }), NullLogger<NamsPersistenceService>.Instance, new NamsMetrics());
 
         var result = await service.PersistTurnAsync("conv-1", [new NamsMessageToPersist("hi")], [], CancellationToken.None);
 

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 using AgentMemory.Nams.Recall;
 
 namespace AgentMemory.Tests.Unit.Nams;
@@ -36,12 +37,15 @@ public sealed class NamsRecallServiceTests
             SearchEntitiesCallCount++;
             return (OnSearchEntities ?? ((_, _, _) => Task.FromResult<IReadOnlyList<NamsEntity>>([])))(query, limit, cancellationToken);
         }
+
+        public Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static readonly NamsContext EmptyContext = new([], [], []);
 
     private static NamsRecallService CreateService(FakeNamsClient client, NamsRecallOptions? options = null) =>
-        new(client, Options.Create(options ?? new NamsRecallOptions()), NullLogger<NamsRecallService>.Instance);
+        new(client, Options.Create(options ?? new NamsRecallOptions()), NullLogger<NamsRecallService>.Instance, new NamsMetrics());
 
     [Fact]
     public async Task RecallAsync_MapsReflectionsObservationsAndRecentMessages()

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
@@ -123,6 +123,38 @@ public sealed class NamsRetryPolicyTests
     }
 
     [Fact]
+    public async Task Idempotent_TransientServerErrorThenSuccess_InvokesOnRetryOnceForTheOneRetry()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+        var retryCount = 0;
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None,
+            onRetry: () => retryCount++);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        retryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PermanentFailure_NeverInvokesOnRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+        var retryCount = 0;
+
+        using var response = await CreatePolicy().ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None,
+            onRetry: () => retryCount++);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        retryCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task Idempotent_NetworkExceptionExhaustsRetries_Throws()
     {
         var fake = new FakeHttpMessageHandler((_, _) => throw new HttpRequestException("boom"));

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using AgentMemory.Nams;
 using AgentMemory.Nams.Client;
 using AgentMemory.Nams.Domain;
+using AgentMemory.Nams.Observability;
 
 namespace AgentMemory.Tests.Unit.Nams;
 
@@ -21,7 +22,7 @@ public sealed class Neo4jNamsClientAdapterTests
             MaxRetryAttempts = 2,
             InitialRetryDelay = TimeSpan.FromMilliseconds(1)
         });
-        return new Neo4jNamsClientAdapter(httpClient, options, NullLogger<Neo4jNamsClientAdapter>.Instance);
+        return new Neo4jNamsClientAdapter(httpClient, options, NullLogger<Neo4jNamsClientAdapter>.Instance, new NamsMetrics());
     }
 
     private static HttpResponseMessage Json(HttpStatusCode statusCode, string json) =>
@@ -132,6 +133,20 @@ public sealed class Neo4jNamsClientAdapterTests
 
         entities.Single().Name.Should().Be("Acme");
         fake.Requests.Should().HaveCount(2); // search is a read despite the POST verb -- retries like other reads
+    }
+
+    [Fact]
+    public async Task ListEntitiesAsync_Success_DeserializesEntities_NoQueryInRequest()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK,
+            """{"entities":[{"id":"e1","name":"Acme"}]}"""));
+        var adapter = CreateAdapter(fake);
+
+        var entities = await adapter.ListEntitiesAsync(1, CancellationToken.None);
+
+        entities.Single().Name.Should().Be("Acme");
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Get);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/entities?limit=1"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Instruments the NAMS backend with spans/metrics matching the engineering plan's own naming: `memory.backend.operations`/`.duration`/`.failures`/`.retries`/`.rate_limited`/`.unknown_write_outcomes`/`.context_items`/`.context_truncated`. Uses BCL diagnostics (`ActivitySource`/`Meter`) directly rather than depending on `AgentMemory.Observability` -- keeps `AgentMemory.Nams` at zero sibling references (B9).
- Adds a framework-agnostic `INamsHealthCheck` distinguishing `Unhealthy` from `Degraded` (rate-limited), backed by a new `INamsClient.ListEntitiesAsync` (`GET /v1/entities`, confirmed live) -- the one safe, side-effect-free, no-precondition read this client can use as a connectivity probe (`SearchEntitiesAsync` needs a non-empty query -- confirmed live it 400s on empty -- and `GetContextAsync` needs an existing conversation).
- Cancellation is never counted as a service failure, per the plan's own test list.
- Reviewed every log call site in `AgentMemory.Nams`/`AgentMemory.AgentFramework.Nams` for secret/PII/content leakage: clean by design (only IDs and already-redacted exceptions), no changes needed.
- Explicitly out of scope: data-governance verification (needs live testing / org decisions) and the direct-Neo4j-focused `docs/security/production-checklist.md` (NAMS isn't released yet -- premature to graft onto it now).

Full write-up: `docs/reviews/NAMS_Phase9_Observability_PlanningAndImplementationPlan.md`.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3234+ green (Nams: 189, ~30 net new)
- [x] Re-ran the 3 live NAMS integration tests against the real SaaS after wiring `NamsMetrics` through DI -- still 3/3 green
- [x] Self-reviewed (3 parallel agents: correctness, cross-file impact, cleanup/conventions) -- 0 correctness/cross-file findings; 1 minor, deliberate convention divergence noted (a centralized `NamsMetricTags` helper vs. the sibling package's inline tag arrays -- judged a reasonable improvement, kept as-is)
- [x] CI green (no Copilot review per standing instruction)