### PR TITLE
NAMS Phase 10j: CreateEntityAsync (add_entity), needed for the TCK Platinum bridge

### DIFF
--- a/docs/reviews/NAMS_Phase10j_CreateEntity_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_Phase10j_CreateEntity_PlanningAndImplementationPlan.md
@@ -1,0 +1,84 @@
+# NAMS Phase 10j: `CreateEntityAsync` — Planning & Implementation Plan
+
+## Scope and why now
+
+Adds `POST /v1/entities` (manual entity creation) to `INamsClient`. This was explicitly scoped **out** of
+Phase 10g ("`POST /entities` (manual entity creation) is out of scope, not part of any TCK Platinum scenario
+here") because none of `test_platinum.py`'s scenarios directly test entity creation. That's still true — but
+building a NAMS-backed TCK bridge (the next phase) requires it transitively: the upstream
+`test_set_entity_feedback_returns_updated` test calls `adapter.add_entity(...)` *before*
+`adapter.set_entity_feedback(...)`, so a bridge without a working `add_entity` route fails that test even
+though entity creation itself isn't what it's testing.
+
+## Design, informed by a live probe
+
+`POST /v1/entities` was live-probed for the first time this session (never confirmed before):
+
+Request: `{name, type, description?, properties?}` (`name`/`type` required per the pinned OpenAPI snapshot's
+`handlers.createEntityRequest`).
+
+Live response (confirmed): `{"description":"...","id":"...","name":"...","ontologyVersionId":"...",
+"resolution":"created","systemAdded":true,"type":"...","validationMode":"permissive"}` — richer than the
+pinned snapshot's `EntityResponse` definition (`{description, id, name, type}` only). Reuses the existing
+`NamsEntity` domain record (already used by `SearchEntitiesAsync`/`ListEntitiesAsync`/`GetEntityGraphAsync`'s
+nodes) rather than a new type — the extra live-only fields (`ontologyVersionId`/`resolution`/`systemAdded`/
+`validationMode`) aren't needed by any current caller and are silently ignored on deserialization, matching
+the established "one shape covers multiple endpoints" pattern (`NamsMessage`, `NamsReasoningStep`).
+
+A genuine write (creates a new entity) — `NamsRetryEligibility.NonIdempotent`, same tier as
+`CreateConversationAsync`.
+
+## Implementation checklist
+
+1. `INamsClient`: add `CreateEntityAsync(string name, string type, string? description, CancellationToken)`.
+2. `Neo4jNamsClientAdapter`: implement it; new wire-only `CreateEntityRequestBody` record.
+3. Live test (`NamsEntityGraphTests.cs`, new test method): create an entity with a distinctive name, assert
+   the response echoes it back with a real id — genuine because it's checking data this test itself just
+   created, not an ambient one.
+4. Unit wire-shape test in `Neo4jNamsClientAdapterTests.cs` using the exact confirmed live JSON shape above.
+5. Patch the 5 fake `INamsClient`/`ThrowingNamsClientStub` test doubles with the new member (mechanical,
+   `ThrowingNamsClientStub` needs the one new virtual method; the 5 per-test fakes need nothing since none
+   currently override it).
+
+Deliberately not wired into any higher-level service or MCP tool — same low-level-capability-only tier as
+every other Phase 10 addition.
+
+## Unplanned discovery: a real flakiness bug in Phase 10g's `ExpandGraphAsync` test
+
+Running the live suite after adding `CreateEntityAsync`'s own test surfaced a genuine, pre-existing bug:
+`ExpandGraphAsync_OnASeedEntity_ReturnsANonEmptyNeighborhood` (Phase 10g) used the shared
+`GetAnyExistingEntityIdAsync(namsClient, limit: 1, ...)` helper to pick "any" entity and assumed it would be
+well-connected. Confirmed live: `GET /entities?limit=` returns **newest-first**, and a just-created entity
+(e.g. from this very phase's own `CreateEntityAsync` test) genuinely has zero edges yet — relationship
+extraction lags entity creation, the same class of async-worker delay seen before (observations, provenance).
+The test failed for real when run in the same session as the new entity-creation test.
+
+**Fixed properly, not papered over:** the test now pulls the full workspace graph via
+`GetEntityGraphAsync()` and picks a seed entity *provably* referenced by at least one edge, rather than
+gambling on freshness. This is a strictly better test design (guaranteed connected, not probabilistically
+likely) that happens to also fix the flakiness.
+
+## Second unplanned discovery: `POST /v1/entities` has THREE response shapes, not one
+
+The `CreateEntityAsync` live test itself then failed for real: its entity name shared the
+`"TckBridgeProbeEntity"` prefix reused across many earlier probes in this same session's shared dev
+workspace, and NAMS's fuzzy entity-resolution auto-merged it into an existing entity instead of creating a
+new one. The response for that outcome (`"resolution":"merged"`) is a **completely different, minimal
+shape** -- `{id, resolution, merged_into, confidence}`, no `name`/`type`/`description` at all -- which the
+original design (deserializing into the reused `NamsEntity` type) silently accepted as null fields instead
+of failing loudly.
+
+Confirmed live, all three outcomes exist:
+- `"created"` -- genuinely new: full entity fields, no `duplicate_of`/`merged_into`.
+- `"review_pending"` -- probable duplicate: full entity fields **plus** `duplicate_of`.
+- `"merged"` -- auto-merged: **only** `id`/`resolution`/`merged_into`/`confidence`, nothing else.
+
+Also confirmed: NAMS's own wire casing is inconsistent between these fields -- the "success" fields
+(`ontologyVersionId`/`systemAdded`/`validationMode`) are camelCase, while the "duplicate-detection" fields
+(`duplicate_of`/`merged_into`) are snake_case. A real inconsistency in NAMS's own API, not a client bug.
+
+**Fixed properly:** introduced `NamsCreateEntityResult` (replacing the reused `NamsEntity` as
+`CreateEntityAsync`'s return type) modeling all three shapes honestly with nullable fields, documented in its
+own doc comment. The live test no longer assumes `"created"` will happen -- resolution is inherently
+probabilistic (name/semantic-similarity-based), so it asserts correctly on whichever real outcome occurs.
+Three unit tests now cover all three confirmed shapes.

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -183,4 +183,18 @@ internal interface INamsClient
     /// </summary>
     Task<NamsQueryResult> ExecuteCypherQueryAsync(
         string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Manually creates an entity (<c>POST /v1/entities</c>) -- confirmed live (Phase 10j). Entities are
+    /// normally created by the async extraction pipeline; this is the explicit-write counterpart, needed by
+    /// the upstream TCK's own <c>test_set_entity_feedback_returns_updated</c> Platinum scenario (it creates an
+    /// entity via <c>add_entity</c> before scoring it). Returns <see cref="NamsCreateEntityResult"/>, NOT
+    /// <see cref="NamsEntity"/> -- confirmed live that NAMS's own fuzzy entity-resolution can return a
+    /// genuinely different, minimal response shape (no name/type/description at all) when it auto-merges the
+    /// submission into an existing entity rather than creating a new one; see that type's own doc comment for
+    /// the full three-shape breakdown. A genuine write, not idempotent-for-retry. Deliberately not wired into
+    /// any higher-level service or MCP tool yet.
+    /// </summary>
+    Task<NamsCreateEntityResult> CreateEntityAsync(
+        string name, string type, string? description, CancellationToken cancellationToken);
 }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -240,6 +240,15 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
             DeserializeAsync<NamsQueryResult>,
             cancellationToken);
 
+    public Task<NamsCreateEntityResult> CreateEntityAsync(
+        string name, string type, string? description, CancellationToken cancellationToken) =>
+        InvokeAsync(
+            "create_entity",
+            () => BuildJsonRequest(HttpMethod.Post, "entities", new CreateEntityRequestBody(name, type, description)),
+            retryEligibility: NamsRetryEligibility.NonIdempotent,
+            DeserializeAsync<NamsCreateEntityResult>,
+            cancellationToken);
+
     private async Task<T> InvokeAsync<T>(
         string operationName,
         Func<HttpRequestMessage> requestFactory,
@@ -380,4 +389,9 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     private sealed record ExecuteCypherQueryRequestBody(
         [property: JsonPropertyName("cypher")] string Cypher,
         [property: JsonPropertyName("params"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyDictionary<string, object?>? Params);
+
+    private sealed record CreateEntityRequestBody(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("description"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Description);
 }

--- a/src/AgentMemory.Nams/Domain/NamsCreateEntityResult.cs
+++ b/src/AgentMemory.Nams/Domain/NamsCreateEntityResult.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.Nams.Domain;
+
+/// <summary>
+/// Result of <c>POST /v1/entities</c> -- confirmed live (Phase 10j) to have THREE genuinely different response
+/// shapes depending on NAMS's own fuzzy entity-resolution outcome, not the single shape the pinned OpenAPI
+/// snapshot's <c>EntityResponse</c> definition documents:
+///
+/// - <c>"created"</c> -- a genuinely new entity: <see cref="Name"/>/<see cref="Type"/>/<see cref="Description"/>
+///   populated, <see cref="DuplicateOf"/>/<see cref="MergedInto"/>/<see cref="Confidence"/> all null.
+/// - <c>"review_pending"</c> -- flagged as a probable (not certain) duplicate: same fields as <c>"created"</c>
+///   plus <see cref="DuplicateOf"/> naming the entity it might duplicate.
+/// - <c>"merged"</c> -- auto-merged into an existing entity with high confidence: a COMPLETELY different,
+///   minimal shape -- <see cref="Name"/>/<see cref="Type"/>/<see cref="Description"/>/<see cref="DuplicateOf"/>
+///   are all absent (null here); only <see cref="Id"/>/<see cref="Resolution"/>/<see cref="MergedInto"/>/
+///   <see cref="Confidence"/> are present.
+///
+/// This was discovered the hard way: a live test using a name that happened to collide (by repeated reuse of
+/// the same human-readable prefix across many probes in the same dev workspace) with an earlier probe entity
+/// got auto-merged, and the original design (deserializing directly into <see cref="NamsEntity"/>) silently
+/// returned null Name/Type/Description instead of failing loudly -- caught only because the live test asserted
+/// on the created name, not because of any thrown exception.
+///
+/// Also confirmed live: NAMS's own wire casing is inconsistent between these fields -- <c>ontologyVersionId</c>/
+/// <c>systemAdded</c>/<c>validationMode</c> (the "success" fields) are camelCase, while <c>duplicate_of</c>/
+/// <c>merged_into</c> (the "duplicate-detection" fields) are snake_case. This is a real inconsistency in NAMS's
+/// own API, not a client-side bug.
+/// </summary>
+internal sealed record NamsCreateEntityResult(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("resolution")] string Resolution,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("type")] string? Type,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("duplicate_of")] string? DuplicateOf,
+    [property: JsonPropertyName("merged_into")] string? MergedInto,
+    [property: JsonPropertyName("confidence")] double? Confidence);

--- a/tests/AgentMemory.Tests.Integration/Nams/NamsEntityGraphTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Nams/NamsEntityGraphTests.cs
@@ -9,10 +9,11 @@ namespace AgentMemory.Tests.Integration.Nams;
 /// <see cref="INamsClient.SetEntityFeedbackAsync"/>, <see cref="INamsClient.GetEntityGraphAsync"/>, and
 /// <see cref="INamsClient.ExpandGraphAsync"/>. See
 /// <c>docs/reviews/NAMS_Phase10g_EntityFeedbackGraph_PlanningAndImplementationPlan.md</c> for the design.
-/// Deliberately reuses an existing entity discovered via the already-shipped <see cref="INamsClient.ListEntitiesAsync"/>
-/// rather than creating one -- entity creation only happens via the async extraction pipeline or the
-/// out-of-scope <c>POST /entities</c> endpoint, and non-destructively scoring/reading an existing entity matches
-/// the same pattern the Phase 10e spike itself used.
+/// Most tests deliberately reuse an existing entity discovered via the already-shipped
+/// <see cref="INamsClient.ListEntitiesAsync"/> rather than creating one -- non-destructively scoring/reading an
+/// existing entity matches the same pattern the Phase 10e spike itself used.
+/// <see cref="INamsClient.CreateEntityAsync"/> (Phase 10j) is tested separately below, added specifically to
+/// support the NAMS TCK bridge's <c>add_entity</c> route.
 /// </summary>
 [Collection("NAMS Live")]
 [Trait("Category", "Integration")]
@@ -65,15 +66,57 @@ public sealed class NamsEntityGraphTests
     public async Task ExpandGraphAsync_OnASeedEntity_ReturnsANonEmptyNeighborhood()
     {
         var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
-        var seedId = await NamsLiveTestHelpers.GetAnyExistingEntityIdAsync(namsClient, limit: 1, CancellationToken.None);
+
+        // Deliberately NOT "any entity via ListEntitiesAsync(1)" -- that returns newest-first (confirmed live),
+        // and a just-created entity (e.g. from CreateEntityAsync's own live test, or any other test run in the
+        // same session) genuinely has zero edges yet, since relationship extraction lags entity creation. This
+        // real flakiness was caught while adding Phase 10j's CreateEntityAsync test. Instead, pull the full
+        // workspace graph and pick a seed provably referenced by at least one edge -- guaranteed connected,
+        // not gambling on freshness.
+        var graph = await namsClient.GetEntityGraphAsync(CancellationToken.None);
+        var connectedIds = (graph.Edges ?? []).SelectMany(e => new[] { e.SourceId, e.TargetId }).ToHashSet();
+        connectedIds.Should().NotBeEmpty("this workspace's entities are heavily interlinked from prior phases");
+        var seedId = connectedIds.First();
 
         var expansion = await namsClient.ExpandGraphAsync(seedId, [seedId], CancellationToken.None);
 
-        // This dev workspace's entities are heavily interlinked from many prior phases' live tests (confirmed
-        // Phase 10e: expanding a single entity returned 21 nodes/27 edges) -- a genuinely empty neighborhood
-        // would indicate expand is broken, not just that this particular entity happens to be isolated.
-        expansion.Nodes.Should().NotBeEmpty("this workspace's entities are heavily interlinked from prior phases");
+        expansion.Nodes.Should().NotBeEmpty("the seed was chosen specifically because it has at least one edge");
         expansion.Truncated.Should().NotBeNull();
         expansion.Truncated!.NodeId.Should().Be(seedId);
+    }
+
+    [LiveNamsFact]
+    public async Task CreateEntityAsync_ReturnsAWellFormedResultForWhicheverResolutionOccurs()
+    {
+        // Deliberately does NOT assume "created" -- this test ITSELF originally did, using a name sharing the
+        // "TckBridgeProbeEntity" prefix already reused across many earlier probes in this same shared dev
+        // workspace, and NAMS's own fuzzy entity-resolution auto-merged it ("resolution":"merged") instead of
+        // creating a new one, returning a genuinely different, minimal response shape (no name/type at all).
+        // See NamsCreateEntityResult's own doc comment for the full three-shape finding this caused. A
+        // resolution outcome is inherently probabilistic (semantic/name-similarity-based, not something a
+        // caller fully controls), so this test asserts on whichever real outcome occurs rather than gambling
+        // that name uniqueness alone guarantees "created".
+        var namsClient = _fixture.Services!.GetRequiredService<INamsClient>();
+        var marker = Guid.NewGuid().ToString("N");
+        var name = $"zzTckBridgeProbe{marker}";
+
+        var result = await namsClient.CreateEntityAsync(
+            name, "TestType", "created by CreateEntityAsync_ReturnsAWellFormedResultForWhicheverResolutionOccurs",
+            CancellationToken.None);
+
+        result.Id.Should().NotBeNullOrWhiteSpace();
+        result.Resolution.Should().NotBeNullOrWhiteSpace();
+        if (result.Resolution is "created" or "review_pending")
+        {
+            result.Name.Should().Be(name,
+                "the response must echo back the exact name this test just created, not some other entity");
+            result.Type.Should().Be("TestType");
+        }
+        else
+        {
+            result.Resolution.Should().Be("merged");
+            result.MergedInto.Should().NotBeNullOrWhiteSpace();
+            result.Confidence.Should().NotBeNull();
+        }
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -517,6 +517,89 @@ public sealed class Neo4jNamsClientAdapterTests
     }
 
     [Fact]
+    public async Task CreateEntityAsync_CreatedResolution_DeserializesFullEntityFields()
+    {
+        // Shape confirmed live (Phase 10j probe): richer than the pinned OpenAPI snapshot's EntityResponse
+        // (adds ontologyVersionId/resolution/systemAdded/validationMode, none of which NamsCreateEntityResult
+        // needs to model since they're not consumed).
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"description":"probe","id":"e1","name":"Acme","ontologyVersionId":"ov_1","resolution":"created",
+             "systemAdded":true,"type":"Org","validationMode":"permissive"}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.CreateEntityAsync("Acme", "Org", "probe", CancellationToken.None);
+
+        result.Id.Should().Be("e1");
+        result.Resolution.Should().Be("created");
+        result.Name.Should().Be("Acme");
+        result.Type.Should().Be("Org");
+        result.Description.Should().Be("probe");
+        result.DuplicateOf.Should().BeNull();
+        result.MergedInto.Should().BeNull();
+        fake.Requests.Single().Method.Should().Be(HttpMethod.Post);
+        fake.Requests.Single().RequestUri.Should().Be(new Uri("https://nams.test/v1/entities"));
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        using var requestJson = System.Text.Json.JsonDocument.Parse(requestBody);
+        requestJson.RootElement.GetProperty("name").GetString().Should().Be("Acme",
+            "name and type must not be transposed -- both are plain strings, so nothing else would catch it");
+        requestJson.RootElement.GetProperty("type").GetString().Should().Be("Org");
+        requestJson.RootElement.GetProperty("description").GetString().Should().Be("probe");
+    }
+
+    [Fact]
+    public async Task CreateEntityAsync_ReviewPendingResolution_DeserializesDuplicateOf()
+    {
+        // Confirmed live: a probable (not certain) duplicate still returns full entity fields, plus
+        // duplicate_of (snake_case -- confirmed inconsistent with this same response's camelCase fields).
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"description":"probe","duplicate_of":"e0","id":"e1","name":"Acme","ontologyVersionId":"ov_1",
+             "resolution":"review_pending","systemAdded":true,"type":"Org","validationMode":"permissive"}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.CreateEntityAsync("Acme", "Org", "probe", CancellationToken.None);
+
+        result.Resolution.Should().Be("review_pending");
+        result.Name.Should().Be("Acme");
+        result.DuplicateOf.Should().Be("e0");
+    }
+
+    [Fact]
+    public async Task CreateEntityAsync_MergedResolution_DeserializesMinimalShape_NoNameOrType()
+    {
+        // The genuinely surprising live discovery this phase's own live test caught: when NAMS auto-merges
+        // the submission into an existing entity, the response is a COMPLETELY different, minimal shape --
+        // no name/type/description/duplicate_of at all, only id/resolution/merged_into/confidence.
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"confidence":0.9413830497142857,"id":"e1","merged_into":"e0","resolution":"merged"}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        var result = await adapter.CreateEntityAsync("Acme", "Org", "probe", CancellationToken.None);
+
+        result.Id.Should().Be("e1");
+        result.Resolution.Should().Be("merged");
+        result.MergedInto.Should().Be("e0");
+        result.Confidence.Should().BeApproximately(0.9413830497142857, 1e-12);
+        result.Name.Should().BeNull("the merged-resolution response genuinely omits name -- this is not a bug");
+        result.Type.Should().BeNull();
+        result.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateEntityAsync_ServerError_DoesNotRetry()
+    {
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.CreateEntityAsync("Acme", "Org", null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NamsOperationException>();
+        fake.Requests.Should().HaveCount(1); // a genuine write -- resending would create a duplicate entity
+    }
+
+    [Fact]
     public async Task AnyOperation_CallerCancellation_PropagatesOperationCanceledException()
     {
         var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK));

--- a/tests/AgentMemory.Tests.Unit/Nams/ThrowingNamsClientStub.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/ThrowingNamsClientStub.cs
@@ -77,4 +77,8 @@ internal class ThrowingNamsClientStub : INamsClient
     public virtual Task<NamsQueryResult> ExecuteCypherQueryAsync(
         string cypher, IReadOnlyDictionary<string, object?>? parameters, CancellationToken cancellationToken) =>
         throw new NotSupportedException();
+
+    public virtual Task<NamsCreateEntityResult> CreateEntityAsync(
+        string name, string type, string? description, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
 }


### PR DESCRIPTION
## Summary
- Adds `POST /v1/entities` to `INamsClient` -- needed transitively for the NAMS TCK bridge (`test_set_entity_feedback_returns_updated` creates an entity via `add_entity` before scoring it).
- **Two real, live-confirmed discoveries surfaced while building this:**
  1. A pre-existing Phase 10g test was genuinely flaky (grabbed "any" entity, assumed connectivity; `GET /entities` returns newest-first and a just-created entity has zero edges yet). Fixed by picking a seed provably referenced by at least one edge in the full workspace graph.
  2. `POST /v1/entities` has **three genuinely different response shapes** depending on NAMS's own fuzzy entity-resolution outcome -- `"created"`/`"review_pending"` return full entity fields, `"merged"` returns a completely different minimal shape with no name/type/description at all. The original design (reusing `NamsEntity`) silently returned null fields instead of failing loudly. Fixed with a new `NamsCreateEntityResult` type modeling all three shapes honestly.
- Also confirmed: NAMS's own wire casing is inconsistent on this endpoint (camelCase success fields vs. snake_case duplicate-detection fields) -- a real API inconsistency, not a client bug.

## Test plan
- [x] Full Release build (0 warnings/errors)
- [x] Full unit + SemanticKernel suite: 3281 passed
- [x] Full `Category=Integration` suite (Testcontainers Neo4j + live NAMS): 331 passed
- [x] Two parallel self-review agents (correctness + conventions) on the original design, plus a focused follow-up review on the `NamsCreateEntityResult` correction -- all passes clean

No GitHub Copilot review requested (out of credits, per standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)