### PR TITLE
NAMS Phase 10: expand live scenario coverage (concurrency, cancellation, Unicode)

### DIFF
--- a/docs/reviews/NAMS_Phase10_LiveScenarioExpansion_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10_LiveScenarioExpansion_PlanningAndImplementationPlan.md
@@ -45,7 +45,36 @@ real NAMS SaaS (`agent-memory-dotnet-dev` workspace):
   MAF-layer mapping/gating logic (`NamsMafTypeMapper`, Phase 6), already unit-tested there; they're not
   live-NAMS-specific behavior to re-verify against the real service.
 
-## 3. Explicitly deferred
+## 3. Self-review findings and fixes
+
+Self-review (2 angles, given the smaller diff: correctness + combined cross-file/conventions) found the
+test *logic*, not just the code, needed tightening -- a live test passing once against an eventually
+consistent external service doesn't by itself prove the logic is sound:
+
+- **`ResolveAsync_SameIdentityResolvedConcurrently_...`**: traced the actual execution and confirmed this
+  single-process test can only ever exercise `KeyedAsyncLock` serialization + the already-populated-store
+  fast path -- it structurally cannot reach the cross-process "lost the race, reconcile an orphaned
+  conversation" branch (that needs two separate resolver instances racing a shared store, already listed
+  under "Multi-instance mapping" in §3). Renamed `...ReconcilesToOneConversation` ->
+  `...SerializesToOneConversation` and added a doc comment stating exactly what this does and doesn't prove.
+- **Cross-contamination test**: `NamsRecallOptions.IncludeEntitySearch` defaults `true` and wasn't
+  overridden, so the original assertion checked ALL recalled items -- including entities, which are
+  workspace-wide, not conversation-scoped (per the `NamsAgent` sample's own README). That made the test's
+  actual scope wider than its documented intent and a source of unrelated flakiness. Fixed to filter to
+  `NamsRecallCategory.RecentMessage` only, matching the documented scope exactly. Renamed to
+  `...EventuallyRecallOnlyTheirOwnRecentMessage` (also fixes a naming-convention gap the other review angle
+  found: new eventually-consistent tests should say "Eventually", matching the file's existing two).
+- **Unicode round-trip test**: "byte-for-byte" was only actually guaranteed for the `RecentMessage` tier
+  (`NamsRecallService.MapMessage` passes `Content` through verbatim); reflections/observations are
+  NAMS-synthesized text with no such guarantee. Fixed the match condition to require
+  `Category == NamsRecallCategory.RecentMessage`, making the claim proven rather than probabilistic.
+  Renamed to `...EventuallyRoundTripsByteForByteInRecentMessages`.
+- **Cancellation test**: added a one-line comment stating the `CancelAfter(1ms)` timing is an environment
+  assumption (this session's observed 400-1000ms live NAMS latency), not a language/runtime guarantee.
+
+Re-ran all 7 live tests after the fixes: still 7/7 green, ~7s.
+
+## 4. Explicitly deferred
 
 - **Multi-instance mapping** (separate resolver processes, crash reconciliation) -- needs actual
   multi-process orchestration, a bigger investment than fits this increment.
@@ -58,7 +87,7 @@ real NAMS SaaS (`agent-memory-dotnet-dev` workspace):
 - **Payload: empty / max size / multi-message / non-text** -- Unicode was judged the highest-value single
   addition for this pass; the rest are reasonable follow-ups, not done here.
 
-## 4. Verification
+## 5. Verification
 
 - `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors.
 - `dotnet test tests/AgentMemory.Tests.Integration --filter "FullyQualifiedName~Nams.NamsLiveConnectivityTests"`
@@ -66,8 +95,9 @@ real NAMS SaaS (`agent-memory-dotnet-dev` workspace):
 - `dotnet test tests/AgentMemory.Tests.Unit` -- full suite green, unaffected (no unit-level changes this
   phase).
 
-## 5. Definition of done
+## 6. Definition of done
 
 - [x] 4 new live scenarios added and passing against the real NAMS SaaS.
 - [x] Coverage overlap and deferred scope explicitly documented (no silent gaps).
-- [ ] Self-reviewed, PR opened, CI green (live tests report Skipped there, as established), merged to `main`.
+- [x] Self-reviewed and fixes applied.
+- [ ] PR opened, CI green (live tests report Skipped there, as established), merged to `main`.

--- a/docs/reviews/NAMS_Phase10_LiveScenarioExpansion_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10_LiveScenarioExpansion_PlanningAndImplementationPlan.md
@@ -1,0 +1,73 @@
+# NAMS Phase 10 — Live Scenario Expansion — Planning and Implementation Plan
+
+**Prepared:** 2026-07-17
+**Branch:** `nams/phase10-expansion`
+**Purpose:** Expands live-integration coverage from the earlier live-validation branch's 3 scenarios toward
+the engineering plan's own "mandatory scenario matrix" (§7 Phase 10). Not an attempt at all 18 matrix areas
+in one PR -- see §2 for what's covered elsewhere already, and §3 for what's explicitly deferred.
+
+## 1. What this adds
+
+4 new tests in `tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs`, all run against the
+real NAMS SaaS (`agent-memory-dotnet-dev` workspace):
+
+- **`ResolveAsync_SameIdentityResolvedConcurrently_ReconcilesToOneConversation`** (matrix: Conversation ->
+  concurrent create) -- resolves the SAME identity twice concurrently; asserts both calls agree on one
+  conversation ID and exactly one of the two actually created it. Phase 3's `KeyedAsyncLock` reconciliation
+  was unit-tested against a fake client; this is the first time it's proven against the real API's actual
+  concurrent-create race behavior.
+- **`PersistTurnAsync_TwoConcurrentUsers_DoNotCrossContaminateChatHistory`** (matrix: Concurrency -> parallel
+  turns, different users) -- two different identities' conversations, persisted concurrently, each recalling
+  only its own marker text, never the other's. Deliberately scoped to the **chat-history/recent-message
+  tier** (conversation-scoped), not entity extraction -- the `AgentMemory.Sample.NamsAgent` README already
+  documents that NAMS's entity search is workspace-wide, not conversation-scoped, as a separate, known
+  characteristic; this test doesn't re-litigate that, it confirms the tier that IS properly isolated.
+- **`RecallAsync_CancelledBeforeTheHttpRoundTripCompletes_PropagatesOperationCanceledException`** (matrix:
+  Cancellation -> during request) -- cancels 1ms after issuing a live recall call; confirms cancellation
+  propagates as `OperationCanceledException` against the real service, not just the fake-handler-backed unit
+  tests.
+- **`PersistTurnAsync_UnicodeAndEmojiContent_RoundTripsByteForByte`** (matrix: Payload -> Unicode) --
+  persists Japanese text + an emoji + accented characters, confirms it recalls back byte-for-byte.
+
+## 2. Already covered elsewhere (not duplicated here)
+
+- **Identity** (missing/valid), **Conversation** (create/reuse), **Recall** (empty/normal), **Persistence**
+  (success) -- the original 3 live tests (this session's earlier live-validation branch).
+- **Service failure** (401/403/404/429/500/502, malformed JSON) -- `NamsClientExceptionMapperTests.cs`,
+  already comprehensive via HTTP-simulation (a real network call can't deterministically produce a 500 from
+  the live service on demand; simulation is the correct tool here, not live).
+- **Rate limit** (retry, `Retry-After`), **Cancellation** (before request, during retry delay) --
+  `NamsRetryPolicyTests.cs`, HTTP-simulation.
+- **Observability** (expected metrics, no secrets/PII) -- Phase 9, just merged.
+- **Eventual consistency** (immediate absence, bounded poll, completion) -- the original 3 live tests'
+  bounded-poll pattern, now also exercised implicitly by this PR's new tests.
+- **Security** (prompt injection, delimiter forgery, wrong user/workspace) -- these are properties of the
+  MAF-layer mapping/gating logic (`NamsMafTypeMapper`, Phase 6), already unit-tested there; they're not
+  live-NAMS-specific behavior to re-verify against the real service.
+
+## 3. Explicitly deferred
+
+- **Multi-instance mapping** (separate resolver processes, crash reconciliation) -- needs actual
+  multi-process orchestration, a bigger investment than fits this increment.
+- **Session restore as an asserted integration test** (vs. the `NamsAgent` sample's informal demonstration)
+  -- real value, but a distinct piece of work (building a live MAF-agent test harness), left for later.
+- **DNS/TLS failure simulation** -- not practically triggerable against a real external service on demand.
+- **MCP separation, Tools** -- N/A, Phase 8 not built yet (next in this session's queue).
+- **Data lifecycle** (conversation deletion, export) -- needs live testing of destructive operations and/or
+  an organizational decision; `INamsClient` doesn't even expose a delete operation yet.
+- **Payload: empty / max size / multi-message / non-text** -- Unicode was judged the highest-value single
+  addition for this pass; the rest are reasonable follow-ups, not done here.
+
+## 4. Verification
+
+- `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors.
+- `dotnet test tests/AgentMemory.Tests.Integration --filter "FullyQualifiedName~Nams.NamsLiveConnectivityTests"`
+  -- **7/7 live, ~7s total** (3 original + 4 new).
+- `dotnet test tests/AgentMemory.Tests.Unit` -- full suite green, unaffected (no unit-level changes this
+  phase).
+
+## 5. Definition of done
+
+- [x] 4 new live scenarios added and passing against the real NAMS SaaS.
+- [x] Coverage overlap and deferred scope explicitly documented (no silent gaps).
+- [ ] Self-reviewed, PR opened, CI green (live tests report Skipped there, as established), merged to `main`.

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
@@ -98,8 +98,16 @@ public sealed class NamsLiveConnectivityTests
         found.Should().BeTrue($"an entity named '{entityName}' should eventually be extracted and recallable");
     }
 
+    /// <summary>
+    /// Proves the single-process path only: the shared <c>KeyedAsyncLock</c> serializes the second call
+    /// behind the first, which then takes the already-populated-store fast path -- it never reaches
+    /// <c>CreateConversationAsync</c> itself. This does NOT exercise the cross-process "lost the race,
+    /// reconcile an orphaned conversation" branch (that needs two separate resolver instances/processes
+    /// racing against a genuinely shared store -- out of scope here, see the Phase 10 planning doc's
+    /// "Multi-instance mapping" deferral).
+    /// </summary>
     [LiveNamsFact]
-    public async Task ResolveAsync_SameIdentityResolvedConcurrently_ReconcilesToOneConversation()
+    public async Task ResolveAsync_SameIdentityResolvedConcurrently_SerializesToOneConversation()
     {
         var resolver = _fixture.Services!.GetRequiredService<INamsConversationResolver>();
         var identity = UniqueIdentity(); // one identity, resolved twice concurrently below
@@ -114,8 +122,14 @@ public sealed class NamsLiveConnectivityTests
             "exactly one of the two concurrent resolutions should have actually created the conversation");
     }
 
+    /// <summary>
+    /// Deliberately scoped to the <see cref="NamsRecallCategory.RecentMessage"/> tier only (conversation-
+    /// scoped) -- NAMS entity search is workspace-wide, not conversation-scoped (documented in
+    /// <c>AgentMemory.Sample.NamsAgent</c>'s README), so including entity-tier items here would make this
+    /// test noisy/flaky for a reason unrelated to what it's actually verifying.
+    /// </summary>
     [LiveNamsFact]
-    public async Task PersistTurnAsync_TwoConcurrentUsers_DoNotCrossContaminateChatHistory()
+    public async Task PersistTurnAsync_TwoConcurrentUsers_EventuallyRecallOnlyTheirOwnRecentMessage()
     {
         var services = _fixture.Services!;
         var resolver = services.GetRequiredService<INamsConversationResolver>();
@@ -139,16 +153,18 @@ public sealed class NamsLiveConnectivityTests
             {
                 var recalledA = await recall.RecallAsync(conversationA.NamsConversationId, markerA, CancellationToken.None);
                 var recalledB = await recall.RecallAsync(conversationB.NamsConversationId, markerB, CancellationToken.None);
-                var aHasOwnMarker = recalledA.Items.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
-                var bHasOwnMarker = recalledB.Items.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal));
+                var recentA = recalledA.Items.Where(i => i.Category == NamsRecallCategory.RecentMessage).ToList();
+                var recentB = recalledB.Items.Where(i => i.Category == NamsRecallCategory.RecentMessage).ToList();
+                var aHasOwnMarker = recentA.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
+                var bHasOwnMarker = recentB.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal));
                 var noCrossContamination =
-                    !recalledA.Items.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal))
-                    && !recalledB.Items.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
+                    !recentA.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal))
+                    && !recentB.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
                 return aHasOwnMarker && bHasOwnMarker && noCrossContamination;
             },
             timeout: TimeSpan.FromSeconds(30));
 
-        found.Should().BeTrue("each conversation's recall should see only its own persisted message, never the other's");
+        found.Should().BeTrue("each conversation's recent-message tier should show only its own persisted message, never the other's");
     }
 
     [LiveNamsFact]
@@ -160,15 +176,25 @@ public sealed class NamsLiveConnectivityTests
         var conversation = await resolver.ResolveAsync(UniqueIdentity(), CancellationToken.None);
 
         using var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMilliseconds(1)); // a live round trip to NAMS never completes this fast
+        // Environment assumption, not a language/runtime guarantee: this session's observed live NAMS
+        // latency is consistently 400-1000ms, so 1ms reliably cancels first. If NAMS round-trips ever get
+        // fast enough to race this, this test (not the production code) would need a longer delay.
+        cts.CancelAfter(TimeSpan.FromMilliseconds(1));
 
         var act = () => recall.RecallAsync(conversation.NamsConversationId, "test", cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    /// <summary>
+    /// Matches only <see cref="NamsRecallCategory.RecentMessage"/> items -- <see cref="MapMessage"/>-mapped
+    /// (in <c>NamsRecallService</c>) recent messages pass <c>Content</c> through verbatim, so a match there
+    /// genuinely proves a byte-for-byte round trip. Reflections/observations are NAMS-synthesized text, not
+    /// guaranteed to preserve the original bytes -- matching against those tiers too would make "byte for
+    /// byte" a probabilistic claim rather than a proven one.
+    /// </summary>
     [LiveNamsFact]
-    public async Task PersistTurnAsync_UnicodeAndEmojiContent_RoundTripsByteForByte()
+    public async Task PersistTurnAsync_UnicodeAndEmojiContent_EventuallyRoundTripsByteForByteInRecentMessages()
     {
         var services = _fixture.Services!;
         var resolver = services.GetRequiredService<INamsConversationResolver>();
@@ -184,11 +210,12 @@ public sealed class NamsLiveConnectivityTests
             async () =>
             {
                 var recalled = await recall.RecallAsync(conversation.NamsConversationId, marker, CancellationToken.None);
-                return recalled.Items.Any(i => i.Content.Contains(marker, StringComparison.Ordinal));
+                return recalled.Items.Any(i =>
+                    i.Category == NamsRecallCategory.RecentMessage && i.Content.Contains(marker, StringComparison.Ordinal));
             },
             timeout: TimeSpan.FromSeconds(30));
 
-        found.Should().BeTrue("Unicode/emoji content should round-trip through NAMS byte-for-byte");
+        found.Should().BeTrue("Unicode/emoji content should round-trip through NAMS byte-for-byte in the recent-messages tier");
     }
 
     private static NamsConversationIdentity UniqueIdentity([CallerMemberName] string testName = "") => new()

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
@@ -98,6 +98,99 @@ public sealed class NamsLiveConnectivityTests
         found.Should().BeTrue($"an entity named '{entityName}' should eventually be extracted and recallable");
     }
 
+    [LiveNamsFact]
+    public async Task ResolveAsync_SameIdentityResolvedConcurrently_ReconcilesToOneConversation()
+    {
+        var resolver = _fixture.Services!.GetRequiredService<INamsConversationResolver>();
+        var identity = UniqueIdentity(); // one identity, resolved twice concurrently below
+
+        var task1 = resolver.ResolveAsync(identity, CancellationToken.None);
+        var task2 = resolver.ResolveAsync(identity, CancellationToken.None);
+        var results = await Task.WhenAll(task1, task2);
+
+        results[0].NamsConversationId.Should().Be(results[1].NamsConversationId,
+            "both resolutions are for the same identity -- they must agree on one conversation");
+        results.Count(r => r.WasCreated).Should().Be(1,
+            "exactly one of the two concurrent resolutions should have actually created the conversation");
+    }
+
+    [LiveNamsFact]
+    public async Task PersistTurnAsync_TwoConcurrentUsers_DoNotCrossContaminateChatHistory()
+    {
+        var services = _fixture.Services!;
+        var resolver = services.GetRequiredService<INamsConversationResolver>();
+        var persistence = services.GetRequiredService<INamsPersistenceService>();
+        var recall = services.GetRequiredService<INamsRecallService>();
+
+        var resolveTaskA = resolver.ResolveAsync(UniqueIdentity(), CancellationToken.None);
+        var resolveTaskB = resolver.ResolveAsync(UniqueIdentity(), CancellationToken.None);
+        await Task.WhenAll(resolveTaskA, resolveTaskB);
+        var conversationA = await resolveTaskA;
+        var conversationB = await resolveTaskB;
+
+        var markerA = $"Concurrency test A {Guid.NewGuid():N}";
+        var markerB = $"Concurrency test B {Guid.NewGuid():N}";
+        await Task.WhenAll(
+            persistence.PersistTurnAsync(conversationA.NamsConversationId, [new NamsMessageToPersist(markerA)], [], CancellationToken.None),
+            persistence.PersistTurnAsync(conversationB.NamsConversationId, [new NamsMessageToPersist(markerB)], [], CancellationToken.None));
+
+        var found = await PollUntilAsync(
+            async () =>
+            {
+                var recalledA = await recall.RecallAsync(conversationA.NamsConversationId, markerA, CancellationToken.None);
+                var recalledB = await recall.RecallAsync(conversationB.NamsConversationId, markerB, CancellationToken.None);
+                var aHasOwnMarker = recalledA.Items.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
+                var bHasOwnMarker = recalledB.Items.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal));
+                var noCrossContamination =
+                    !recalledA.Items.Any(i => i.Content.Contains(markerB, StringComparison.Ordinal))
+                    && !recalledB.Items.Any(i => i.Content.Contains(markerA, StringComparison.Ordinal));
+                return aHasOwnMarker && bHasOwnMarker && noCrossContamination;
+            },
+            timeout: TimeSpan.FromSeconds(30));
+
+        found.Should().BeTrue("each conversation's recall should see only its own persisted message, never the other's");
+    }
+
+    [LiveNamsFact]
+    public async Task RecallAsync_CancelledBeforeTheHttpRoundTripCompletes_PropagatesOperationCanceledException()
+    {
+        var services = _fixture.Services!;
+        var resolver = services.GetRequiredService<INamsConversationResolver>();
+        var recall = services.GetRequiredService<INamsRecallService>();
+        var conversation = await resolver.ResolveAsync(UniqueIdentity(), CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(1)); // a live round trip to NAMS never completes this fast
+
+        var act = () => recall.RecallAsync(conversation.NamsConversationId, "test", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [LiveNamsFact]
+    public async Task PersistTurnAsync_UnicodeAndEmojiContent_RoundTripsByteForByte()
+    {
+        var services = _fixture.Services!;
+        var resolver = services.GetRequiredService<INamsConversationResolver>();
+        var persistence = services.GetRequiredService<INamsPersistenceService>();
+        var recall = services.GetRequiredService<INamsRecallService>();
+        var conversation = await resolver.ResolveAsync(UniqueIdentity(), CancellationToken.None);
+
+        var marker = $"Unicode test {Guid.NewGuid():N}: 日本語のテスト 🎉 émoji café";
+        await persistence.PersistTurnAsync(
+            conversation.NamsConversationId, userMessages: [new NamsMessageToPersist(marker)], assistantMessages: [], CancellationToken.None);
+
+        var found = await PollUntilAsync(
+            async () =>
+            {
+                var recalled = await recall.RecallAsync(conversation.NamsConversationId, marker, CancellationToken.None);
+                return recalled.Items.Any(i => i.Content.Contains(marker, StringComparison.Ordinal));
+            },
+            timeout: TimeSpan.FromSeconds(30));
+
+        found.Should().BeTrue("Unicode/emoji content should round-trip through NAMS byte-for-byte");
+    }
+
     private static NamsConversationIdentity UniqueIdentity([CallerMemberName] string testName = "") => new()
     {
         ApplicationId = "agent-memory-dotnet-live-tests",


### PR DESCRIPTION
## Summary
Adds 4 live-integration tests to `NamsLiveConnectivityTests.cs`, run against the real NAMS SaaS:
- Concurrent resolution of the same identity serializes to one conversation (proven scope: single-process `KeyedAsyncLock` reconciliation; cross-process orphan reconciliation is explicitly out of scope, see the planning doc).
- Two concurrent different users don't cross-contaminate the `RecentMessage` recall tier.
- Live mid-request cancellation propagates `OperationCanceledException`.
- Unicode/emoji content round-trips byte-for-byte in the `RecentMessage` tier.

Documents which of the plan's mandatory scenario-matrix areas are already covered elsewhere (HTTP-simulation for service-failure/rate-limit, Phase 9 for observability) versus explicitly deferred (multi-instance mapping, data lifecycle, DNS/TLS simulation, session-restore-as-assertion).

Self-review (2 angles: correctness/test-soundness + combined cross-file/conventions) found the test *logic*, not just the code, needed tightening -- full details and fixes in `docs/reviews/NAMS_Phase10_LiveScenarioExpansion_PlanningAndImplementationPlan.md` §3:
- The concurrency test's name/claim was narrowed to what it actually proves (traced the real execution path).
- The cross-contamination and Unicode tests were scoped to the `RecentMessage` tier specifically, since NAMS entity search is workspace-wide (not conversation-scoped) and was making both tests' claims broader than justified.
- Naming brought in line with the file's existing "Eventually..." convention.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3234 green, unaffected
- [x] Live suite: 7/7 green (~7s) against the real NAMS SaaS, both before and after the self-review fixes
- [x] Self-reviewed (2 parallel agents) -- findings applied, re-verified live afterward
- [x] CI green (no Copilot review per standing instruction)