### PR TITLE
NAMS Phase 10i: Cypher query console (gated capability)

### DIFF
--- a/docs/reviews/NAMS_Phase10i_CypherQueryConsole_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10i_CypherQueryConsole_PlanningAndImplementationPlan.md
@@ -1,0 +1,73 @@
+# NAMS Phase 10i: Cypher Query Console — Planning & Implementation Plan
+
+## Scope, and why this phase required explicit approval
+
+Adds the TCK Platinum `cypher_query` capability to `INamsClient`: `POST /v1/query`, a caller-supplied
+Cypher passthrough against the tenant's graph database. Unlike every other Phase 10e-10h addition, this
+one was **deliberately not started under the general autonomous-execution authorization** — it was
+called out from the first scoping pass (`neo4j-meeting-2026-07-nams-priority.md`) as needing the user's
+explicit go-ahead, the same treatment as Phase 12 (release), because it's a security/design decision
+(raw Cypher passthrough) rather than a routine capability add, even though NAMS enforces read-only
+server-side. The user was asked directly after Phase 10h merged and confirmed proceeding.
+
+Same tier as every prior Phase 10 addition otherwise: low-level `INamsClient` capability only (already
+`internal`, not part of the public NuGet surface), **not** wired into any higher-level service or MCP
+tool in this phase — a caller-facing exposure decision (e.g. a new MCP tool, or a public service method)
+is explicitly a separate, later decision, not bundled into this one.
+
+## Design, informed by the Phase 10e live-probe spike
+
+Both the request/response shape and the read-only guarantee were already confirmed live in Phase 10e —
+no new probing needed. Key finding from that probe, worth restating because it's the crux of why this
+capability is acceptable to add at all: a real `CREATE` write attempt against the live NAMS SaaS was
+rejected with **HTTP 400**, `{"error":"write operations are not permitted via this endpoint"}` — this is
+a genuine, server-enforced guarantee, not merely a documentation claim. This phase's own live test
+re-confirms that guarantee empirically as part of the merged suite (see below), rather than relying on
+the Phase 10e finding alone.
+
+```csharp
+internal sealed record NamsQueryResult(
+    [property: JsonPropertyName("columns")] IReadOnlyList<string> Columns,
+    [property: JsonPropertyName("rows")] IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> Rows,
+    [property: JsonPropertyName("stats")] IReadOnlyDictionary<string, JsonElement>? Stats);
+```
+
+Rows are per-record dictionaries keyed by column name with heterogeneous values (confirmed live:
+`{"columns":["cnt"],"rows":[{"cnt":541}],"stats":{...}}`) — modeled as `JsonElement` values, matching the
+precedent already established for `NamsExpandNode.Properties` (Phase 10g) and `NamsEntityProvenance`
+(Phase 10h) for genuinely heterogeneous/untyped wire payloads. `stats` is likewise untyped per the pinned
+schema (`additionalProperties: true`) — the live probe saw a fixed set of int counters, but modeling it
+generically avoids brittleness if NAMS adds/removes fields.
+
+`ExecuteCypherQueryAsync(string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken)`
+— named with the full "Cypher" qualifier (not just "Query") to avoid ambiguity with this codebase's
+existing `Search*Async` methods, which are also loosely "queries." `parameters` accepts a heterogeneous
+dictionary (Cypher params can be any JSON-compatible value: string/number/bool/null/nested
+list-or-map) and serializes generically via `System.Text.Json`'s built-in object handling.
+
+## Idempotency classification
+
+A `POST` verb, but read-only by the endpoint's own server-enforced contract (confirmed live) — same
+idempotent-for-retry treatment as `SearchEntitiesAsync`/`ExpandGraphAsync`.
+
+## Implementation checklist
+
+1. New domain record `NamsQueryResult` (`src/AgentMemory.Nams/Domain/`, one file).
+2. `INamsClient`: add `ExecuteCypherQueryAsync`, with a doc comment that states the read-only guarantee
+   is server-enforced (confirmed live) and explicitly notes this is not wired into any higher-level
+   service or MCP tool — exposing raw Cypher to an agent/end-user is a separate, later decision.
+3. `Neo4jNamsClientAdapter`: implement it; wire-only `ExecuteCypherQueryRequestBody` record.
+4. Live tests (`tests/AgentMemory.Tests.Integration/Nams/NamsCypherQueryTests.cs`, new file,
+   `LiveNamsFactAttribute`-gated):
+   - `ExecuteCypherQueryAsync_ReadQuery_ReturnsRealResults`: run a simple, genuinely informative read
+     query (`MATCH (n) RETURN count(n) AS cnt`) and assert the response has the expected column name and
+     a real (not hardcoded) row value — proves live round-trip, not just "didn't throw."
+   - `ExecuteCypherQueryAsync_WriteAttempt_IsRejectedByTheServer`: attempt a real `CREATE` against the
+     live dev workspace and assert it throws with a failure kind mapping the documented 400 — the single
+     most important test in this phase, since it's the empirical proof the safety property this whole
+     phase's approval was conditioned on actually holds, not just documented.
+   - `ExecuteCypherQueryAsync_WithParameters_SubstitutesThemCorrectly`: pass a parameterized query
+     (`MATCH (n) WHERE n.id = $id RETURN n.id AS id` or similar safe read) with a real param value and
+     assert the substitution genuinely happened — proves parameters aren't silently dropped/ignored.
+5. Unit-level wire-shape tests in `Neo4jNamsClientAdapterTests.cs`, using the exact confirmed JSON shapes
+   above, plus a test confirming a 400 response maps to a client-thrown exception (not silently swallowed).

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -165,4 +165,18 @@ internal interface INamsClient
     /// into any higher-level service or MCP tool yet.
     /// </summary>
     Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes a caller-supplied Cypher query against the tenant's graph (<c>POST /v1/query</c>) --
+    /// confirmed live as part of the Phase 10e TCK Platinum probe. NAMS enforces read-only server-side: a real
+    /// write attempt (<c>CREATE</c>) was confirmed live to be rejected with HTTP 400, not merely documented as
+    /// read-only. A POST verb, but read-only by that server-enforced contract -- treated as idempotent-for-retry
+    /// like <see cref="ExpandGraphAsync"/>. This is the last TCK Platinum capability added deliberately behind
+    /// explicit user approval (like Phase 12) rather than the general autonomous-execution authorization
+    /// covering Phase 10e-10h, given it's a raw-Cypher-passthrough security/design decision. Deliberately not
+    /// wired into any higher-level service or MCP tool -- exposing this to an agent/end-user is a separate,
+    /// later decision from adding the client capability itself.
+    /// </summary>
+    Task<NamsQueryResult> ExecuteCypherQueryAsync(
+        string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -232,6 +232,17 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             DeserializeAsync<NamsEntityProvenance>,
             cancellationToken);
 
+    public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+        string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "execute_cypher_query",
+            // Read-only by NAMS's own server-enforced contract (confirmed live) -- same idempotent-for-retry
+            // treatment as ExpandGraphAsync/SearchEntitiesAsync despite the POST verb.
+            () => BuildJsonRequest(HttpMethod.Post, "query", new ExecuteCypherQueryRequestBody(cypher, parameters)),
+            isIdempotent: true,
+            DeserializeAsync<NamsQueryResult>,
+            cancellationToken);
+
     private async Task<T> InvokeAsync<T>(
         string operationName,
         Func<HttpRequestMessage> requestFactory,
@@ -363,4 +374,8 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         [property: JsonPropertyName("output")] string? Output,
         [property: JsonPropertyName("status")] string? Status,
         [property: JsonPropertyName("durationMs")] int? DurationMs);
+
+    private sealed record ExecuteCypherQueryRequestBody(
+        [property: JsonPropertyName("cypher")] string Cypher,
+        [property: JsonPropertyName("params")] IReadOnlyDictionary<string, object?>? Params);
 }

--- a/src/AgentMemory.Nams/Domain/NamsQueryResult.cs
+++ b/src/AgentMemory.Nams/Domain/NamsQueryResult.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// Result of <c>POST /v1/query</c> -- a caller-supplied, server-enforced-read-only Cypher query (confirmed
+/// live, Phase 10e: a real write attempt was rejected with HTTP 400). Rows are per-record dictionaries keyed
+/// by column name with heterogeneous values, modeled as <see cref="JsonElement"/> -- the same untyped-payload
+/// treatment already used for <c>NamsExpandNode.Properties</c> (Phase 10g) and <c>NamsEntityProvenance</c>
+/// (Phase 10h). <see cref="Stats"/> is likewise untyped per the pinned schema (a fixed set of int counters was
+/// observed live, but modeling it generically avoids brittleness if NAMS adds/removes fields).
+/// </summary>
+internal sealed record NamsQueryResult(
+    [property: JsonPropertyName("columns")] IReadOnlyList<string> Columns,
+    [property: JsonPropertyName("rows")] IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> Rows,
+    [property: JsonPropertyName("stats")] IReadOnlyDictionary<string, JsonElement>? Stats);

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsCypherQueryTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsCypherQueryTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using FluentAssertions;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+
+namespace AgentMemory.Tests.Integration.Nams;
+
+/// <summary>
+/// Live tests for the Phase 10i TCK Platinum Cypher query console: <see cref="INamsClient.ExecuteCypherQueryAsync"/>.
+/// See <c>docs/reviews/NAMS_Phase10i_CypherQueryConsole_PlanningAndImplementationPlan.md</c> for the design and
+/// for why this phase specifically required the user's explicit go-ahead before implementation (unlike Phase
+/// 10e-10h). <see cref="ExecuteCypherQueryAsync_WriteAttempt_IsRejectedByTheServer"/> is the single most
+/// important test in this phase: it re-confirms, as part of the merged suite (not just a one-off research
+/// probe), that NAMS's read-only enforcement is a real server-side guarantee -- the property this whole
+/// capability's approval was conditioned on.
+/// </summary>
+[Collection("NAMS Live")]
+[Trait("Category", "Integration")]
+public sealed class NamsCypherQueryTests
+{
+    private readonly NamsLiveFixture _fixture;
+
+    public NamsCypherQueryTests(NamsLiveFixture fixture) => _fixture = fixture;
+
+    [LiveNamsFact]
+    public async Task ExecuteCypherQueryAsync_ReadQuery_ReturnsRealResults()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+
+        var result = await namsClient.ExecuteCypherQueryAsync(
+            "MATCH (n) RETURN count(n) AS cnt", parameters: null, CancellationToken.None);
+
+        result.Columns.Should().Equal("cnt");
+        result.Rows.Should().ContainSingle();
+        result.Rows[0]["cnt"].GetInt32().Should().BeGreaterThan(0,
+            "this live dev workspace has accumulated real graph data from every prior phase's live tests");
+    }
+
+    [LiveNamsFact]
+    public async Task ExecuteCypherQueryAsync_WriteAttempt_IsRejectedByTheServer()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+
+        var act = () => namsClient.ExecuteCypherQueryAsync(
+            "CREATE (n:Phase10iShouldNeverExist {marker: 1}) RETURN n", parameters: null, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>(
+            "NAMS must enforce read-only server-side -- this is the empirical guarantee this whole " +
+            "capability's approval was conditioned on, not just a documentation claim");
+        exception.Which.FailureKind.Should().Be(NamsFailureKind.Validation);
+    }
+
+    [LiveNamsFact]
+    public async Task ExecuteCypherQueryAsync_WithParameters_SubstitutesThemCorrectly()
+    {
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var entities = await namsClient.ListEntitiesAsync(1, CancellationToken.None);
+        entities.Should().NotBeEmpty();
+        var knownEntityId = entities[0].Id;
+
+        var result = await namsClient.ExecuteCypherQueryAsync(
+            "MATCH (n) WHERE n.id = $id RETURN n.id AS id",
+            new Dictionary<string, object?> { ["id"] = knownEntityId },
+            CancellationToken.None);
+
+        result.Rows.Should().ContainSingle(
+            "the parameter must genuinely substitute into the query -- a silently-ignored or malformed " +
+            "$id parameter would either match everything or nothing, not exactly the one entity queried");
+        result.Rows[0]["id"].GetString().Should().Be(knownEntityId);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsConversationResolverTests.cs
@@ -89,6 +89,10 @@ public sealed class NamsConversationResolverTests
 
         public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+            string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsConversationIdentity Identity(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsHealthCheckTests.cs
@@ -76,6 +76,10 @@ public sealed class NamsHealthCheckTests
 
         public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+            string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsOptions ValidOptions() => new() { Endpoint = new Uri("https://nams.test/v1/"), ApiKey = "nams_key" };

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsObservabilityTests.cs
@@ -301,5 +301,9 @@ public sealed class NamsObservabilityTests
 
         public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+            string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsPersistenceServiceTests.cs
@@ -81,6 +81,10 @@ public sealed class NamsPersistenceServiceTests
 
         public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+            string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static NamsPersistenceService CreateService(

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRecallServiceTests.cs
@@ -83,6 +83,10 @@ public sealed class NamsRecallServiceTests
 
         public Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
+
+        public Task<NamsQueryResult> ExecuteCypherQueryAsync(
+            string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 
     private static readonly NamsContext EmptyContext = new([], [], []);

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -441,6 +441,58 @@ public sealed class Neo4jNamsClientAdapterTests
     }
 
     [Fact]
+    public async Task ExecuteCypherQueryAsync_Success_SendsCypherAndParamsAndDeserializesResult()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """
+            {"columns":["cnt"],"rows":[{"cnt":541}],
+             "stats":{"nodesCreated":0,"nodesDeleted":0,"relationshipsCreated":0}}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.ExecuteCypherQueryAsync(
+            "MATCH (n) WHERE n.id = $id RETURN count(n) AS cnt",
+            new Dictionary<string, object?> { ["id"] = "e1" },
+            CancellationToken.None);
+
+        result.Columns.Should().Equal("cnt");
+        result.Rows.Single()["cnt"].GetInt32().Should().Be(541);
+        result.Stats!["nodesCreated"].GetInt32().Should().Be(0);
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Post);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/query"));
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        using var requestJson = System.Text.Json.JsonDocument.Parse(requestBody);
+        requestJson.RootElement.GetProperty("cypher").GetString().Should().Contain("$id");
+        requestJson.RootElement.GetProperty("params").GetProperty("id").GetString().Should().Be("e1");
+    }
+
+    [Fact]
+    public async Task ExecuteCypherQueryAsync_WriteRejectedByServer_ThrowsValidationFailure()
+    {
+        // Confirmed live (Phase 10e): a real CREATE attempt against the live NAMS SaaS was rejected with
+        // exactly this shape -- HTTP 400, {"error":"write operations are not permitted via this endpoint"}.
+        var fake = new FakeHttpMessageHandler(() => Json(
+            HttpStatusCode.BadRequest, """{"error":"write operations are not permitted via this endpoint"}"""));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.ExecuteCypherQueryAsync("CREATE (n:Test) RETURN n", null, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.FailureKind.Should().Be(NamsFailureKind.Validation);
+        fake.Requests.Should().HaveCount(1); // a 400 is not transient -- must not retry
+    }
+
+    [Fact]
+    public async Task ExecuteCypherQueryAsync_NullParameters_OmitsParamsWithoutError()
+    {
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.OK, """{"columns":[],"rows":[]}"""));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.ExecuteCypherQueryAsync("MATCH (n) RETURN n LIMIT 0", null, CancellationToken.None);
+
+        result.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task AnyOperation_CallerCancellation_PropagatesOperationCanceledException()
     {
         var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));


### PR DESCRIPTION
## Summary
- Adds `ExecuteCypherQueryAsync` (`POST /query`) to `INamsClient` -- a caller-supplied, read-only Cypher passthrough against the tenant's graph. Low-level client capability only, not wired into any higher-level service or MCP tool.
- Unlike Phase 10e-10h, this phase was deliberately **not** started under the general autonomous-execution authorization -- it was flagged from the first scoping pass as needing the user's explicit go-ahead (like Phase 12), given it's a security/design decision even though NAMS enforces read-only server-side. The user was asked directly after Phase 10h merged and confirmed proceeding.
- The live test suite re-confirms, as part of the merged tests, that NAMS's read-only enforcement is a real server-side guarantee: a live `CREATE` attempt is asserted to be rejected with a mapped validation failure. A second live test confirms Cypher parameters genuinely substitute by matching an exact known entity id.
- Self-reviewed via two parallel agents (correctness+security, conventions): **both returned zero findings** -- confirmed no read-only-bypass vector, no query/parameter leakage into telemetry beyond the existing API-key redaction pattern, correct idempotency-for-retry reasoning, and no repeat of the naming-drift class caught in Phase 10g/10h's own reviews.

This completes the TCK Platinum implementation for NAMS (Phases 10e-10i).

## Test plan
- [x] Full Release build (0 warnings/errors)
- [x] Full unit + SemanticKernel suite: 3278 passed
- [x] Full `Category=Integration` suite (Testcontainers Neo4j + live NAMS): 330 passed
- [x] All 3 new NAMS live tests passed against the real NAMS SaaS dev workspace, including the write-rejection safety test
- [x] Two parallel self-review agents (correctness+security, conventions) -- zero findings from either

No GitHub Copilot review requested (out of credits, per standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)