### PR TITLE
NAMS client: replace bool isIdempotent with a NamsRetryEligibility enum

### DIFF
--- a/src/AgentMemory.Nams/Client/NamsRetryEligibility.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryEligibility.cs
@@ -1,0 +1,25 @@
+namespace AgentMemory.Nams.Client;
+
+/// <summary>
+/// Whether a NAMS operation is safe for <see cref="NamsRetryPolicy"/> to retry automatically on a transient
+/// failure (429/5xx). Mirrors the engineering plan's own retry matrix: idempotent reads -- including read-only
+/// operations that happen to use a POST verb -- retry with backoff; non-idempotent writes make a single
+/// attempt, since <c>strategy/NAMS/Neo4j_Questions.md</c> #12-15 (does NAMS support idempotency keys?) are
+/// unanswered and retrying risks a duplicate side effect.
+///
+/// Introduced (Phase 10-followup) to replace a raw <c>bool isIdempotent</c> threaded through 18
+/// <see cref="Neo4jNamsClientAdapter"/> call sites -- each carried its own prose comment re-deriving this same
+/// general rule alongside its endpoint-specific fact. The general rule now lives here once; each call site's
+/// own comment states only the fact specific to that endpoint (e.g. "PUT full-value replace" or "server-
+/// enforced read-only, confirmed live").
+/// </summary>
+internal enum NamsRetryEligibility
+{
+    /// <summary>Resending this request is safe: either it's a pure read, or a full-value-replace/read-only-
+    /// enforced operation where retrying reproduces the same end state.</summary>
+    Idempotent,
+
+    /// <summary>Resending this request risks a duplicate side effect (e.g. a second row created) -- never
+    /// retried automatically, regardless of transient-failure classification.</summary>
+    NonIdempotent
+}

--- a/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
@@ -31,11 +31,11 @@ internal sealed class NamsRetryPolicy
     public async Task<HttpResponseMessage> ExecuteAsync(
         Func<HttpRequestMessage> requestFactory,
         HttpClient httpClient,
-        bool isIdempotent,
+        NamsRetryEligibility retryEligibility,
         CancellationToken cancellationToken,
         Action? onRetry = null)
     {
-        if (!isIdempotent)
+        if (retryEligibility == NamsRetryEligibility.NonIdempotent)
             return await httpClient.SendAsync(requestFactory(), cancellationToken).ConfigureAwait(false);
 
         for (var attempt = 0; ; attempt++)

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -47,7 +47,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         InvokeAsync(
             "resolve_conversation",
             () => BuildJsonRequest(HttpMethod.Post, "conversations", new CreateConversationRequestBody(userId, metadata)),
-            isIdempotent: false,
+            retryEligibility: NamsRetryEligibility.NonIdempotent,
             DeserializeAsync<NamsConversation>,
             cancellationToken);
 
@@ -55,7 +55,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         InvokeAsync(
             "get_context",
             () => new HttpRequestMessage(HttpMethod.Get, $"conversations/{Uri.EscapeDataString(conversationId)}/context"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsContext>,
             cancellationToken);
 
@@ -66,7 +66,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         var response = await InvokeAsync(
             "store_turn",
             () => BuildJsonRequest(HttpMethod.Post, path, new AddMessagesBulkRequestBody(messages)),
-            isIdempotent: false,
+            retryEligibility: NamsRetryEligibility.NonIdempotent,
             DeserializeAsync<AddMessagesBatchResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Messages;
@@ -75,13 +75,12 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     public async Task<IReadOnlyList<NamsEntity>> SearchEntitiesAsync(
         string query, string? type, int limit, CancellationToken cancellationToken)
     {
-        // A POST verb, but a pure read-only query with no server-side side effects -- safe to treat as
-        // idempotent for retry purposes (matches the engineering plan's retry matrix, which lists "Search" as
-        // always-retryable regardless of the verb it happens to use).
+        // A POST verb, but a pure read-only query with no server-side side effects -- the engineering plan's
+        // retry matrix lists "Search" as always-retryable regardless of the verb it happens to use.
         var response = await InvokeAsync(
             "search_entities",
             () => BuildJsonRequest(HttpMethod.Post, "entities/search", new SearchEntitiesRequestBody(query, type, limit)),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<SearchEntitiesResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Entities;
@@ -92,7 +91,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         var response = await InvokeAsync(
             "list_entities",
             () => new HttpRequestMessage(HttpMethod.Get, $"entities?limit={limit.ToString(CultureInfo.InvariantCulture)}"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<ListEntitiesResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Entities;
@@ -101,13 +100,12 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     public async Task<IReadOnlyList<NamsMessage>> SearchMessagesAsync(
         string conversationId, string query, int limit, CancellationToken cancellationToken)
     {
-        // A POST verb, but a pure read-only query with no server-side side effects -- same idempotent-for-
-        // retry-purposes treatment as SearchEntitiesAsync above.
+        // A POST verb, but a pure read-only query with no server-side side effects, same as SearchEntitiesAsync.
         var path = $"conversations/{Uri.EscapeDataString(conversationId)}/search";
         var response = await InvokeAsync(
             "search_messages",
             () => BuildJsonRequest(HttpMethod.Post, path, new SearchMessagesRequestBody(query, limit)),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<SearchMessagesResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Messages;
@@ -118,8 +116,8 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             "delete_conversation",
             () => new HttpRequestMessage(HttpMethod.Delete, $"conversations/{Uri.EscapeDataString(conversationId)}"),
             // Confirmed live: deleting an already-deleted (or otherwise nonexistent) conversation still
-            // returns 200, not 404 -- genuinely idempotent, safe to retry like any other read.
-            isIdempotent: true,
+            // returns 200, not 404 -- genuinely idempotent.
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<DeleteConversationResponseBody>,
             cancellationToken);
 
@@ -129,7 +127,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         var response = await InvokeAsync(
             "list_conversations",
             () => new HttpRequestMessage(HttpMethod.Get, $"conversations?limit={limit.ToString(CultureInfo.InvariantCulture)}"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<ListConversationsResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Conversations;
@@ -142,7 +140,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         var response = await InvokeAsync(
             "get_observations",
             () => new HttpRequestMessage(HttpMethod.Get, path),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<GetObservationsResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Observations;
@@ -156,9 +154,8 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
                 HttpMethod.Put, $"entities/{Uri.EscapeDataString(entityId)}/feedback",
                 new EntityFeedbackRequestBody(userScore, confirmed)),
             // A PUT full-value replacement, not a POST create -- resending the same body produces the same end
-            // state, none of the duplicate-row risk NamsRetryPolicy's writes-don't-retry default guards
-            // against. Genuinely idempotent, safe to retry like DeleteConversationAsync above.
-            isIdempotent: true,
+            // state, none of the duplicate-row risk a non-idempotent classification guards against.
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsEntityFeedbackResult>,
             cancellationToken);
 
@@ -166,7 +163,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         InvokeAsync(
             "get_entity_graph",
             () => new HttpRequestMessage(HttpMethod.Get, "entities/graph"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsEntityGraph>,
             cancellationToken);
 
@@ -174,10 +171,9 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken) =>
         InvokeAsync(
             "expand_graph",
-            // POST verb, but read-only (no server-side side effects) -- same idempotent-for-retry treatment
-            // as SearchEntitiesAsync/SearchMessagesAsync.
+            // POST verb, but read-only (no server-side side effects), same as SearchEntitiesAsync/SearchMessagesAsync.
             () => BuildJsonRequest(HttpMethod.Post, "graph/expand", new ExpandGraphRequestBody(nodeId, loadedIds)),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsGraphExpansion>,
             cancellationToken);
 
@@ -188,7 +184,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             () => BuildJsonRequest(
                 HttpMethod.Post, "reasoning/steps",
                 new RecordReasoningStepRequestBody(conversationId, reasoning, actionTaken, result)),
-            isIdempotent: false,
+            retryEligibility: NamsRetryEligibility.NonIdempotent,
             DeserializeAsync<NamsReasoningStep>,
             cancellationToken);
 
@@ -199,7 +195,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         var response = await InvokeAsync(
             "list_reasoning_steps",
             () => new HttpRequestMessage(HttpMethod.Get, path),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<ListReasoningStepsResponseBody>,
             cancellationToken).ConfigureAwait(false);
         return response.Steps;
@@ -213,7 +209,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             () => BuildJsonRequest(
                 HttpMethod.Post, "reasoning/tool-calls",
                 new RecordToolCallRequestBody(stepId, toolName, input, output, status, durationMs)),
-            isIdempotent: false,
+            retryEligibility: NamsRetryEligibility.NonIdempotent,
             DeserializeAsync<NamsToolCall>,
             cancellationToken);
 
@@ -221,7 +217,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         InvokeAsync(
             "get_reasoning_trace",
             () => new HttpRequestMessage(HttpMethod.Get, $"reasoning/trace/{Uri.EscapeDataString(conversationId)}"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsReasoningTrace>,
             cancellationToken);
 
@@ -229,7 +225,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         InvokeAsync(
             "get_entity_provenance",
             () => new HttpRequestMessage(HttpMethod.Get, $"reasoning/provenance/{Uri.EscapeDataString(entityId)}"),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsEntityProvenance>,
             cancellationToken);
 
@@ -237,17 +233,17 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
         InvokeAsync(
             "execute_cypher_query",
-            // Read-only by NAMS's own server-enforced contract (confirmed live) -- same idempotent-for-retry
-            // treatment as ExpandGraphAsync/SearchEntitiesAsync despite the POST verb.
+            // Read-only by NAMS's own server-enforced contract (confirmed live), same as ExpandGraphAsync/
+            // SearchEntitiesAsync despite the POST verb.
             () => BuildJsonRequest(HttpMethod.Post, "query", new ExecuteCypherQueryRequestBody(cypher, parameters)),
-            isIdempotent: true,
+            retryEligibility: NamsRetryEligibility.Idempotent,
             DeserializeAsync<NamsQueryResult>,
             cancellationToken);
 
     private async Task<T> InvokeAsync<T>(
         string operationName,
         Func<HttpRequestMessage> requestFactory,
-        bool isIdempotent,
+        NamsRetryEligibility retryEligibility,
         Func<Stream, CancellationToken, Task<T>> deserialize,
         CancellationToken cancellationToken)
     {
@@ -256,7 +252,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         try
         {
             using var response = await _retryPolicy.ExecuteAsync(
-                requestFactory, _httpClient, isIdempotent, cancellationToken,
+                requestFactory, _httpClient, retryEligibility, cancellationToken,
                 onRetry: () => _metrics.BackendRetries.Add(1, NamsMetricTags.Operation(operationName)))
                 .ConfigureAwait(false);
             var result = await NamsClientExceptionMapper.MapResponseAsync(response, deserialize, _apiKeyForRedaction, cancellationToken)

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
@@ -20,7 +20,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         fake.Requests.Should().HaveCount(2);
@@ -33,7 +33,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy(maxAttempts: 2).ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         fake.Requests.Should().HaveCount(3); // initial attempt + 2 retries
@@ -53,7 +53,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         fake.Requests.Should().HaveCount(2);
@@ -76,7 +76,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         fake.Requests.Should().HaveCount(2);
@@ -89,7 +89,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         fake.Requests.Should().HaveCount(1);
@@ -102,7 +102,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Post, "x"), client, isIdempotent: false, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Post, "x"), client, retryEligibility: NamsRetryEligibility.NonIdempotent, CancellationToken.None);
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
         fake.Requests.Should().HaveCount(1);
@@ -117,7 +117,7 @@ public sealed class NamsRetryPolicyTests
         await cts.CancelAsync();
 
         var act = () => CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, cts.Token);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
@@ -132,7 +132,7 @@ public sealed class NamsRetryPolicyTests
         var retryCount = 0;
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None,
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None,
             onRetry: () => retryCount++);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -147,7 +147,7 @@ public sealed class NamsRetryPolicyTests
         var retryCount = 0;
 
         using var response = await CreatePolicy().ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None,
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None,
             onRetry: () => retryCount++);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -161,7 +161,7 @@ public sealed class NamsRetryPolicyTests
         using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
 
         var act = () => CreatePolicy(maxAttempts: 2).ExecuteAsync(
-            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, isIdempotent: true, CancellationToken.None);
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
 
         await act.Should().ThrowAsync<HttpRequestException>();
         fake.Requests.Should().HaveCount(3); // initial attempt + 2 retries


### PR DESCRIPTION
## Summary
- Pure internal refactor, zero behavior change. The Phase 10 post-completion review flagged that `isIdempotent`'s retry-safety reasoning was duplicated as prose comments across 18 call sites in `Neo4jNamsClientAdapter`, with a raw `bool` giving no compiler signal if a future endpoint got misclassified.
- Replaced with `NamsRetryEligibility` (`Idempotent`/`NonIdempotent`), threaded through `NamsRetryPolicy.ExecuteAsync` and `InvokeAsync`; the general retry-safety rule now lives once on the enum's own doc comment, and each call site's comment keeps only its endpoint-specific fact.
- Doing this now rather than deferring it, since the per-endpoint retry classification reasoning was freshly re-verified across all 18 call sites during the post-completion review -- cheaper to encode while that context is live than to rebuild it later.

## Test plan
- [x] Full Release build (0 warnings/errors)
- [x] Full unit + SemanticKernel suite: 3279 passed
- [x] Full `Category=Integration` suite (Testcontainers Neo4j + live NAMS): 330 passed -- confirms zero behavior change
- [x] Two parallel self-review agents (correctness, conventions) -- both zero findings

No GitHub Copilot review requested (out of credits, per standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)