### PR TITLE
NAMS Phase 10g: entity feedback + graph

### DIFF
--- a/docs/reviews/NAMS_Phase10g_EntityFeedbackGraph_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10g_EntityFeedbackGraph_PlanningAndImplementationPlan.md
@@ -1,0 +1,123 @@
+# NAMS Phase 10g: Entity Feedback + Graph — Planning & Implementation Plan
+
+## Scope
+
+Add the TCK Platinum entity-feedback and graph capabilities to `INamsClient`:
+
+- `set_entity_feedback` (`PUT /entities/{id}/feedback`)
+- `get_entity_graph` (`GET /entities/graph`)
+- graph expand (`POST /graph/expand`) — not itself a named Platinum scenario, but the natural pair to
+  `get_entity_graph` per the engineering plan's own §5.6 description of NAMS's graph-view capability,
+  and already fully shape-confirmed by the Phase 10e spike, so bundling it into this phase avoids a
+  near-duplicate phase later for one more endpoint.
+
+Same tier as every other Phase 10e/10f/10a/10b addition: low-level `INamsClient` capability only, not
+wired into any higher-level service or MCP tool. `POST /entities` (manual entity creation) is explicitly
+**out of scope** — it's not part of any TCK Platinum scenario for this area, and adding it now would be
+scope creep beyond this phase's plan; live tests instead reuse an existing entity discovered via the
+already-shipped `ListEntitiesAsync` (Phase 9), the same non-destructive pattern the Phase 10e spike
+itself used.
+
+## Design, informed by the Phase 10e live-probe spike
+
+All three shapes were already confirmed live in Phase 10e — no new probing needed before implementing.
+
+### Entity feedback
+
+`PUT /entities/{id}/feedback`, body `{userScore?, confirmed?}` (both optional per the pinned schema),
+response `{id, updated: true}`. New minimal result record:
+
+```csharp
+internal sealed record NamsEntityFeedbackResult(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("updated")] bool Updated);
+```
+
+`SetEntityFeedbackAsync(string entityId, double? userScore, bool? confirmed, CancellationToken)`.
+
+### Entity graph
+
+`GET /entities/graph` (no parameters — returns the whole workspace graph). Live-confirmed node shape is
+**identical to the already-existing `NamsEntity`** record (id/name/type/description/confidence/
+sourceStage/createdAt/updatedAt) — no new node type needed, just reuse `NamsEntity`. Edges need a new
+shared record:
+
+```csharp
+internal sealed record NamsGraphEdge(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("sourceId")] string SourceId,
+    [property: JsonPropertyName("targetId")] string TargetId,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("legacyType")] string? LegacyType,
+    [property: JsonPropertyName("confidence")] double? Confidence,
+    [property: JsonPropertyName("method")] string? Method,
+    [property: JsonPropertyName("predicate")] string? Predicate,
+    [property: JsonPropertyName("sourceMessageCount")] int? SourceMessageCount);
+
+internal sealed record NamsEntityGraph(
+    [property: JsonPropertyName("nodes")] IReadOnlyList<NamsEntity> Nodes,
+    [property: JsonPropertyName("edges")] IReadOnlyList<NamsGraphEdge> Edges);
+```
+
+`GetEntityGraphAsync(CancellationToken)`.
+
+### Graph expand — genuinely different node shape (confirmed Phase 10e)
+
+`POST /graph/expand`, body `{nodeId, loadedIds}`. **Nodes here are NOT `NamsEntity`** — expand can pull
+in non-Entity nodes (a `Message` node was observed live), so nodes are generic: `{id, labels: [...],
+properties: {...}}`. Reuses `NamsGraphEdge` for edges (same shape confirmed). New records:
+
+```csharp
+internal sealed record NamsExpandNode(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("labels")] IReadOnlyList<string> Labels,
+    [property: JsonPropertyName("properties")] IReadOnlyDictionary<string, JsonElement> Properties);
+
+internal sealed record NamsExpandTruncation(
+    [property: JsonPropertyName("nodeId")] string? NodeId,
+    [property: JsonPropertyName("shown")] int Shown,
+    [property: JsonPropertyName("total")] int Total);
+
+internal sealed record NamsGraphExpansion(
+    [property: JsonPropertyName("nodes")] IReadOnlyList<NamsExpandNode> Nodes,
+    [property: JsonPropertyName("edges")] IReadOnlyList<NamsGraphEdge> Edges,
+    [property: JsonPropertyName("truncated")] NamsExpandTruncation? Truncated);
+```
+
+`ExpandGraphAsync(string nodeId, IReadOnlyList<string> loadedIds, CancellationToken)`. `Properties` uses
+`JsonElement` (not a typed record) because the property bag is genuinely heterogeneous across node
+labels (`Message` vs. `Entity` vs. whatever else the graph contains) — matching how this codebase already
+treats other untyped/heterogeneous wire payloads.
+
+## Implementation checklist
+
+1. New domain records: `NamsEntityFeedbackResult`, `NamsGraphEdge`, `NamsEntityGraph`, `NamsExpandNode`,
+   `NamsExpandTruncation`, `NamsGraphExpansion` (`src/AgentMemory.Nams/Domain/`) -- one file per record,
+   matching every existing domain type's convention (no bundling multiple records into one file).
+2. `INamsClient`: add `SetEntityFeedbackAsync`, `GetEntityGraphAsync`, `ExpandGraphAsync`, each with a
+   doc comment following the established convention.
+3. `Neo4jNamsClientAdapter`: implement all three. `SetEntityFeedbackAsync` is a `PUT` (new verb for this
+   adapter — every existing write is `POST`/`DELETE`); treat as non-idempotent like other writes.
+   `GetEntityGraphAsync` is a parameterless `GET`. `ExpandGraphAsync` is a `POST` but read-only (no
+   server-side side effects per its own description) — idempotent-for-retry like `SearchEntitiesAsync`.
+4. Live tests (`tests/AgentMemory.Tests.Integration/Nams/NamsEntityGraphTests.cs`, new file,
+   `LiveNamsFactAttribute`-gated):
+   - `SetEntityFeedbackAsync_OnExistingEntity_UpdatesScoreAndConfirmedFlag`: use `ListEntitiesAsync` to
+     find an existing entity (non-destructive reuse, matching the Phase 10e spike's own pattern), set
+     feedback with a specific score/confirmed value, assert `{id, updated: true}` — genuine because it's
+     against a real entity id from a real prior list call, not a hardcoded/guessed id.
+   - `GetEntityGraphAsync_ReturnsNodesAndEdgesFromTheWorkspace`: list several (not just one) existing
+     entities via `ListEntitiesAsync`, assert at least one appears among the graph's returned nodes (by
+     id) — proves the two endpoints are talking about the same real workspace data, not just
+     independently well-typed, while avoiding a single-entity dependency on `GET /entities/graph`'s
+     undocumented ordering/cap behavior (a real risk a self-review correctness pass flagged: neither
+     endpoint's confirmed shape documents any pagination contract linking them).
+   - `ExpandGraphAsync_OnASeedEntity_ReturnsANonEmptyNeighborhood`: expand from a known entity id, assert
+     the response's `Nodes` are non-empty and `Truncated.NodeId` matches the seed -- avoiding a "trivially
+     always empty" assertion given entities in this dev workspace are heavily interlinked (confirmed
+     Phase 10e: 21 nodes/27 edges from expanding a single entity). Note: the seed's own id is not expected
+     to appear among its own expansion's neighbor nodes (confirmed empirically), so the assertion checks
+     the truncation metadata's echoed node id instead.
+5. Unit-level wire-shape tests in `Neo4jNamsClientAdapterTests.cs` for all three methods, using the exact
+   confirmed JSON shapes above (matching the pattern Phase 10f's self-review established for closing
+   deserialization coverage gaps without depending on live timing).

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -91,4 +91,31 @@ internal interface INamsClient
     /// </summary>
     Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
         string conversationId, int limit, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Scores/confirms an entity (<c>PUT /v1/entities/{id}/feedback</c>) -- confirmed live as part of the
+    /// Phase 10e TCK Platinum probe. Both <paramref name="userScore"/> (0-1 confidence) and
+    /// <paramref name="confirmed"/> (human-verified flag) are optional; pass <see langword="null"/> to leave
+    /// either unset. Deliberately not wired into any higher-level service or MCP tool yet -- low-level client
+    /// capability only.
+    /// </summary>
+    Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+        string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full workspace entity graph (<c>GET /v1/entities/graph</c>, no parameters) -- confirmed live as
+    /// part of the Phase 10e TCK Platinum probe. Nodes reuse <see cref="NamsEntity"/> (confirmed identical
+    /// shape); see <see cref="ExpandGraphAsync"/> for the genuinely different node shape that endpoint returns.
+    /// Deliberately not wired into any higher-level service or MCP tool yet -- low-level client capability only.
+    /// </summary>
+    Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Expands a graph node's 1-hop neighborhood (<c>POST /v1/graph/expand</c>) -- confirmed live as part of
+    /// the Phase 10e TCK Platinum probe. A POST verb but read-only (no server-side side effects per its own
+    /// description), so treated as idempotent-for-retry like <see cref="SearchEntitiesAsync"/>. Deliberately not
+    /// wired into any higher-level service or MCP tool yet -- low-level client capability only.
+    /// </summary>
+    Task<NamsGraphExpansion> ExpandGraphAsync(
+        string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -147,6 +147,39 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         return response.Observations;
     }
 
+    public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+        string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "set_entity_feedback",
+            () => BuildJsonRequest(
+                HttpMethod.Put, $"entities/{Uri.EscapeDataString(entityId)}/feedback",
+                new EntityFeedbackRequestBody(userScore, confirmed)),
+            // A PUT full-value replacement, not a POST create -- resending the same body produces the same end
+            // state, none of the duplicate-row risk NamsRetryPolicy's writes-don't-retry default guards
+            // against. Genuinely idempotent, safe to retry like DeleteConversationAsync above.
+            isIdempotent: true,
+            DeserializeAsync<NamsEntityFeedbackResult>,
+            cancellationToken);
+
+    public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "get_entity_graph",
+            () => new HttpRequestMessage(HttpMethod.Get, "entities/graph"),
+            isIdempotent: true,
+            DeserializeAsync<NamsEntityGraph>,
+            cancellationToken);
+
+    public Task<NamsGraphExpansion> ExpandGraphAsync(
+        string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "expand_graph",
+            // POST verb, but read-only (no server-side side effects) -- same idempotent-for-retry treatment
+            // as SearchEntitiesAsync/SearchMessagesAsync.
+            () => BuildJsonRequest(HttpMethod.Post, "graph/expand", new ExpandGraphRequestBody(nodeId, loadedIds)),
+            isIdempotent: true,
+            DeserializeAsync<NamsGraphExpansion>,
+            cancellationToken);
+
     private async Task<T> InvokeAsync<T>(
         string operationName,
         Func<HttpRequestMessage> requestFactory,
@@ -253,4 +286,12 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
 
     private sealed record GetObservationsResponseBody(
         [property: JsonPropertyName("observations")] IReadOnlyList<NamsObservation> Observations);
+
+    private sealed record EntityFeedbackRequestBody(
+        [property: JsonPropertyName("userScore")] double? UserScore,
+        [property: JsonPropertyName("confirmed")] bool? Confirmed);
+
+    private sealed record ExpandGraphRequestBody(
+        [property: JsonPropertyName("nodeId")] string NodeId,
+        [property: JsonPropertyName("loadedIds")] IReadOnlyList<string> LoadedIds);
 }

--- a/src/AgentMemory.Nams/Domain/NamsEntityFeedbackResult.cs
+++ b/src/AgentMemory.Nams/Domain/NamsEntityFeedbackResult.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result of <c>PUT /v1/entities/{id}/feedback</c> -- matches <c>handlers.UpdateSchemaResponse</c> in the
+/// pinned OpenAPI snapshot, confirmed live (Phase 10e/10g).</summary>
+internal sealed record NamsEntityFeedbackResult(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("updated")] bool Updated);

--- a/src/AgentMemory.Nams/Domain/NamsEntityGraph.cs
+++ b/src/AgentMemory.Nams/Domain/NamsEntityGraph.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// Result of <c>GET /v1/entities/graph</c> -- the whole workspace entity graph. Nodes are confirmed live
+/// (Phase 10e) to be shaped identically to <see cref="NamsEntity"/> (id/name/type/description/confidence/
+/// sourceStage/createdAt/updatedAt) -- reused directly rather than duplicating a near-identical record.
+/// </summary>
+internal sealed record NamsEntityGraph(
+    [property: JsonPropertyName("nodes")] IReadOnlyList<NamsEntity> Nodes,
+    [property: JsonPropertyName("edges")] IReadOnlyList<NamsGraphEdge> Edges);

--- a/src/AgentMemory.Nams/Domain/NamsExpandNode.cs
+++ b/src/AgentMemory.Nams/Domain/NamsExpandNode.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// A single node returned by <c>POST /v1/graph/expand</c> -- confirmed live (Phase 10e) to be a genuinely
+/// different shape from <see cref="NamsEntityGraph"/>'s flat <see cref="NamsEntity"/> nodes: expand can surface
+/// non-Entity nodes (a <c>Message</c> node was observed live), so nodes here are generic graph nodes with
+/// <see cref="Labels"/> and a heterogeneous <see cref="Properties"/> bag rather than fixed entity fields.
+/// </summary>
+internal sealed record NamsExpandNode(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("labels")] IReadOnlyList<string> Labels,
+    [property: JsonPropertyName("properties")] IReadOnlyDictionary<string, JsonElement> Properties);

--- a/src/AgentMemory.Nams/Domain/NamsExpandTruncation.cs
+++ b/src/AgentMemory.Nams/Domain/NamsExpandTruncation.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Truncation metadata on a <c>POST /v1/graph/expand</c> response -- confirmed live (Phase 10e).</summary>
+internal sealed record NamsExpandTruncation(
+    [property: JsonPropertyName("nodeId")] string? NodeId,
+    [property: JsonPropertyName("shown")] int Shown,
+    [property: JsonPropertyName("total")] int Total);

--- a/src/AgentMemory.Nams/Domain/NamsGraphEdge.cs
+++ b/src/AgentMemory.Nams/Domain/NamsGraphEdge.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// A graph relationship edge -- shared shape between <c>GET /v1/entities/graph</c> and
+/// <c>POST /v1/graph/expand</c> (confirmed identical live, Phase 10e/10g). <see cref="Id"/> is a compound
+/// <c>"sourceId|TYPE|targetId"</c> string, not a standalone identifier.
+/// </summary>
+internal sealed record NamsGraphEdge(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("sourceId")] string SourceId,
+    [property: JsonPropertyName("targetId")] string TargetId,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("legacyType")] string? LegacyType,
+    [property: JsonPropertyName("confidence")] double? Confidence,
+    [property: JsonPropertyName("method")] string? Method,
+    [property: JsonPropertyName("predicate")] string? Predicate,
+    [property: JsonPropertyName("sourceMessageCount")] int? SourceMessageCount);

--- a/src/AgentMemory.Nams/Domain/NamsGraphExpansion.cs
+++ b/src/AgentMemory.Nams/Domain/NamsGraphExpansion.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result of <c>POST /v1/graph/expand</c> -- the 1-hop neighborhood of a node plus the resolved
+/// relationships among the resulting node set.</summary>
+internal sealed record NamsGraphExpansion(
+    [property: JsonPropertyName("nodes")] IReadOnlyList<NamsExpandNode> Nodes,
+    [property: JsonPropertyName("edges")] IReadOnlyList<NamsGraphEdge> Edges,
+    [property: JsonPropertyName("truncated")] NamsExpandTruncation? Truncated);

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsEntityGraphTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsEntityGraphTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+using FluentAssertions;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.Tests.Integration.Nams;
+
+/// <summary>
+/// Live tests for the Phase 10g TCK Platinum entity-feedback/graph additions:
+/// <see cref="INamsClient.SetEntityFeedbackAsync"/>, <see cref="INamsClient.GetEntityGraphAsync"/>, and
+/// <see cref="INamsClient.ExpandGraphAsync"/>. See
+/// <c>docs/reviews/NAMS_Phase10g_EntityFeedbackGraph_PlanningAndImplementationPlan.md</c> for the design.
+/// Deliberately reuses an existing entity discovered via the already-shipped <see cref="INamsClient.ListEntitiesAsync"/>
+/// rather than creating one -- entity creation only happens via the async extraction pipeline or the
+/// out-of-scope <c>POST /entities</c> endpoint, and non-destructively scoring/reading an existing entity matches
+/// the same pattern the Phase 10e spike itself used.
+/// </summary>
+[Collection("NAMS Live")]
+[Trait("Category", "Integration")]
+public sealed class NamsEntityGraphTests
+{
+    private readonly NamsLiveFixture _fixture;
+
+    public NamsEntityGraphTests(NamsLiveFixture fixture) => _fixture = fixture;
+
+    [LiveNamsFact]
+    public async Task SetEntityFeedbackAsync_OnExistingEntity_UpdatesScoreAndConfirmedFlag()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var entities = await namsClient.ListEntitiesAsync(1, CancellationToken.None);
+        entities.Should().NotBeEmpty(
+            "this live dev workspace has accumulated entities from earlier phases' extraction runs -- " +
+            "if this ever fails, the workspace was reset and this test needs a different entity source");
+        var entityId = entities[0].Id;
+
+        var result = await namsClient.SetEntityFeedbackAsync(entityId, userScore: 0.75, confirmed: true, CancellationToken.None);
+
+        result.Id.Should().Be(entityId, "the response must echo back the exact entity id we scored, not some other one");
+        result.Updated.Should().BeTrue();
+    }
+
+    [LiveNamsFact]
+    public async Task GetEntityGraphAsync_ReturnsNodesAndEdgesFromTheWorkspace()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        // Cross-check against several listed entities, not just one: GET /entities/graph documents no limit
+        // param or ordering contract linking it to ListEntitiesAsync, so a single arbitrary entity could in
+        // principle fall outside some undocumented cap as this shared dev workspace keeps growing. Requiring
+        // overlap with ANY of several entities (rather than one specific one) keeps the assertion genuine
+        // while removing that single-entity fragility.
+        var entities = await namsClient.ListEntitiesAsync(20, CancellationToken.None);
+        entities.Should().NotBeEmpty();
+        var knownEntityIds = entities.Select(e => e.Id).ToHashSet();
+
+        var graph = await namsClient.GetEntityGraphAsync(CancellationToken.None);
+
+        graph.Nodes.Should().NotBeEmpty();
+        graph.Nodes.Should().Contain(n => knownEntityIds.Contains(n.Id),
+            "at least one of the entities independently confirmed to exist via ListEntitiesAsync must also " +
+            "appear in the full workspace graph -- proves both endpoints are reading the same real data, not " +
+            "just independently well-typed empty/placeholder responses");
+    }
+
+    [LiveNamsFact]
+    public async Task ExpandGraphAsync_OnASeedEntity_ReturnsANonEmptyNeighborhood()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var entities = await namsClient.ListEntitiesAsync(1, CancellationToken.None);
+        entities.Should().NotBeEmpty();
+        var seedId = entities[0].Id;
+
+        var expansion = await namsClient.ExpandGraphAsync(seedId, [seedId], CancellationToken.None);
+
+        // This dev workspace's entities are heavily interlinked from many prior phases' live tests (confirmed
+        // Phase 10e: expanding a single entity returned 21 nodes/27 edges) -- a genuinely empty neighborhood
+        // would indicate expand is broken, not just that this particular entity happens to be isolated.
+        expansion.Nodes.Should().NotBeEmpty("this workspace's entities are heavily interlinked from prior phases");
+        expansion.Truncated.Should().NotBeNull();
+        expansion.Truncated!.NodeId.Should().Be(seedId);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
@@ -60,6 +60,17 @@ public sealed class NamsConversationResolverTests
         public Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
             string conversationId, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsConversationIdentity Identity(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
@@ -47,6 +47,17 @@ public sealed class NamsHealthCheckTests
         public Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
             string conversationId, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsOptions ValidOptions() => new() { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = "nams_key" };

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
@@ -272,5 +272,16 @@ public sealed class NamsObservabilityTests
         public Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
             string conversationId, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
@@ -52,6 +52,17 @@ public sealed class NamsPersistenceServiceTests
         public Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
             string conversationId, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsPersistenceService CreateService(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
@@ -54,6 +54,17 @@ public sealed class NamsRecallServiceTests
         public Task<IReadOnlyList<NamsObservation>> GetObservationsAsync(
             string conversationId, int limit, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static readonly NamsContext EmptyContext = new([], [], []);

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -243,6 +243,101 @@ public sealed class Neo4jNamsClientAdapterTests
     }
 
     [Fact]
+    public async Task SetEntityFeedbackAsync_Success_SendsPutWithBodyAndDeserializesResult()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """{"id":"e1","updated":true}"""));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.SetEntityFeedbackAsync("e1", 0.9, true, CancellationToken.None);
+
+        result.Id.Should().Be("e1");
+        result.Updated.Should().BeTrue();
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Put);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/entities/e1/feedback"));
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        requestBody.Should().Contain("\"userScore\":0.9").And.Contain("\"confirmed\":true");
+    }
+
+    [Fact]
+    public async Task SetEntityFeedbackAsync_TransientFailureThenSuccess_Retries()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => Json(HttpStatusCode.OK, """{"id":"e1","updated":true}"""));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.SetEntityFeedbackAsync("e1", 0.9, true, CancellationToken.None);
+
+        result.Updated.Should().BeTrue();
+        // A PUT full-value replacement is genuinely idempotent -- retries like DeleteConversationAsync's PUT/DELETE.
+        fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetEntityGraphAsync_Success_DeserializesNodesAndEdges()
+    {
+        // Shape confirmed live (Phase 10e probe): nodes are flat NamsEntity records; edges carry a compound id.
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {"nodes":[{"id":"e1","name":"Acme","type":"Org","confidence":0.9}],
+             "edges":[{"id":"e1|RELATED_TO|e2","sourceId":"e1","targetId":"e2","type":"RELATED_TO",
+             "confidence":0.8,"method":"gliner2","predicate":"located_at","sourceMessageCount":3}]}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var graph = await adapter.GetEntityGraphAsync(CancellationToken.None);
+
+        graph.Nodes.Single().Name.Should().Be("Acme");
+        var edge = graph.Edges.Single();
+        edge.SourceId.Should().Be("e1");
+        edge.TargetId.Should().Be("e2");
+        edge.Predicate.Should().Be("located_at");
+        edge.SourceMessageCount.Should().Be(3);
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Get);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/entities/graph"));
+    }
+
+    [Fact]
+    public async Task ExpandGraphAsync_Success_DeserializesGenericNodesAndTruncation()
+    {
+        // Shape confirmed live (Phase 10e probe): expand nodes are NOT flat NamsEntity records -- they carry
+        // labels + a heterogeneous properties bag (a Message node was observed live alongside Entity nodes).
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {"nodes":[{"id":"m1","labels":["Message"],"properties":{"content":"hi","role":"user"}}],
+             "edges":[{"id":"m1|MENTIONS|e1","sourceId":"m1","targetId":"e1","type":"MENTIONS"}],
+             "truncated":{"nodeId":"e1","shown":1,"total":1}}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var expansion = await adapter.ExpandGraphAsync("e1", ["e1"], CancellationToken.None);
+
+        var node = expansion.Nodes.Single();
+        node.Id.Should().Be("m1");
+        node.Labels.Should().Equal("Message");
+        node.Properties["content"].GetString().Should().Be("hi");
+        expansion.Edges.Single().Type.Should().Be("MENTIONS");
+        expansion.Truncated!.Shown.Should().Be(1);
+        expansion.Truncated.Total.Should().Be(1);
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Post);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/graph/expand"));
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        requestBody.Should().Contain("\"nodeId\":\"e1\"").And.Contain("\"loadedIds\":[\"e1\"]");
+    }
+
+    [Fact]
+    public async Task ExpandGraphAsync_TransientFailureThenSuccess_Retries()
+    {
+        var fake = new FakeHttpMessageHandler(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            () => Json(HttpStatusCode.OK, """{"nodes":[],"edges":[],"truncated":null}"""));
+        var adapter = CreateAdapter(fake);
+
+        var expansion = await adapter.ExpandGraphAsync("e1", ["e1"], CancellationToken.None);
+
+        expansion.Nodes.Should().BeEmpty();
+        fake.Requests.Should().HaveCount(2); // read-only POST -- retries like SearchEntitiesAsync/SearchMessagesAsync
+    }
+
+    [Fact]
     public async Task AnyOperation_CallerCancellation_PropagatesOperationCanceledException()
     {
         var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));


### PR DESCRIPTION
## Summary
- Adds `SetEntityFeedbackAsync` (`PUT /entities/{id}/feedback`), `GetEntityGraphAsync` (`GET /entities/graph`), and `ExpandGraphAsync` (`POST /graph/expand`) to `INamsClient`. Low-level client capability only, not wired into higher-level services or MCP tools yet.
- Graph node shapes genuinely differ between the two graph endpoints (confirmed live via the Phase 10e spike): `GetEntityGraphAsync`'s nodes reuse the existing flat `NamsEntity` record, while `ExpandGraphAsync`'s nodes are generic (labels + a heterogeneous properties bag) since expand can surface non-Entity nodes (a `Message` node was observed live).
- Live tests reuse an existing entity discovered via the already-shipped `ListEntitiesAsync` (non-destructive scoring/reading) rather than adding a new `CreateEntityAsync` -- that's out of scope, not part of any TCK Platinum scenario here.
- Self-reviewed via two parallel agents (correctness + conventions): fixed a wrong idempotency classification (`SetEntityFeedbackAsync` is a PUT full-value replacement, genuinely safe to retry), renamed an envelope record for naming consistency, split a file that bundled three domain records into one-per-file, hardened a live test that depended on a single arbitrary entity appearing in an endpoint with no documented ordering/pagination contract, and fixed stale spots in the planning doc.

## Test plan
- [x] Full Release build (0 warnings/errors)
- [x] Full unit + SemanticKernel suite: 3269 passed
- [x] Full `Category=Integration` suite (Testcontainers Neo4j + live NAMS): 324 passed
- [x] All 3 new NAMS live tests passed against the real NAMS SaaS dev workspace
- [x] Two parallel self-review agents (correctness, conventions) -- findings addressed

No GitHub Copilot review requested (out of credits, per standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)