### PR TITLE
NAMS Phase 10h: reasoning & provenance

### DIFF
--- a/docs/reviews/NAMS_Phase10h_ReasoningProvenance_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10h_ReasoningProvenance_PlanningAndImplementationPlan.md
@@ -1,0 +1,124 @@
+# NAMS Phase 10h: Reasoning & Provenance — Planning & Implementation Plan
+
+## Scope
+
+Add the TCK Platinum reasoning/provenance capabilities to `INamsClient` — an entirely new domain
+`INamsClient` has never touched before (repeatedly flagged across Phase 4/5/10a docs as "no
+reasoning-endpoint method yet"):
+
+- `record_step` (`POST /reasoning/steps`)
+- list steps (`GET /reasoning/steps?conversation_id=`) — not itself a named Platinum scenario, but the
+  natural read counterpart to `record_step`, already fully shape-confirmed, and needed to make
+  `record_step` testable without only relying on the trace endpoint
+- `record_tool_call` (`POST /reasoning/tool-calls`)
+- `get_trace_by_conversation` (`GET /reasoning/trace/{conversationId}`)
+- `get_provenance` (`GET /reasoning/provenance/{entityId}`)
+
+Same tier as every other Phase 10e-10g addition: low-level `INamsClient` capability only, not wired into
+any higher-level service or MCP tool.
+
+## Design, informed by the Phase 10e live-probe spike
+
+All five shapes were already confirmed live in Phase 10e — no new probing needed before implementing.
+Two of them (`record_step`'s response and the list/trace responses) share one underlying record, since
+NAMS returns strict subsets of the same fields depending on which endpoint is called (matches how
+`NamsMessage` already covers multiple endpoints' near-identical shapes in this codebase):
+
+```csharp
+internal sealed record NamsReasoningStep(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("conversationId")] string? ConversationId,
+    [property: JsonPropertyName("reasoning")] string Reasoning,
+    [property: JsonPropertyName("actionTaken")] string ActionTaken,
+    [property: JsonPropertyName("result")] string? Result,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt);
+```
+
+(`record_step`'s own response omits `createdAt`; the list/trace endpoints include it — nullable covers
+both without a second near-duplicate type.)
+
+```csharp
+internal sealed record NamsToolCall(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("stepId")] string? StepId,
+    [property: JsonPropertyName("toolName")] string ToolName,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("input")] string? Input,
+    [property: JsonPropertyName("output")] string? Output,
+    [property: JsonPropertyName("durationMs")] int? DurationMs,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt);
+```
+
+(Same reasoning: `record_tool_call`'s own response only echoes `{id, stepId, toolName, status}`; the
+trace endpoint's `toolCalls` array includes the rest.)
+
+```csharp
+internal sealed record NamsReasoningTrace(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("steps")] IReadOnlyList<NamsReasoningStep> Steps,
+    [property: JsonPropertyName("toolCalls")] IReadOnlyList<NamsToolCall> ToolCalls);
+```
+
+### Provenance — genuinely unconfirmed item shape, modeled honestly
+
+The Phase 10e probe confirmed the **envelope** field name (`provenance`, not `steps` as the pinned
+snapshot's schema name wrongly implied) but never observed a **non-empty** provenance array — the probe
+queried an entity with no recorded reasoning link, so the shape of an individual provenance entry is
+still unconfirmed. The pinned OpenAPI snapshot itself only documents the array items as
+`additionalProperties: true` (untyped). Rather than guess a concrete shape that might not match reality —
+exactly the mistake the pinned snapshot already made once on the envelope field name — provenance entries
+are modeled as raw `JsonElement`:
+
+```csharp
+internal sealed record NamsEntityProvenance(
+    [property: JsonPropertyName("entityId")] string EntityId,
+    [property: JsonPropertyName("provenance")] IReadOnlyList<JsonElement> Provenance);
+```
+
+If a later phase confirms the entry shape live, it can be tightened then without breaking callers (they
+already only see an opaque, correctly-enveloped list).
+
+### Test design: steps/tool-calls/trace are direct writes (genuinely testable); provenance is not
+
+Unlike Phase 10f's observations (which depend on an async, non-deterministic server-side worker),
+`record_step`/`record_tool_call`/`get_trace` are **direct, synchronous writes and reads** — recording a
+step and immediately listing/tracing it back is not subject to any eventual-consistency delay (confirmed
+live in the Phase 10e probe: step recorded and immediately visible via both list and trace, no polling
+needed). These get genuine positive-assertion live tests.
+
+`get_provenance`, by contrast, links reasoning to *entity extraction* — an async, worker-driven process
+(the same family as Phase 10f's observations). Forcing a non-empty provenance result would mean
+recording reasoning steps and then waiting for NAMS's backend to (a) extract an entity and (b) link it
+back to those steps, an even less certain and slower chain than the observations timing that already
+failed a real test run in Phase 10f. Per that phase's hard-won lesson, this phase does **not** attempt to
+force a positive provenance result — only a shape/wiring test against an existing entity (empty result,
+correctly typed, no error).
+
+## Implementation checklist
+
+1. New domain records: `NamsReasoningStep`, `NamsToolCall`, `NamsReasoningTrace`, `NamsEntityProvenance`
+   (`src/AgentMemory.Nams/Domain/`, one file per record).
+2. `INamsClient`: add `RecordReasoningStepAsync`, `ListReasoningStepsAsync`, `RecordToolCallAsync`,
+   `GetReasoningTraceAsync`, `GetEntityProvenanceAsync`, each with a doc comment following the
+   established convention.
+3. `Neo4jNamsClientAdapter`: implement all five. Recording a step/tool-call is a genuine write
+   (`isIdempotent: false`, matches `CreateConversationAsync`/`AddMessagesAsync` — resending would create
+   a duplicate step/tool-call, unlike Phase 10g's PUT feedback). Listing steps, getting the trace, and
+   getting provenance are reads (`isIdempotent: true`).
+4. Live tests (`tests/AgentMemory.Tests.Integration/Nams/NamsReasoningTests.cs`, new file,
+   `LiveNamsFactAttribute`-gated):
+   - `RecordReasoningStepAsync_ThenListReasoningStepsAsync_ReturnsTheRecordedStep`: create a conversation,
+     record a step with distinctive reasoning/action text, list steps for that conversation, assert the
+     recorded step appears with matching content — genuine because it's a fresh conversation with exactly
+     one step, no pre-existing data to accidentally match against.
+   - `RecordToolCallAsync_LinkedToAStep_AppearsInTheTrace`: record a step, record a tool call linked to
+     it (distinctive tool name/input), fetch the trace, assert both the step and the tool call appear
+     with matching content and the tool call's `StepId` matches the recorded step's id.
+   - `GetEntityProvenanceAsync_OnExistingEntity_ReturnsWellTypedResult`: use `ListEntitiesAsync` (Phase 9)
+     to find an existing entity, call `GetEntityProvenanceAsync`, assert it returns without throwing and
+     the envelope's `EntityId` echoes the queried id — deliberately not asserting non-empty `Provenance`,
+     per the design note above.
+   - All tests delete their conversations afterward via the existing `DeleteConversationAsync` for
+     workspace hygiene.
+5. Unit-level wire-shape tests in `Neo4jNamsClientAdapterTests.cs` for all five methods, using the exact
+   confirmed JSON shapes above.

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -118,4 +118,51 @@ internal interface INamsClient
     /// </summary>
     Task<NamsGraphExpansion> ExpandGraphAsync(
         string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records a reasoning step (<c>POST /v1/reasoning/steps</c>) -- confirmed live as part of the Phase 10e TCK
+    /// Platinum probe. Unlike every other addition in Phase 10e-10g, this is the first method touching an
+    /// entirely new domain -- reasoning/provenance -- this client has never exposed before. A genuine write
+    /// (resending would create a duplicate step), not idempotent-for-retry. Deliberately not wired into any
+    /// higher-level service or MCP tool yet -- low-level client capability only.
+    /// </summary>
+    Task<NamsReasoningStep> RecordReasoningStepAsync(
+        string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists reasoning steps for a conversation (<c>GET /v1/reasoning/steps?conversation_id=</c>) -- confirmed
+    /// live as part of the Phase 10e TCK Platinum probe. Unlike Phase 10f's observations, recording and
+    /// immediately listing a step is NOT subject to any async worker delay -- confirmed live to be immediately
+    /// visible. Deliberately not wired into any higher-level service or MCP tool yet.
+    /// </summary>
+    Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records a tool call, optionally linked to a step (<c>POST /v1/reasoning/tool-calls</c>) -- confirmed
+    /// live as part of the Phase 10e TCK Platinum probe. <paramref name="input"/>/<paramref name="output"/>
+    /// must be pre-serialized JSON strings, not objects -- NAMS stores them as scalar string properties. A
+    /// genuine write, not idempotent-for-retry. Deliberately not wired into any higher-level service or MCP
+    /// tool yet.
+    /// </summary>
+    Task<NamsToolCall> RecordToolCallAsync(
+        string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full reasoning trace for a conversation -- all steps and tool calls, in order
+    /// (<c>GET /v1/reasoning/trace/{conversationId}</c>) -- confirmed live as part of the Phase 10e TCK
+    /// Platinum probe. Flat shape (steps and toolCalls as parallel arrays), not steps-with-nested-toolCalls
+    /// despite the endpoint's own prose description implying nesting. Deliberately not wired into any
+    /// higher-level service or MCP tool yet.
+    /// </summary>
+    Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the reasoning chain that influenced an entity's creation (<c>GET /v1/reasoning/provenance/{entityId}</c>)
+    /// -- confirmed live as part of the Phase 10e TCK Platinum probe. Like Phase 10f's observations, this links
+    /// to async entity-extraction machinery -- callers should not assume a call shortly after recording
+    /// reasoning steps will see a populated provenance chain for any particular entity. Deliberately not wired
+    /// into any higher-level service or MCP tool yet.
+    /// </summary>
+    Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -180,6 +180,58 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             DeserializeAsync<NamsGraphExpansion>,
             cancellationToken);
 
+    public Task<NamsReasoningStep> RecordReasoningStepAsync(
+        string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "record_reasoning_step",
+            () => BuildJsonRequest(
+                HttpMethod.Post, "reasoning/steps",
+                new RecordReasoningStepRequestBody(conversationId, reasoning, actionTaken, result)),
+            isIdempotent: false,
+            DeserializeAsync<NamsReasoningStep>,
+            cancellationToken);
+
+    public async Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(
+        string conversationId, CancellationToken cancellationToken)
+    {
+        var path = $"reasoning/steps?conversation_id={Uri.EscapeDataString(conversationId)}";
+        var response = await InvokeAsync(
+            "list_reasoning_steps",
+            () => new HttpRequestMessage(HttpMethod.Get, path),
+            isIdempotent: true,
+            DeserializeAsync<ListReasoningStepsResponseBody>,
+            cancellationToken).ConfigureAwait(false);
+        return response.Steps;
+    }
+
+    public Task<NamsToolCall> RecordToolCallAsync(
+        string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+        CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "record_tool_call",
+            () => BuildJsonRequest(
+                HttpMethod.Post, "reasoning/tool-calls",
+                new RecordToolCallRequestBody(stepId, toolName, input, output, status, durationMs)),
+            isIdempotent: false,
+            DeserializeAsync<NamsToolCall>,
+            cancellationToken);
+
+    public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "get_reasoning_trace",
+            () => new HttpRequestMessage(HttpMethod.Get, $"reasoning/trace/{Uri.EscapeDataString(conversationId)}"),
+            isIdempotent: true,
+            DeserializeAsync<NamsReasoningTrace>,
+            cancellationToken);
+
+    public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "get_entity_provenance",
+            () => new HttpRequestMessage(HttpMethod.Get, $"reasoning/provenance/{Uri.EscapeDataString(entityId)}"),
+            isIdempotent: true,
+            DeserializeAsync<NamsEntityProvenance>,
+            cancellationToken);
+
     private async Task<T> InvokeAsync<T>(
         string operationName,
         Func<HttpRequestMessage> requestFactory,
@@ -294,4 +346,21 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     private sealed record ExpandGraphRequestBody(
         [property: JsonPropertyName("nodeId")] string NodeId,
         [property: JsonPropertyName("loadedIds")] IReadOnlyList<string> LoadedIds);
+
+    private sealed record RecordReasoningStepRequestBody(
+        [property: JsonPropertyName("conversationId")] string ConversationId,
+        [property: JsonPropertyName("reasoning")] string Reasoning,
+        [property: JsonPropertyName("actionTaken")] string ActionTaken,
+        [property: JsonPropertyName("result")] string? Result);
+
+    private sealed record ListReasoningStepsResponseBody(
+        [property: JsonPropertyName("steps")] IReadOnlyList<NamsReasoningStep> Steps);
+
+    private sealed record RecordToolCallRequestBody(
+        [property: JsonPropertyName("stepId")] string? StepId,
+        [property: JsonPropertyName("toolName")] string ToolName,
+        [property: JsonPropertyName("input")] string Input,
+        [property: JsonPropertyName("output")] string? Output,
+        [property: JsonPropertyName("status")] string? Status,
+        [property: JsonPropertyName("durationMs")] int? DurationMs);
 }

--- a/src/AgentMemory.Nams/Domain/NamsEntityProvenance.cs
+++ b/src/AgentMemory.Nams/Domain/NamsEntityProvenance.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// Result of <c>GET /v1/reasoning/provenance/{entityId}</c> -- the reasoning chain that influenced an entity's
+/// creation. The envelope's array field is confirmed live (Phase 10e) to be named <see cref="Provenance"/>, NOT
+/// "steps" as the pinned OpenAPI snapshot's schema name wrongly implied. Individual entry shape is genuinely
+/// unconfirmed -- the Phase 10e probe only observed an empty array (no entity with a recorded reasoning link
+/// was available), and the pinned snapshot itself only documents entries as untyped. Modeled as raw
+/// <see cref="JsonElement"/> rather than guessing a concrete shape that might not match reality -- exactly the
+/// mistake the pinned snapshot already made once on the envelope field name.
+/// </summary>
+internal sealed record NamsEntityProvenance(
+    [property: JsonPropertyName("entityId")] string EntityId,
+    [property: JsonPropertyName("provenance")] IReadOnlyList<JsonElement> Provenance);

--- a/src/AgentMemory.Nams/Domain/NamsReasoningStep.cs
+++ b/src/AgentMemory.Nams/Domain/NamsReasoningStep.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// A reasoning step -- covers both <c>POST /v1/reasoning/steps</c>'s create-response (which omits
+/// <see cref="CreatedAt"/>) and the list/trace endpoints' shape (which includes it), confirmed live
+/// (Phase 10e/10h). One shape covers both rather than two near-duplicate records, matching how
+/// <see cref="NamsMessage"/> already covers multiple endpoints' near-identical shapes.
+/// </summary>
+internal sealed record NamsReasoningStep(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("conversationId")] string? ConversationId,
+    [property: JsonPropertyName("reasoning")] string Reasoning,
+    [property: JsonPropertyName("actionTaken")] string ActionTaken,
+    [property: JsonPropertyName("result")] string? Result,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt);

--- a/src/AgentMemory.Nams/Domain/NamsReasoningTrace.cs
+++ b/src/AgentMemory.Nams/Domain/NamsReasoningTrace.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>Result of <c>GET /v1/reasoning/trace/{conversationId}</c> -- a flat conversation-scoped bundle of
+/// all recorded steps and tool calls (confirmed live, Phase 10e: flat, not steps-with-nested-toolCalls despite
+/// the endpoint's own prose description implying nesting).</summary>
+internal sealed record NamsReasoningTrace(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("steps")] IReadOnlyList<NamsReasoningStep> Steps,
+    [property: JsonPropertyName("toolCalls")] IReadOnlyList<NamsToolCall> ToolCalls);

--- a/src/AgentMemory.Nams/Domain/NamsToolCall.cs
+++ b/src/AgentMemory.Nams/Domain/NamsToolCall.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// A recorded tool call -- covers both <c>POST /v1/reasoning/tool-calls</c>'s create-response (which only
+/// echoes <see cref="Id"/>/<see cref="StepId"/>/<see cref="ToolName"/>/<see cref="Status"/>) and the trace
+/// endpoint's shape (which includes <see cref="Input"/>/<see cref="Output"/>/<see cref="DurationMs"/>/
+/// <see cref="CreatedAt"/>), confirmed live (Phase 10e/10h). <see cref="Input"/>/<see cref="Output"/> are
+/// JSON-encoded strings on the wire, not nested objects -- NAMS stores them as scalar string properties.
+/// </summary>
+internal sealed record NamsToolCall(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("stepId")] string? StepId,
+    [property: JsonPropertyName("toolName")] string ToolName,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("input")] string? Input,
+    [property: JsonPropertyName("output")] string? Output,
+    [property: JsonPropertyName("durationMs")] int? DurationMs,
+    [property: JsonPropertyName("createdAt")] string? CreatedAt);

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsReasoningTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsReasoningTests.cs
@@ -1,0 +1,98 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using FluentAssertions;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.Tests.Integration.Nams;
+
+/// <summary>
+/// Live tests for the Phase 10h TCK Platinum reasoning/provenance additions: <see cref="INamsClient.RecordReasoningStepAsync"/>,
+/// <see cref="INamsClient.ListReasoningStepsAsync"/>, <see cref="INamsClient.RecordToolCallAsync"/>,
+/// <see cref="INamsClient.GetReasoningTraceAsync"/>, and <see cref="INamsClient.GetEntityProvenanceAsync"/>. See
+/// <c>docs/reviews/NAMS_Phase10h_ReasoningProvenance_PlanningAndImplementationPlan.md</c> for the design.
+/// Unlike Phase 10f's observations, recording and immediately reading back a reasoning step/tool call is a
+/// direct, synchronous write/read with no async worker delay (confirmed live) -- so those get genuine
+/// positive-assertion tests. Provenance links to async entity extraction (the same family as observations), so
+/// it only gets a shape/wiring test, per that phase's hard-won lesson against forcing unreliable timing.
+/// </summary>
+[Collection("NAMS Live")]
+[Trait("Category", "Integration")]
+public sealed class NamsReasoningTests
+{
+    private readonly NamsLiveFixture _fixture;
+
+    public NamsReasoningTests(NamsLiveFixture fixture) => _fixture = fixture;
+
+    [LiveNamsFact]
+    public async Task RecordReasoningStepAsync_ThenListReasoningStepsAsync_ReturnsTheRecordedStep()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var conversation = await namsClient.CreateConversationAsync(UniqueUserId(), null, CancellationToken.None);
+        var marker = Guid.NewGuid().ToString("N");
+
+        try
+        {
+            var recorded = await namsClient.RecordReasoningStepAsync(
+                conversation.Id, $"reasoning-{marker}", $"action-{marker}", $"result-{marker}", CancellationToken.None);
+            recorded.ConversationId.Should().Be(conversation.Id);
+
+            var steps = await namsClient.ListReasoningStepsAsync(conversation.Id, CancellationToken.None);
+
+            steps.Should().ContainSingle(s => s.Id == recorded.Id).Which.Reasoning.Should().Be($"reasoning-{marker}");
+        }
+        finally
+        {
+            await namsClient.DeleteConversationAsync(conversation.Id, CancellationToken.None);
+        }
+    }
+
+    [LiveNamsFact]
+    public async Task RecordToolCallAsync_LinkedToAStep_AppearsInTheTrace()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var conversation = await namsClient.CreateConversationAsync(UniqueUserId(), null, CancellationToken.None);
+        var marker = Guid.NewGuid().ToString("N");
+
+        try
+        {
+            var step = await namsClient.RecordReasoningStepAsync(
+                conversation.Id, "deciding to search", $"search-{marker}", null, CancellationToken.None);
+            var toolCall = await namsClient.RecordToolCallAsync(
+                step.Id, $"tool-{marker}", "{\"query\":\"test\"}", "{\"results\":[]}", "success", 42, CancellationToken.None);
+
+            var trace = await namsClient.GetReasoningTraceAsync(conversation.Id, CancellationToken.None);
+
+            trace.ConversationId.Should().Be(conversation.Id);
+            trace.Steps.Should().ContainSingle(s => s.Id == step.Id);
+            var tracedToolCall = trace.ToolCalls.Should().ContainSingle(t => t.Id == toolCall.Id).Which;
+            tracedToolCall.StepId.Should().Be(step.Id,
+                "the trace must correctly link the tool call back to the step it was recorded against");
+            tracedToolCall.ToolName.Should().Be($"tool-{marker}");
+        }
+        finally
+        {
+            await namsClient.DeleteConversationAsync(conversation.Id, CancellationToken.None);
+        }
+    }
+
+    [LiveNamsFact]
+    public async Task GetEntityProvenanceAsync_OnExistingEntity_ReturnsWellTypedResult()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var entities = await namsClient.ListEntitiesAsync(1, CancellationToken.None);
+        entities.Should().NotBeEmpty();
+        var entityId = entities[0].Id;
+
+        var provenance = await namsClient.GetEntityProvenanceAsync(entityId, CancellationToken.None);
+
+        provenance.EntityId.Should().Be(entityId,
+            "the response must echo back the exact entity id queried, not some other one");
+        provenance.Provenance.Should().NotBeNull();
+        // Deliberately not asserting non-empty Provenance -- linking reasoning to entity extraction is async
+        // worker machinery (the same family as Phase 10f's observations), and this phase's own design doc
+        // explains why forcing that timing is out of scope here.
+    }
+
+    private static string UniqueUserId([CallerMemberName] string testName = "") =>
+        $"test-{testName}-{Guid.NewGuid():N}";
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
@@ -71,6 +71,24 @@ public sealed class NamsConversationResolverTests
         public Task<NamsGraphExpansion> ExpandGraphAsync(
             string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsConversationIdentity Identity(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
@@ -58,6 +58,24 @@ public sealed class NamsHealthCheckTests
         public Task<NamsGraphExpansion> ExpandGraphAsync(
             string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsOptions ValidOptions() => new() { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = "nams_key" };

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
@@ -283,5 +283,23 @@ public sealed class NamsObservabilityTests
         public Task<NamsGraphExpansion> ExpandGraphAsync(
             string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
@@ -63,6 +63,24 @@ public sealed class NamsPersistenceServiceTests
         public Task<NamsGraphExpansion> ExpandGraphAsync(
             string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsPersistenceService CreateService(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
@@ -65,6 +65,24 @@ public sealed class NamsRecallServiceTests
         public Task<NamsGraphExpansion> ExpandGraphAsync(
             string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static readonly NamsContext EmptyContext = new([], [], []);

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -338,6 +338,109 @@ public sealed class Neo4jNamsClientAdapterTests
     }
 
     [Fact]
+    public async Task RecordReasoningStepAsync_Success_SendsPostAndDeserializesStep()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"id":"s1","conversationId":"conv-1","reasoning":"thinking","actionTaken":"search","result":"found it"}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var step = await adapter.RecordReasoningStepAsync("conv-1", "thinking", "search", "found it", CancellationToken.None);
+
+        step.Id.Should().Be("s1");
+        step.ConversationId.Should().Be("conv-1");
+        step.Reasoning.Should().Be("thinking");
+        step.ActionTaken.Should().Be("search");
+        step.Result.Should().Be("found it");
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Post);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/reasoning/steps"));
+    }
+
+    [Fact]
+    public async Task RecordReasoningStepAsync_ServerError_DoesNotRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.RecordReasoningStepAsync("conv-1", "thinking", "search", null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NamsOperationException>();
+        fake.Requests.Should().HaveCount(1); // a genuine write -- resending would create a duplicate step
+    }
+
+    [Fact]
+    public async Task ListReasoningStepsAsync_Success_DeserializesStepsAndUsesConversationIdQueryParam()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {"steps":[{"id":"s1","reasoning":"thinking","actionTaken":"search","createdAt":"2026-07-18T12:26:02.143Z"}]}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var steps = await adapter.ListReasoningStepsAsync("conv-1", CancellationToken.None);
+
+        steps.Single().Id.Should().Be("s1");
+        steps.Single().CreatedAt.Should().Be("2026-07-18T12:26:02.143Z");
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Get);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/reasoning/steps?conversation_id=conv-1"));
+    }
+
+    [Fact]
+    public async Task RecordToolCallAsync_Success_SendsPostWithPreSerializedInputOutput()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created,
+            """{"id":"t1","stepId":"s1","toolName":"web_search","status":"success"}"""));
+        var adapter = CreateAdapter(fake);
+
+        var toolCall = await adapter.RecordToolCallAsync(
+            "s1", "web_search", "{\"query\":\"foo\"}", "{\"results\":[\"r1\"]}", "success", 150, CancellationToken.None);
+
+        toolCall.Id.Should().Be("t1");
+        toolCall.StepId.Should().Be("s1");
+        toolCall.ToolName.Should().Be("web_search");
+        toolCall.Status.Should().Be("success");
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        using var requestJson = System.Text.Json.JsonDocument.Parse(requestBody);
+        requestJson.RootElement.GetProperty("input").GetString().Should().Be("{\"query\":\"foo\"}",
+            "input must be a pre-serialized JSON string value, not a nested object");
+        requestJson.RootElement.GetProperty("durationMs").GetInt32().Should().Be(150);
+    }
+
+    [Fact]
+    public async Task GetReasoningTraceAsync_Success_DeserializesFlatStepsAndToolCalls()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {"conversationId":"conv-1",
+             "steps":[{"id":"s1","reasoning":"thinking","actionTaken":"search","createdAt":"2026-07-18T12:26:02.143Z"}],
+             "toolCalls":[{"id":"t1","stepId":"s1","toolName":"web_search","status":"success","input":"{}",
+             "output":"{}","durationMs":42,"createdAt":"2026-07-18T12:26:03.729Z"}]}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var trace = await adapter.GetReasoningTraceAsync("conv-1", CancellationToken.None);
+
+        trace.ConversationId.Should().Be("conv-1");
+        trace.Steps.Single().Id.Should().Be("s1");
+        trace.ToolCalls.Single().StepId.Should().Be("s1");
+        trace.ToolCalls.Single().DurationMs.Should().Be(42);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/reasoning/trace/conv-1"));
+    }
+
+    [Fact]
+    public async Task GetEntityProvenanceAsync_Success_DeserializesEnvelopeWithProvenanceField()
+    {
+        // Confirmed live (Phase 10e): the field is named "provenance", not "steps" as the pinned OpenAPI
+        // snapshot's schema name wrongly implied.
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """{"entityId":"e1","provenance":[]}"""));
+        var adapter = CreateAdapter(fake);
+
+        var provenance = await adapter.GetEntityProvenanceAsync("e1", CancellationToken.None);
+
+        provenance.EntityId.Should().Be("e1");
+        provenance.Provenance.Should().BeEmpty();
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/reasoning/provenance/e1"));
+    }
+
+    [Fact]
     public async Task AnyOperation_CallerCancellation_PropagatesOperationCanceledException()
     {
         var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));


### PR DESCRIPTION
## Summary
- Adds `RecordReasoningStepAsync`, `ListReasoningStepsAsync`, `RecordToolCallAsync`, `GetReasoningTraceAsync`, and `GetEntityProvenanceAsync` to `INamsClient` -- the first methods touching a domain this client has never exposed before. Low-level client capability only, not wired into higher-level services or MCP tools yet.
- Unlike Phase 10f's observations, recording and immediately reading back a reasoning step/tool call is a direct, synchronous write/read with no async worker delay (confirmed live) -- so those get genuine positive-assertion live tests. Entity provenance links to async entity-extraction machinery (the same family as observations), so it only gets a shape/wiring test, per that phase's hard-won lesson against forcing unreliable timing.
- Provenance's individual entry shape is modeled as raw `JsonElement` rather than guessing a concrete type -- the Phase 10e probe only confirmed the envelope field name (`provenance`, not `steps` as the pinned OpenAPI snapshot's schema name wrongly implied), never a populated example.
- Self-reviewed via two parallel agents (correctness + conventions): fixed one envelope-record naming inconsistency; correctness review found no bugs and confirmed this phase did not repeat any of the naming/idempotency/file-organization mistakes caught in Phase 10f/10g's own self-reviews.

## Test plan
- [x] Full Release build (0 warnings/errors)
- [x] Full unit + SemanticKernel suite: 3275 passed
- [x] Full `Category=Integration` suite (Testcontainers Neo4j + live NAMS): 327 passed
- [x] All 3 new NAMS live tests passed against the real NAMS SaaS dev workspace
- [x] Two parallel self-review agents (correctness, conventions) -- findings addressed

No GitHub Copilot review requested (out of credits, per standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)