### PR TITLE
NAMS Phase 10d: session-restore asserted live test

### DIFF
--- a/docs/reviews/NAMS_Phase10d_SessionRestoreTest_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10d_SessionRestoreTest_PlanningAndImplementationPlan.md
@@ -1,0 +1,106 @@
+# NAMS Phase 10d — Session-Restore Asserted Live Test — Planning and Implementation Plan
+
+**Prepared:** 2026-07-18
+**Branch:** `nams/phase10d-session-restore-test`
+**Purpose:** Fourth of five follow-up Phase 10 increments (10a-10d + TCK Platinum research).
+
+## 1. What this formalizes
+
+`AgentMemory.Sample.NamsAgent`'s console demo shows session serialize/restore working (step 2 of its script:
+`SerializeSessionAsync` → `DeserializeSessionAsync` → re-apply `.WithMemoryIdentity(...)` → the agent still
+answers "what did I tell you?" correctly) -- but only as printed console output a human has to eyeball. No
+asserted test exercised this. This phase builds a minimal, real (not scripted-stub) MAF-agent harness and
+turns it into two asserted live tests.
+
+## 2. Design decisions
+
+**Real `ChatClientAgent`, stubbed model only.** Unlike `MemoryOwnerScopingAgentIntegrationTests`'
+`ScriptedInnerAgent` (whose `SerializeSessionCoreAsync`/`DeserializeSessionCoreAsync` are trivial stubs
+returning `default(JsonElement)`), this phase needs MAF's REAL session-serialization machinery, since that is
+exactly what's under test. So: a real `ChatClientAgent` built via `stubChatClient.AsAIAgent(...)` (matching
+the sample exactly), with only the model call stubbed via an NSubstitute `IChatClient` returning a canned
+response -- no real LLM dependency, but genuine `SerializeSessionAsync`/`DeserializeSessionAsync` behavior.
+
+**DI setup extended, not duplicated.** `NamsLiveFixture` previously only wired `AddNamsAgentMemory`. Added
+`AddAgentMemoryFramework()` + `AddNamsAgentMemoryFramework()` (purely additive registrations -- new
+`AgentFrameworkOptions`/`ContextFormatOptions` options plus a new scoped `NamsMemoryContextProvider` -- no
+change to anything the other 15 NAMS live tests already resolve) rather than standing up a second, duplicate
+DI container inside this new test file. Also added the `Microsoft.Agents.AI` package reference (the concrete
+package with `ChatClientAgent`/`AsAIAgent`, vs. the `.Abstractions`-only reference the project already had)
+and a project reference to `AgentMemory.AgentFramework.Nams`.
+
+**Empirically probed MAF's real serialized-session JSON before writing any assertion** (per this whole Phase
+10 push's discipline). A throwaway test dumped `(await agent.SerializeSessionAsync(session)).GetRawText()`
+after calling `.WithMemoryIdentity(...)` and running one turn:
+
+```
+{"stateBag":{"user_id":"...","conversation_id":"...","InMemoryChatHistoryProvider":{"messages":[...]},
+"application_id":"...","session_id":"..."}}
+```
+
+Two things this revealed, both shaping the final test design:
+
+1. **The memory-identity state bag (`user_id`/`session_id`/`conversation_id`/`application_id`) is already
+   embedded in `ChatClientAgent`'s own serialized JSON.** This means the sample's re-application of
+   `.WithMemoryIdentity(...)` after `DeserializeSessionAsync` is likely defensive, not strictly load-bearing --
+   a genuinely surprising, non-obvious finding worth its own test (see Test 2 below) rather than just assuming
+   the sample's recipe is the only way it works.
+2. **`ChatClientAgent` also carries its OWN turn history** (`InMemoryChatHistoryProvider`) inside the same
+   state bag. This ruled out the originally-planned assertion strategy of inspecting the stub `IChatClient`'s
+   received messages for the pre-restore marker text: a restored session's next turn would include that
+   marker via MAF's own built-in history regardless of whether NAMS recall did anything, so finding it there
+   would prove nothing about NAMS specifically. A `<recalled_memory category="...">`-wrapper search (the
+   sample's own `MemoryTraceChatClient` approach) was considered and also ruled out: per
+   `NamsMafTypeMapper.ToContextMessages`, the `RecentMessage`/`RelevantMessage` categories a plain persisted
+   turn recalls under are deliberately left undelimited ("a recalled message renders as an individual
+   conversation turn, not an injected block"), so a plain marker message carries no distinguishing wrapper to
+   search for either.
+
+**Final assertion strategy: direct, live NAMS reads outside the agent pipeline.** Each test resolves the
+underlying `NamsConversationId` once (via `INamsConversationResolver`, from the same DI scope) purely to know
+which conversation to poll -- not as the thing being proven, since a second direct resolver call with the
+same identity values would trivially agree regardless of whether restore worked (the shared singleton
+`INamsConversationStateStore` already remembers the mapping from the first call). The actual proof is
+that content persisted through the RESTORED session's own real `agent.RunAsync(...)` call -- which internally
+extracts identity from the restored session's own post-deserialize state and persists through it -- lands in
+that SAME conversation, confirmed via a bounded `PollUntilAsync` against `INamsRecallService.RecallAsync`
+called independently of the agent pipeline.
+
+## 3. What was added
+
+New file `tests/AgentMemory.Tests.Integration/Nams/NamsSessionRestoreTests.cs`:
+
+- `SessionRestore_WithMemoryIdentityReapplied_ContinuesPersistingToTheSameNamsConversation` -- the documented
+  recipe: run a turn, serialize, deserialize, re-apply `.WithMemoryIdentity(...)` (matching the sample
+  exactly), run a second turn, and confirm (via direct NAMS recall) that it persisted to the same conversation
+  the first turn did.
+- `SessionRestore_WithoutReapplyingMemoryIdentity_StillPersistsToTheSameNamsConversation` -- identical, but
+  deliberately skips re-applying `.WithMemoryIdentity(...)` after restore, proving the empirically-discovered
+  finding above: the state bag survives `ChatClientAgent`'s own serialization on its own.
+
+Both also assert `restored.Should().NotBeSameAs(session, ...)` -- a basic sanity check that this is a genuine
+restore-from-JSON, not an accidentally-reused object reference.
+
+Modified: `NamsLiveFixture.cs` (added the two AgentFramework registrations, see §2), and
+`AgentMemory.Tests.Integration.csproj` (added the `Microsoft.Agents.AI` package reference and the
+`AgentMemory.AgentFramework.Nams` project reference).
+
+## 4. Verification
+
+- `dotnet build tests/AgentMemory.Tests.Integration -c Debug` -- clean.
+- `dotnet test tests/AgentMemory.Tests.Integration --filter "...NamsSessionRestoreTests"` -- **2/2 live**,
+  first try (including the "without reapplying identity" test, confirming the empirical finding), against the
+  real NAMS SaaS.
+- `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors.
+- `dotnet test tests/AgentMemory.Tests.Unit -c Release` -- full suite green, 3262/3262 (no new unit tests --
+  this phase is integration-only; the fixture/csproj changes are purely additive and touch no unit-tested code).
+- `dotnet test tests/AgentMemory.Tests.Integration --filter "FullyQualifiedName~Nams"` -- **17/17 live** (15
+  previous + 2 new), against the real NAMS SaaS.
+
+## 5. Definition of done
+
+- [x] Two new live tests proving session identity (and the underlying NAMS conversation it maps to) survives
+  `SerializeSessionAsync`/`DeserializeSessionAsync`, both with and without re-applying `.WithMemoryIdentity`.
+- [x] Full unit + live suites green.
+- [ ] Self-reviewed via parallel fork agents.
+- [ ] PR opened, CI green, merged to `main`.

--- a/docs/reviews/NAMS_Phase10d_SessionRestoreTest_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10d_SessionRestoreTest_PlanningAndImplementationPlan.md
@@ -85,7 +85,49 @@ Modified: `NamsLiveFixture.cs` (added the two AgentFramework registrations, see 
 `AgentMemory.Tests.Integration.csproj` (added the `Microsoft.Agents.AI` package reference and the
 `AgentMemory.AgentFramework.Nams` project reference).
 
-## 4. Verification
+## 4. Self-review findings and fixes
+
+2 parallel reviewers (correctness/test-soundness, cross-file/conventions).
+
+**Correctness reviewer found one HIGH finding, fixed:** `SessionRestore_WithMemoryIdentityReapplied_...`
+re-applied `.WithMemoryIdentity(...)` after restore using the SAME closed-over identity values the test had
+already used before serialization. Since that call unconditionally overwrites the state bag, the second
+turn's persistence target was fully determined by the test's own known values, not by anything the JSON
+round-trip actually preserved -- reintroducing, one layer down (`WithMemoryIdentity → ExtractIds →
+ResolveAsync`), exactly the "second direct resolver call with the same identity, which would trivially agree
+regardless of whether restore worked" triviality this file's own doc comment says the design avoids. Only the
+second test (which never re-applies) was actually non-vacuous as originally written. Fixed by reading the
+restored session's identity back via the same public `GetMemoryIdentity()` extension the production code
+itself uses, and asserting it already matches BEFORE re-applying `WithMemoryIdentity` -- this reads what
+restore actually produced, independent of the known values, making the "state survived" claim genuine. The
+re-apply step (matching the sample's recipe) still follows afterward, so the test now proves both things: the
+state bag itself survived, and the documented recipe subsequently works end-to-end.
+
+A second, lower-severity point (both pre- and post-restore turns share one `agent`/`ChatClientAgent`
+instance, so a hypothetical bug that dropped only `SessionId`/`ConversationId` while `UserId` survived could
+hide behind `ExtractIds`'s `agent.Id` fallback) was noted as a narrow residual seam, not required to fix: all
+four state-bag keys share one read/write code path, making that scenario very unlikely, and the new explicit
+`GetMemoryIdentity()` assertions in Test 1 already check all four fields independently.
+
+**Conventions reviewer found 3 low/medium findings, all fixed:**
+
+- **Missing orphan-tracing convention (Medium):** `UniqueIds()` didn't embed the calling test's name via
+  `[CallerMemberName]` the way `NamsLiveConnectivityTests.UniqueIdentity`/`NamsMultiInstanceMappingTests.UniqueIdentity`
+  do -- relevant here too, since these tests also never delete the NAMS-side conversations they create. Fixed
+  by replacing `UniqueIds()` with a `UniqueIdentity([CallerMemberName] string testName = "")` returning a
+  `NamsConversationIdentity` directly (see next point), matching the sibling convention exactly.
+- **`PollUntilAsync` duplicated verbatim** from `NamsLiveConnectivityTests.cs`. Extracted into a new shared
+  `NamsLiveTestHelpers.PollUntilAsync`; `NamsLiveConnectivityTests.cs` now forwards its own private
+  `PollUntilAsync` to the shared implementation (kept as a thin wrapper rather than rewriting that file's ~8
+  call sites, to keep this phase's blast radius on an already-merged, heavily-used file minimal).
+- **Minor redundancy:** `UniqueIds()` returned a raw 4-string tuple, so both tests separately reconstructed a
+  `NamsConversationIdentity` from it just to call the resolver. Fixed by having `UniqueIdentity()` return
+  `NamsConversationIdentity` directly; both tests now read `.UserId`/`.SessionId`/`.LocalConversationId`/
+  `.ApplicationId` off one object for both `WithMemoryIdentity` and `resolver.ResolveAsync`.
+
+Re-verified after all fixes: 17/17 live tests still green (including both session-restore tests).
+
+## 5. Verification
 
 - `dotnet build tests/AgentMemory.Tests.Integration -c Debug` -- clean.
 - `dotnet test tests/AgentMemory.Tests.Integration --filter "...NamsSessionRestoreTests"` -- **2/2 live**,
@@ -97,10 +139,10 @@ Modified: `NamsLiveFixture.cs` (added the two AgentFramework registrations, see 
 - `dotnet test tests/AgentMemory.Tests.Integration --filter "FullyQualifiedName~Nams"` -- **17/17 live** (15
   previous + 2 new), against the real NAMS SaaS.
 
-## 5. Definition of done
+## 6. Definition of done
 
 - [x] Two new live tests proving session identity (and the underlying NAMS conversation it maps to) survives
   `SerializeSessionAsync`/`DeserializeSessionAsync`, both with and without re-applying `.WithMemoryIdentity`.
 - [x] Full unit + live suites green.
-- [ ] Self-reviewed via parallel fork agents.
+- [x] Self-reviewed via 2 parallel independent reviewers; 1 HIGH + 3 low/medium findings, all fixed.
 - [ ] PR opened, CI green, merged to `main`.

--- a/tests/AgentMemory.Tests.Integration/AgentMemory.Tests.Integration.csproj
+++ b/tests/AgentMemory.Tests.Integration/AgentMemory.Tests.Integration.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.9.0" />
     <PackageReference Include="Microsoft.Agents.AI.Abstractions" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
@@ -34,6 +35,7 @@
     <ProjectReference Include="..\..\src\AgentMemory.Abstractions\AgentMemory.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\AgentMemory.McpServer\AgentMemory.McpServer.csproj" />
     <ProjectReference Include="..\..\src\AgentMemory.AgentFramework\AgentMemory.AgentFramework.csproj" />
+    <ProjectReference Include="..\..\src\AgentMemory.AgentFramework.Nams\AgentMemory.AgentFramework.Nams.csproj" />
     <ProjectReference Include="..\..\src\AgentMemory.Nams\AgentMemory.Nams.csproj" />
     <ProjectReference Include="..\..\tools\AgentMemory.TckBridge\AgentMemory.TckBridge.csproj" />
   </ItemGroup>

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsLiveConnectivityTests.cs
@@ -406,33 +406,6 @@ public sealed class NamsLiveConnectivityTests
         LocalConversationId = Guid.NewGuid().ToString("N")
     };
 
-    /// <summary>
-    /// Bounded poll helper -- never waits longer than <paramref name="timeout"/>. Swallows exceptions from
-    /// <paramref name="condition"/> itself (a live HTTP call can hit a transient blip mid-poll) and keeps
-    /// retrying within the remaining budget, matching <c>Neo4jIntegrationFixture.WaitForVectorIndexesAsync</c>'s
-    /// established pattern for this repo's other eventual-consistency polls.
-    /// </summary>
-    private static async Task<bool> PollUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
-    {
-        using var cts = new CancellationTokenSource(timeout);
-        while (!cts.IsCancellationRequested)
-        {
-            try
-            {
-                if (await condition())
-                    return true;
-            }
-            catch { /* transient failure against a live external service -- ignore and keep polling */ }
-
-            try
-            {
-                await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                return false;
-            }
-        }
-        return false;
-    }
+    private static Task<bool> PollUntilAsync(Func<Task<bool>> condition, TimeSpan timeout) =>
+        NamsLiveTestHelpers.PollUntilAsync(condition, timeout);
 }

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsLiveFixture.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsLiveFixture.cs
@@ -1,14 +1,18 @@
 using Microsoft.Extensions.DependencyInjection;
+using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Nams;
 using AgentMemory.Nams;
 
 namespace AgentMemory.Tests.Integration.Nams;
 
 /// <summary>
 /// Wires a real DI container against the live NAMS SaaS dev workspace, exactly as a consuming application
-/// would via <see cref="NamsServiceCollectionExtensions.AddNamsAgentMemory"/>. Never builds a provider when
-/// <see cref="NamsLiveCredentials.IsAvailable"/> is <see langword="false"/> -- individual tests skip
-/// themselves via <see cref="LiveNamsFactAttribute"/>, so construction here must never throw just because
-/// credentials are absent.
+/// would via <see cref="NamsServiceCollectionExtensions.AddNamsAgentMemory"/> (plus the MAF-facing
+/// <c>AddAgentMemoryFramework</c>/<c>AddNamsAgentMemoryFramework</c> layer, needed by any test that drives a
+/// real MAF agent -- e.g. Phase 10d's session-restore tests -- rather than calling the NAMS services
+/// directly). Never builds a provider when <see cref="NamsLiveCredentials.IsAvailable"/> is
+/// <see langword="false"/> -- individual tests skip themselves via <see cref="LiveNamsFactAttribute"/>, so
+/// construction here must never throw just because credentials are absent.
 /// </summary>
 public sealed class NamsLiveFixture : IAsyncLifetime
 {
@@ -30,6 +34,10 @@ public sealed class NamsLiveFixture : IAsyncLifetime
             o.ApiKey = NamsLiveCredentials.ApiKey;
             o.WorkspaceId = NamsLiveCredentials.WorkspaceId;
         });
+        // AddNamsAgentMemoryFramework's own documented precondition: AddAgentMemoryFramework() must be
+        // registered too (it owns ContextFormatOptions/AgentFrameworkOptions, which the NAMS provider reads).
+        services.AddAgentMemoryFramework();
+        services.AddNamsAgentMemoryFramework();
 
         _provider = services.BuildServiceProvider(validateScopes: true);
         return Task.CompletedTask;

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsLiveTestHelpers.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsLiveTestHelpers.cs
@@ -1,0 +1,37 @@
+namespace AgentMemory.Tests.Integration.Nams;
+
+/// <summary>
+/// Shared helpers for live-NAMS tests across this folder's several test classes.
+/// </summary>
+internal static class NamsLiveTestHelpers
+{
+    /// <summary>
+    /// Bounded poll helper -- never waits longer than <paramref name="timeout"/>. Swallows exceptions from
+    /// <paramref name="condition"/> itself (a live HTTP call can hit a transient blip mid-poll) and keeps
+    /// retrying within the remaining budget, matching <c>Neo4jIntegrationFixture.WaitForVectorIndexesAsync</c>'s
+    /// established pattern for this repo's other eventual-consistency polls.
+    /// </summary>
+    public static async Task<bool> PollUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!cts.IsCancellationRequested)
+        {
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch { /* transient failure against a live external service -- ignore and keep polling */ }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsSessionRestoreTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsSessionRestoreTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,20 +59,17 @@ public sealed class NamsSessionRestoreTests
         var resolver = sp.GetRequiredService<INamsConversationResolver>();
         var recall = sp.GetRequiredService<INamsRecallService>();
 
-        var (applicationId, userId, sessionId, conversationId) = UniqueIds();
+        var identity = UniqueIdentity();
         var agent = CreateStubbedAgent(memoryProvider);
 
-        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(
+            identity.UserId, identity.SessionId, identity.LocalConversationId, identity.ApplicationId);
         var markerBeforeRestore = $"before-restore-{Guid.NewGuid():N}";
         await agent.RunAsync(markerBeforeRestore, session);
 
-        var identity = new NamsConversationIdentity
-        {
-            ApplicationId = applicationId, UserId = userId, SessionId = sessionId, LocalConversationId = conversationId
-        };
         var namsConversationId = (await resolver.ResolveAsync(identity, CancellationToken.None)).NamsConversationId;
 
-        var indexedBeforeRestore = await PollUntilAsync(
+        var indexedBeforeRestore = await NamsLiveTestHelpers.PollUntilAsync(
             async () =>
             {
                 var recalled = await recall.RecallAsync(namsConversationId, markerBeforeRestore, CancellationToken.None);
@@ -81,13 +79,30 @@ public sealed class NamsSessionRestoreTests
         indexedBeforeRestore.Should().BeTrue("the pre-restore turn must actually be indexed before restore can meaningfully be proven to continue it");
 
         var serialized = await agent.SerializeSessionAsync(session);
-        var restored = (await agent.DeserializeSessionAsync(serialized)).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        var restored = await agent.DeserializeSessionAsync(serialized);
         restored.Should().NotBeSameAs(session, "this must be a genuine restore from serialized JSON, not the original in-memory session object");
+
+        // Prove the state bag itself survived BEFORE re-applying WithMemoryIdentity below -- re-stamping the
+        // exact values already used before serialization would trivially reproduce the same conversation
+        // regardless of whether restore preserved anything at all, which is exactly the triviality this
+        // type's own doc comment says the design avoids. Reading the identity back via the same public
+        // GetMemoryIdentity() the production code itself uses (AgentSessionMemoryExtensions) -- independent
+        // of the known values below -- is what makes this assertion non-vacuous.
+        var restoredIdentity = restored.GetMemoryIdentity();
+        restoredIdentity.UserId.Should().Be(identity.UserId);
+        restoredIdentity.SessionId.Should().Be(identity.SessionId);
+        restoredIdentity.ConversationId.Should().Be(identity.LocalConversationId);
+        restoredIdentity.ApplicationId.Should().Be(identity.ApplicationId);
+
+        // Now follow the NamsAgent sample's own documented recipe: re-apply WithMemoryIdentity after restore
+        // anyway (defensive, matches published guidance) and continue the conversation.
+        restored = restored.WithMemoryIdentity(
+            identity.UserId, identity.SessionId, identity.LocalConversationId, identity.ApplicationId);
 
         var markerAfterRestore = $"after-restore-{Guid.NewGuid():N}";
         await agent.RunAsync(markerAfterRestore, restored);
 
-        var indexedAfterRestore = await PollUntilAsync(
+        var indexedAfterRestore = await NamsLiveTestHelpers.PollUntilAsync(
             async () =>
             {
                 var recalled = await recall.RecallAsync(namsConversationId, markerAfterRestore, CancellationToken.None);
@@ -108,20 +123,17 @@ public sealed class NamsSessionRestoreTests
         var resolver = sp.GetRequiredService<INamsConversationResolver>();
         var recall = sp.GetRequiredService<INamsRecallService>();
 
-        var (applicationId, userId, sessionId, conversationId) = UniqueIds();
+        var identity = UniqueIdentity();
         var agent = CreateStubbedAgent(memoryProvider);
 
-        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(
+            identity.UserId, identity.SessionId, identity.LocalConversationId, identity.ApplicationId);
         var markerBeforeRestore = $"before-restore-noreapply-{Guid.NewGuid():N}";
         await agent.RunAsync(markerBeforeRestore, session);
 
-        var identity = new NamsConversationIdentity
-        {
-            ApplicationId = applicationId, UserId = userId, SessionId = sessionId, LocalConversationId = conversationId
-        };
         var namsConversationId = (await resolver.ResolveAsync(identity, CancellationToken.None)).NamsConversationId;
 
-        var indexedBeforeRestore = await PollUntilAsync(
+        var indexedBeforeRestore = await NamsLiveTestHelpers.PollUntilAsync(
             async () =>
             {
                 var recalled = await recall.RecallAsync(namsConversationId, markerBeforeRestore, CancellationToken.None);
@@ -142,7 +154,7 @@ public sealed class NamsSessionRestoreTests
         var markerAfterRestore = $"after-restore-noreapply-{Guid.NewGuid():N}";
         await agent.RunAsync(markerAfterRestore, restored);
 
-        var indexedAfterRestore = await PollUntilAsync(
+        var indexedAfterRestore = await NamsLiveTestHelpers.PollUntilAsync(
             async () =>
             {
                 var recalled = await recall.RecallAsync(namsConversationId, markerAfterRestore, CancellationToken.None);
@@ -168,35 +180,14 @@ public sealed class NamsSessionRestoreTests
         });
     }
 
-    private static (string ApplicationId, string UserId, string SessionId, string ConversationId) UniqueIds() =>
-    (
-        "agent-memory-dotnet-live-tests",
-        $"test-user-{Guid.NewGuid():N}",
-        Guid.NewGuid().ToString("N"),
-        Guid.NewGuid().ToString("N")
-    );
-
-    private static async Task<bool> PollUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    // [CallerMemberName] embeds the calling test's name in UserId -- these tests deliberately leave orphaned
+    // NAMS-side conversations behind (never delete what they create), so this aids tracing them back to the
+    // test that created them, matching NamsLiveConnectivityTests.UniqueIdentity's identical convention.
+    private static NamsConversationIdentity UniqueIdentity([CallerMemberName] string testName = "") => new()
     {
-        using var cts = new CancellationTokenSource(timeout);
-        while (!cts.IsCancellationRequested)
-        {
-            try
-            {
-                if (await condition())
-                    return true;
-            }
-            catch { /* transient failure against a live external service -- ignore and keep polling */ }
-
-            try
-            {
-                await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                return false;
-            }
-        }
-        return false;
-    }
+        ApplicationId = "agent-memory-dotnet-live-tests",
+        UserId = $"test-{testName}-{Guid.NewGuid():N}",
+        SessionId = Guid.NewGuid().ToString("N"),
+        LocalConversationId = Guid.NewGuid().ToString("N")
+    };
 }

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsSessionRestoreTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsSessionRestoreTests.cs
@@ -1,0 +1,202 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using FluentAssertions;
+using NSubstitute;
+using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Nams;
+using AgentMemory.Nams.Identity;
+using AgentMemory.Nams.Recall;
+
+namespace AgentMemory.Tests.Integration.Nams;
+
+/// <summary>
+/// Formalizes, as asserted live tests, what <c>AgentMemory.Sample.NamsAgent</c>'s console demo only shows
+/// informally: that a MAF <see cref="AgentSession"/>'s NAMS conversation identity -- and therefore the real
+/// NAMS-side conversation it maps to -- survives <c>SerializeSessionAsync</c>/<c>DeserializeSessionAsync</c>.
+///
+/// Both tests drive a REAL <see cref="ChatClientAgent"/> (via <c>AsAIAgent</c>) wired to a REAL, DI-resolved
+/// <see cref="NamsMemoryContextProvider"/> against the live NAMS SaaS -- only the model call itself is
+/// stubbed (an NSubstitute <see cref="IChatClient"/> returning a canned response), so there is no dependency
+/// on a real LLM. This exercises MAF's own session-serialization machinery for real, not a hand-rolled
+/// substitute for it (contrast <c>MemoryOwnerScopingAgentIntegrationTests</c>' <c>ScriptedInnerAgent</c>,
+/// whose <c>SerializeSessionCoreAsync</c>/<c>DeserializeSessionCoreAsync</c> are trivial stubs -- unsuitable
+/// here, since serialization behavior is exactly what's under test).
+///
+/// Deliberately does NOT assert on the messages the stub <see cref="IChatClient"/> receives: a probe of
+/// <c>ChatClientAgent</c>'s real serialized-session JSON showed it embeds its own
+/// <c>InMemoryChatHistoryProvider</c> turn history alongside the memory-identity state bag, so a restored
+/// session's next turn would carry the prior turn's raw text as ordinary chat history regardless of whether
+/// NAMS recall works at all -- a marker found in the outgoing request messages wouldn't distinguish "NAMS
+/// recalled it" from "MAF's own history already had it". Also NOT assertable via a
+/// <c>&lt;recalled_memory category="..."&gt;</c> wrapper search (<c>MemoryTraceChatClient</c>'s approach in
+/// the sample): per <c>NamsMafTypeMapper.ToContextMessages</c>, the <c>RecentMessage</c>/<c>RelevantMessage</c>
+/// categories a plain persisted turn recalls under are deliberately left undelimited ("a recalled message
+/// renders as an individual conversation turn, not an injected block"), so they carry no distinguishing
+/// wrapper either. Instead, each test independently confirms -- via a direct, live NAMS read through
+/// <see cref="INamsRecallService"/>, entirely outside the agent pipeline -- that content persisted through
+/// the RESTORED session's own real <c>RunAsync</c> call lands in the SAME NAMS conversation a marker
+/// persisted before serialization did. This is non-trivial specifically because it is the RESTORED session's
+/// own post-deserialize state (not a second direct call with the original identity values, which the shared
+/// singleton <c>INamsConversationStateStore</c> would trivially agree with regardless of whether restore
+/// works) that must resolve to that same conversation.
+/// </summary>
+[Collection("NAMS Live")]
+[Trait("Category", "Integration")]
+public sealed class NamsSessionRestoreTests
+{
+    private readonly NamsLiveFixture _fixture;
+
+    public NamsSessionRestoreTests(NamsLiveFixture fixture) => _fixture = fixture;
+
+    [LiveNamsFact]
+    public async Task SessionRestore_WithMemoryIdentityReapplied_ContinuesPersistingToTheSameNamsConversation()
+    {
+        using var scope = _fixture.Services!.CreateScope();
+        var sp = scope.ServiceProvider;
+        var memoryProvider = sp.GetRequiredService<NamsMemoryContextProvider>();
+        var resolver = sp.GetRequiredService<INamsConversationResolver>();
+        var recall = sp.GetRequiredService<INamsRecallService>();
+
+        var (applicationId, userId, sessionId, conversationId) = UniqueIds();
+        var agent = CreateStubbedAgent(memoryProvider);
+
+        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        var markerBeforeRestore = $"before-restore-{Guid.NewGuid():N}";
+        await agent.RunAsync(markerBeforeRestore, session);
+
+        var identity = new NamsConversationIdentity
+        {
+            ApplicationId = applicationId, UserId = userId, SessionId = sessionId, LocalConversationId = conversationId
+        };
+        var namsConversationId = (await resolver.ResolveAsync(identity, CancellationToken.None)).NamsConversationId;
+
+        var indexedBeforeRestore = await PollUntilAsync(
+            async () =>
+            {
+                var recalled = await recall.RecallAsync(namsConversationId, markerBeforeRestore, CancellationToken.None);
+                return recalled.Items.Any(i => i.Content.Contains(markerBeforeRestore, StringComparison.Ordinal));
+            },
+            timeout: TimeSpan.FromSeconds(30));
+        indexedBeforeRestore.Should().BeTrue("the pre-restore turn must actually be indexed before restore can meaningfully be proven to continue it");
+
+        var serialized = await agent.SerializeSessionAsync(session);
+        var restored = (await agent.DeserializeSessionAsync(serialized)).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        restored.Should().NotBeSameAs(session, "this must be a genuine restore from serialized JSON, not the original in-memory session object");
+
+        var markerAfterRestore = $"after-restore-{Guid.NewGuid():N}";
+        await agent.RunAsync(markerAfterRestore, restored);
+
+        var indexedAfterRestore = await PollUntilAsync(
+            async () =>
+            {
+                var recalled = await recall.RecallAsync(namsConversationId, markerAfterRestore, CancellationToken.None);
+                return recalled.Items.Any(i => i.Content.Contains(markerAfterRestore, StringComparison.Ordinal));
+            },
+            timeout: TimeSpan.FromSeconds(30));
+        indexedAfterRestore.Should().BeTrue(
+            "a turn run on the restored session (with memory identity re-applied, matching the NamsAgent sample's " +
+            "documented recipe) must persist to the SAME NAMS conversation created before serialization, not a new one");
+    }
+
+    [LiveNamsFact]
+    public async Task SessionRestore_WithoutReapplyingMemoryIdentity_StillPersistsToTheSameNamsConversation()
+    {
+        using var scope = _fixture.Services!.CreateScope();
+        var sp = scope.ServiceProvider;
+        var memoryProvider = sp.GetRequiredService<NamsMemoryContextProvider>();
+        var resolver = sp.GetRequiredService<INamsConversationResolver>();
+        var recall = sp.GetRequiredService<INamsRecallService>();
+
+        var (applicationId, userId, sessionId, conversationId) = UniqueIds();
+        var agent = CreateStubbedAgent(memoryProvider);
+
+        var session = (await agent.CreateSessionAsync()).WithMemoryIdentity(userId, sessionId, conversationId, applicationId);
+        var markerBeforeRestore = $"before-restore-noreapply-{Guid.NewGuid():N}";
+        await agent.RunAsync(markerBeforeRestore, session);
+
+        var identity = new NamsConversationIdentity
+        {
+            ApplicationId = applicationId, UserId = userId, SessionId = sessionId, LocalConversationId = conversationId
+        };
+        var namsConversationId = (await resolver.ResolveAsync(identity, CancellationToken.None)).NamsConversationId;
+
+        var indexedBeforeRestore = await PollUntilAsync(
+            async () =>
+            {
+                var recalled = await recall.RecallAsync(namsConversationId, markerBeforeRestore, CancellationToken.None);
+                return recalled.Items.Any(i => i.Content.Contains(markerBeforeRestore, StringComparison.Ordinal));
+            },
+            timeout: TimeSpan.FromSeconds(30));
+        indexedBeforeRestore.Should().BeTrue("the pre-restore turn must actually be indexed before restore can meaningfully be proven to continue it");
+
+        // Deliberately skips re-applying WithMemoryIdentity after restore, unlike the NamsAgent sample's own
+        // recipe and the sibling test above -- proving ChatClientAgent's own state-bag serialization already
+        // carries the memory identity through on its own (confirmed by inspecting the real serialized JSON
+        // before writing this test: it embeds user_id/session_id/conversation_id/application_id alongside its
+        // own chat history), making the sample's re-stamp step defensive rather than strictly load-bearing.
+        var serialized = await agent.SerializeSessionAsync(session);
+        var restored = await agent.DeserializeSessionAsync(serialized);
+        restored.Should().NotBeSameAs(session, "this must be a genuine restore from serialized JSON, not the original in-memory session object");
+
+        var markerAfterRestore = $"after-restore-noreapply-{Guid.NewGuid():N}";
+        await agent.RunAsync(markerAfterRestore, restored);
+
+        var indexedAfterRestore = await PollUntilAsync(
+            async () =>
+            {
+                var recalled = await recall.RecallAsync(namsConversationId, markerAfterRestore, CancellationToken.None);
+                return recalled.Items.Any(i => i.Content.Contains(markerAfterRestore, StringComparison.Ordinal));
+            },
+            timeout: TimeSpan.FromSeconds(30));
+        indexedAfterRestore.Should().BeTrue(
+            "the memory identity survives ChatClientAgent's own session serialization without needing to be re-applied, " +
+            "so a turn on the restored session must still persist to the SAME NAMS conversation created before serialization");
+    }
+
+    private static AIAgent CreateStubbedAgent(NamsMemoryContextProvider memoryProvider)
+    {
+        var chatClient = Substitute.For<IChatClient>();
+        chatClient
+            .GetResponseAsync(Arg.Any<IEnumerable<ChatMessage>>(), Arg.Any<ChatOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "Acknowledged."))));
+
+        return chatClient.AsAIAgent(new ChatClientAgentOptions
+        {
+            Name = "NamsSessionRestoreTestAgent",
+            AIContextProviders = [memoryProvider],
+        });
+    }
+
+    private static (string ApplicationId, string UserId, string SessionId, string ConversationId) UniqueIds() =>
+    (
+        "agent-memory-dotnet-live-tests",
+        $"test-user-{Guid.NewGuid():N}",
+        Guid.NewGuid().ToString("N"),
+        Guid.NewGuid().ToString("N")
+    );
+
+    private static async Task<bool> PollUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!cts.IsCancellationRequested)
+        {
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch { /* transient failure against a live external service -- ignore and keep polling */ }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Formalizes what `AgentMemory.Sample.NamsAgent`'s console demo only showed informally: that a MAF `AgentSession`'s NAMS conversation identity survives `SerializeSessionAsync`/`DeserializeSessionAsync`.
- Drives a REAL `ChatClientAgent` (via `AsAIAgent`) wired to a REAL, DI-resolved `NamsMemoryContextProvider` against the live NAMS SaaS — only the model call is stubbed (NSubstitute `IChatClient`, canned response), so there's no real LLM dependency, but genuine MAF session-serialization behavior is exercised.
- A probe of the real serialized-session JSON (done before writing any test code) revealed `ChatClientAgent`'s own state-bag serialization already embeds the memory identity (`user_id`/`session_id`/`conversation_id`/`application_id`) alongside its own turn history — so this adds two tests: the sample's documented "re-apply identity after restore" recipe, and a second proving the identity survives restore even *without* re-applying it.
- Extends `NamsLiveFixture` with `AddAgentMemoryFramework()`/`AddNamsAgentMemoryFramework()` (additive; verified non-breaking for all 15 pre-existing NAMS live tests) and adds the `Microsoft.Agents.AI` package + a project reference to `AgentMemory.AgentFramework.Nams`.

See `docs/reviews/NAMS_Phase10d_SessionRestoreTest_PlanningAndImplementationPlan.md` for full design reasoning, including why the tests deliberately do NOT assert on the stub chat client's received messages (MAF's own built-in chat history would make that ambiguous), and the self-review findings/fixes below.

## Self-review
2 parallel independent reviewers found and fixed:
- **HIGH**: the "re-apply identity" test originally re-stamped the restored session with the same closed-over identity values used before serialization, making it unable to actually prove restore preserved anything. Fixed by asserting the restored session's identity via `GetMemoryIdentity()` independently, before re-applying it.
- 3 low/medium conventions findings (missing `[CallerMemberName]` orphan-tracing, duplicated `PollUntilAsync`, minor redundancy) — all fixed.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` — 3262/3262 green
- [x] `dotnet test tests/AgentMemory.Tests.Integration --filter "FullyQualifiedName~Nams"` — 17/17 live against real NAMS SaaS (15 previous + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)