### PR TITLE
NAMS TCK Platinum bridge: official upstream conformance suite support

### DIFF
--- a/AgentMemory.slnx
+++ b/AgentMemory.slnx
@@ -33,6 +33,7 @@
   <Folder Name="/tools/">
     <Project Path="tools/AgentMemory.Cli/AgentMemory.Cli.csproj" />
     <Project Path="tools/AgentMemory.TckBridge/AgentMemory.TckBridge.csproj" />
+    <Project Path="tools/AgentMemory.TckBridge.Nams/AgentMemory.TckBridge.Nams.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/AgentMemory.Tests.Integration/AgentMemory.Tests.Integration.csproj" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,9 +20,9 @@
        which builds and runs cleanly under net10.0). net8.0 costs nothing to add and lets consumers on the
        still-widely-deployed .NET 8 LTS use the library without adopting a newer runtime; net10.0 keeps
        pace with the newest release. Verified with real builds and executed tests on all three TFMs, not
-       just compiled. Scoped the same way as the packaging metadata below, plus excluding the two
-       non-packable tools/ console apps (Cli, TckBridge), which stay single-targeted. -->
-  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('AgentMemory')) and !$(MSBuildProjectName.Contains('.Tests')) and !$(MSBuildProjectName.Contains('.Sample')) and '$(MSBuildProjectName)' != 'AgentMemory.Cli' and '$(MSBuildProjectName)' != 'AgentMemory.TckBridge'">
+       just compiled. Scoped the same way as the packaging metadata below, plus excluding the three
+       non-packable tools/ console apps (Cli, TckBridge, TckBridge.Nams), which stay single-targeted. -->
+  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('AgentMemory')) and !$(MSBuildProjectName.Contains('.Tests')) and !$(MSBuildProjectName.Contains('.Sample')) and '$(MSBuildProjectName)' != 'AgentMemory.Cli' and '$(MSBuildProjectName)' != 'AgentMemory.TckBridge' and '$(MSBuildProjectName)' != 'AgentMemory.TckBridge.Nams'">
     <TargetFramework></TargetFramework>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>

--- a/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
@@ -1,0 +1,133 @@
+# NAMS TCK Platinum Bridge — Planning & Implementation Plan
+
+## Purpose
+
+A new sibling project, `tools/AgentMemory.TckBridge.Nams`, implementing the upstream
+`neo4j-labs/agent-memory-tck` bridge protocol's Platinum-tier routes against the real NAMS SaaS via
+`INamsClient`. Its purpose is to let the **official** upstream `pytest -m platinum` conformance suite run
+against our NAMS integration, rather than relying only on our own hand-written live tests (Phases 10e-10j).
+Separate project from the existing `AgentMemory.TckBridge` (direct/self-hosted backend) because the DI/backend
+wiring is completely different (`AddNamsAgentMemory` + `INamsClient`, not `AddNeo4jAgentMemory` + Core/Neo4j
+services) — mixing both into one binary would be a worse design than two small, focused ones.
+
+## Research: what the official suite actually requires
+
+Read the upstream TCK's own client code directly (`tck/adapters/http_bridge.py`, `tck/adapters/base_adapter.py`,
+`tck/tests/v1/test_platinum.py` — checked out at `/c/tmp/agent-memory-tck`, commit `4603b91f`, same one
+used for the existing bridge's Bronze/Silver/Gold conformance runs) rather than guessing at the protocol.
+
+### The 11 scenarios in `test_platinum.py` map to 10 already-built `INamsClient` methods + 1 new one
+
+| Bridge route | `INamsClient` method | Notes |
+|---|---|---|
+| `create_conversation` | `CreateConversationAsync` | |
+| `list_conversations` | `ListConversationsAsync` | |
+| `delete_conversation` | `DeleteConversationAsync` | |
+| `bulk_add_messages` | `AddMessagesAsync` | |
+| `get_context` | `GetContextAsync` | |
+| `get_observations` | `GetObservationsAsync` | |
+| `set_entity_feedback` | `SetEntityFeedbackAsync` | |
+| `get_entity_graph` | `GetEntityGraphAsync` | edges need `sourceId`/`targetId` → `source`/`target` |
+| `record_step` | `RecordReasoningStepAsync` | |
+| `get_trace_by_conversation` | `GetReasoningTraceAsync` | |
+| `cypher_query` | `ExecuteCypherQueryAsync` | |
+| `add_entity` (transitive — used by `test_set_entity_feedback_returns_updated` before scoring) | `CreateEntityAsync` (Phase 10j, built specifically for this) | |
+
+### Required regardless of tier: `setup`/`teardown`/`clear_all_data`
+
+`tck/tests/conftest.py`'s session-scoped `adapter` fixture calls `setup()`/`teardown()` unconditionally, and
+an `autouse=True` fixture calls `clear_all_data()` before **every** test. All three are required even for a
+Platinum-only run, or the whole session fails immediately (confirmed: `_call`'s `RuntimeError` on any missing
+route, not a graceful skip). NAMS has no schema/bootstrap step and — checked the pinned OpenAPI snapshot for
+any wipe/reset/purge endpoint — **no bulk-wipe capability of any kind**. `setup`/`teardown` are no-ops;
+`clear_all_data` does best-effort cleanup (delete every conversation found via `ListConversationsAsync`).
+Entities/reasoning traces are NOT wiped (no such NAMS capability exists) — acceptable because every Platinum
+assertion is permissive (`hasattr`/`isinstance`/asserts-only-on-data-the-test-itself-just-created), never an
+exact-total-count check that accumulated entities would break.
+
+### Wire-shape translation required (cross-referenced against the TCK client's own strict `_xxx_from_dict` parsers)
+
+The TCK client's parsers use plain dict indexing (`d["field"]`, raises `KeyError` if absent) for some fields
+and `.get()` with defaults for others — read every parser used by the 11 routes to know exactly which fields
+must be present and under what name:
+
+- **`_conversation_from_dict`** (used by `create_conversation`/`list_conversations`) requires `id`,
+  `session_id`, `created_at`. NAMS's conversation model has no `session_id` concept at all (a conversation
+  *is* the session) and its create-response has no `created_at` field at all (confirmed live, Phase 2/10e).
+  Bridge fix: echo the conversation's own `id` as `session_id`; synthesize `created_at` as `DateTimeOffset.UtcNow`
+  for `create_conversation` (list_conversations already has a real `createdAt`).
+- **`_message_from_dict`** (used inside `bulk_add_messages`'s response and `get_context`'s `recent_messages`)
+  requires `id`, `role`, `content`, `timestamp` — NAMS's message shape uses `createdAt`, not `timestamp`.
+  Bridge fix: a bridge-local message DTO with a `Timestamp` property (naming-policy-converts to `timestamp`)
+  populated from `NamsMessage.CreatedAt`.
+- **`_entity_from_dict`** (used by `add_entity`) requires `id`, `name`, `type`, `created_at` — NAMS's
+  `POST /entities` response never includes `created_at` in ANY resolution outcome (confirmed live, Phase 10j),
+  and its `"merged"` resolution outcome omits `name`/`type` entirely. Bridge fix: synthesize `created_at`
+  always; fall back to the original request's `name`/`type` when NAMS's response is the minimal "merged" shape
+  (a deliberate, disclosed compromise — the bridge's job is satisfying the test harness's stricter contract,
+  not the client, which stays honest about NAMS's real, sometimes-incomplete response per Phase 10j).
+- **`get_entity_graph`**'s parser requires edge `id`/`source`/`target` (not `sourceId`/`targetId`) — rename.
+- Everything else (`set_entity_feedback`, `record_step`/`get_trace_by_conversation`'s steps/tool_calls,
+  `cypher_query`, `delete_conversation`) maps cleanly via the existing snake_case naming policy with no
+  renaming, confirmed by reading each parser: `set_entity_feedback` only needs `id`/`updated` (matches
+  `NamsEntityFeedbackResult` exactly); reasoning steps/traces' snake_case-converted `conversation_id`/
+  `tool_calls` match `NamsReasoningStep`/`NamsReasoningTrace` directly; `cypher_query`'s result isn't parsed
+  into a typed model at all (raw `columns`/`rows`/`stats` passthrough).
+- `get_observations`/`get_context`'s `reflections`/`observations` tiers are exercised only against a fresh
+  conversation by the actual test scenarios (empty lists) — their per-item shape doesn't matter for passing
+  the official suite, but is modeled correctly anyway for robustness.
+
+## Implementation checklist
+
+1. New project `tools/AgentMemory.TckBridge.Nams` (Minimal API, `Microsoft.NET.Sdk.Web`, `IsPackable=false`,
+   `ProjectReference` to `AgentMemory.Nams` only — no meta-package, no Core/Neo4j).
+2. `AgentMemory.Nams.csproj`: add an `InternalsVisibleTo` grant for `AgentMemory.TckBridge.Nams` (the shared
+   `src/Directory.Build.props` grant already covers the OTHER, direct-backend `AgentMemory.TckBridge` project
+   by that exact name — a different name needs its own explicit grant, matching the project's own existing
+   pattern for `AgentMemory.Tests.Unit`/`AgentMemory.Tests.Integration`).
+3. Add the new project to `AgentMemory.slnx`.
+4. `Program.cs`: config (`NAMS_API_KEY`/`NAMS_WORKSPACE_ID` env vars, default listen port distinct from the
+   direct-backend bridge's 3001 — use 3002), snake_case JSON naming policy (matching the existing bridge),
+   DI via `AddNamsAgentMemory`, all 14 routes (11 Platinum + `add_entity` + `setup`/`teardown`/`clear_all_data`).
+5. `Dtos.cs`: bridge-local response records with the renames identified above.
+6. Verify by actually running the upstream suite: `pytest -m platinum --bridge-url http://localhost:3002`
+   against the real NAMS SaaS dev workspace — this is the actual point of the whole exercise, not optional.
+7. Self-review (2 parallel agents) before merge, same discipline as every other Phase 10 PR.
+
+Deliberately NOT reusing this new bridge to also implement Bronze/Silver/Gold for NAMS — those tiers assume
+short-term/long-term/reasoning memory *service* semantics the direct backend has and NAMS's REST surface
+doesn't expose the same way (e.g. no owner-scoped repository-level API); Platinum is what NAMS's REST surface
+was actually designed to test.
+
+## Result: verified against the real upstream suite, 10/11 passing
+
+Ran `pytest -m platinum --bridge-url http://localhost:3002` against the real NAMS SaaS dev workspace (not a
+mock) after fixing every real bug the first run surfaced:
+
+1. **Missing `/add_message` route** — `test_get_context_shape` calls the single-message `add_message`
+   (Bronze-shared contract), not `bulk_add_messages`. Added, mapping `session_id` (a NAMS conversation IS the
+   "session") to `AddMessagesAsync` with a single-item list.
+2. **Reusing a Nams domain record directly as a bridge response type is unsafe.** System.Text.Json's
+   `PropertyNamingPolicy` only applies to properties WITHOUT an explicit `[JsonPropertyName]` attribute — an
+   explicit attribute always wins. Every Nams domain record has explicit camelCase attributes matching NAMS's
+   own wire casing, so reusing one directly (as the original design did for `record_step`,
+   `get_trace_by_conversation`'s tool calls, and `set_entity_feedback`) silently emitted camelCase instead of
+   snake_case, breaking the TCK client's strict dict-key parsers (`KeyError: 'conversation_id'`, etc.).
+   Fixed by introducing bridge-local DTOs with no `JsonPropertyName` attributes of their own for every route
+   that had reused a domain type directly — documented as a standing rule in `Dtos.cs`'s own comment.
+3. **`get_entity_graph`'s edge `id` isn't a UUID.** NAMS's real edge id is a compound
+   `"sourceId|TYPE|targetId"` string (confirmed live, Phase 10g) — the TCK client's edge parser requires a
+   parseable UUID. Synthesizes a fresh one per response (display-only, never looked up again).
+4. **`cypher_query`'s rows are the wrong shape.** NAMS returns each row as a column-name-keyed dict
+   (`{"total": 296}`); the TCK's `TCKCypherResult.rows` Pydantic model requires a **positional list** ordered
+   by `columns` (`[296]`). Fixed by transforming each row through the confirmed `columns` order, with a
+   `JsonElement`-to-CLR-object unwrap helper for clean re-serialization.
+
+**One test remains unfixable, and confirmed to be a genuine bug in the upstream TCK suite itself, not our
+bridge or NAMS integration:** `test_create_conversation_returns_uuid` asserts
+`conv.user_id == "alice" or conv.user_id is None`, but `TCKConversation`'s own Pydantic model
+(`tck/adapters/base_adapter.py`) declares no `user_id` field at all — only `id`/`session_id`/`messages`/
+`title`/`created_at`/`updated_at`. `_conversation_from_dict` never constructs the model with a `user_id`
+kwarg either. No bridge response could make this attribute exist; this would fail identically against any
+correctly-implemented Platinum adapter. **Final result: 10/11 official Platinum scenarios passing, with the
+1 failure independently attributable to the upstream test suite.**

--- a/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
@@ -131,3 +131,13 @@ bridge or NAMS integration:** `test_create_conversation_returns_uuid` asserts
 kwarg either. No bridge response could make this attribute exist; this would fail identically against any
 correctly-implemented Platinum adapter. **Final result: 10/11 official Platinum scenarios passing, with the
 1 failure independently attributable to the upstream test suite.**
+
+### Deliberate scope gap: no C# test project for this bridge
+
+Unlike the direct-backend `AgentMemory.TckBridge` (which has both a unit-level wire-contract test and a
+`WebApplicationFactory`-hosted round-trip integration test), this project has no equivalent C# tests and no
+`public partial class Program { }` hosting hook. The real upstream `pytest -m platinum` run against the live
+NAMS SaaS dev workspace already *is* the verification — a parallel in-process C# suite would either mock NAMS
+(defeating the point: catching real wire-shape mismatches, as the JsonPropertyName-bypass bug above shows) or
+need live NAMS credentials in CI, which the direct bridge's local-Neo4j-backed tests don't require. Left as a
+disclosed gap rather than added speculatively.

--- a/src/AgentMemory.Nams/AgentMemory.Nams.csproj
+++ b/src/AgentMemory.Nams/AgentMemory.Nams.csproj
@@ -20,6 +20,10 @@
          public service (see its own doc comment). The live-integration test for it needs direct access,
          mirroring AgentMemory.AgentFramework's identical grant to both test projects. -->
     <InternalsVisibleTo Include="AgentMemory.Tests.Integration" />
+    <!-- The TCK Platinum bridge resolves INamsClient directly from DI (same pattern as the direct-backend
+         AgentMemory.TckBridge, which src/Directory.Build.props already grants under that exact name;
+         this is a DIFFERENT project name, so it needs its own explicit grant here). -->
+    <InternalsVisibleTo Include="AgentMemory.TckBridge.Nams" />
   </ItemGroup>
 
 </Project>

--- a/tools/AgentMemory.TckBridge.Nams/AgentMemory.TckBridge.Nams.csproj
+++ b/tools/AgentMemory.TckBridge.Nams/AgentMemory.TckBridge.Nams.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <RootNamespace>AgentMemory.TckBridge.Nams</RootNamespace>
+    <!-- Operator/conformance tooling, not a published library. -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- NAMS backend only, no Core/Neo4j/meta-package reference, unlike the direct-backend bridge. -->
+    <ProjectReference Include="..\..\src\AgentMemory.Nams\AgentMemory.Nams.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/AgentMemory.TckBridge.Nams/Dtos.cs
+++ b/tools/AgentMemory.TckBridge.Nams/Dtos.cs
@@ -89,3 +89,34 @@ internal sealed record TckEntityFeedbackResult(string Id, bool Updated);
 
 internal sealed record TckCypherResult(
     IReadOnlyList<string> Columns, IReadOnlyList<IReadOnlyList<object?>> Rows, IReadOnlyDictionary<string, object?>? Stats);
+
+// ---- Requests (snake_case on the wire via the same naming policy; matches the direct-backend
+// AgentMemory.TckBridge's convention of keeping all wire DTOs, both response and request, in this file
+// rather than split across Program.cs). ----
+
+internal sealed record CreateConversationRequest(string? UserId, IReadOnlyDictionary<string, string>? Metadata);
+
+internal sealed record ListConversationsRequest(int? Limit);
+
+internal sealed record DeleteConversationRequest(string ConversationId);
+
+internal sealed record BulkMessageInput(string Role, string Content);
+
+internal sealed record BulkAddMessagesRequest(string ConversationId, IReadOnlyList<BulkMessageInput> Messages);
+
+internal sealed record AddMessageRequest(string SessionId, string Role, string Content);
+
+internal sealed record GetContextRequest(string ConversationId);
+
+internal sealed record GetObservationsRequest(string ConversationId, int? Limit);
+
+// Wire key is "entity_type" (matching the TCK client's own add_entity call), not "type".
+internal sealed record AddEntityRequest(string Name, string EntityType, string? Description);
+
+internal sealed record SetEntityFeedbackRequest(string EntityId, double? UserScore, bool? Confirmed);
+
+internal sealed record RecordStepRequest(string ConversationId, string Reasoning, string ActionTaken, string? Result);
+
+internal sealed record GetTraceRequest(string ConversationId);
+
+internal sealed record CypherQueryRequest(string Cypher, IReadOnlyDictionary<string, object?>? Params);

--- a/tools/AgentMemory.TckBridge.Nams/Dtos.cs
+++ b/tools/AgentMemory.TckBridge.Nams/Dtos.cs
@@ -1,0 +1,91 @@
+namespace AgentMemory.TckBridge.Nams;
+
+// Wire contract for the upstream neo4j-labs/agent-memory-tck Platinum bridge protocol. Property names are
+// C# PascalCase; ConfigureHttpJsonOptions (Program.cs) maps them to snake_case on the wire via
+// JsonNamingPolicy.SnakeCaseLower, matching the direct-backend AgentMemory.TckBridge's own convention.
+//
+// These are bridge-local translation records, NOT direct reuse of AgentMemory.Nams.Domain types -- see
+// docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md for the full field-by-field research
+// this is based on. None of these reuse a Nams domain record directly, even where a shape looks like it
+// matches exactly (e.g. NamsEntityFeedbackResult, NamsReasoningStep, NamsQueryResult): every Nams domain
+// record carries explicit JsonPropertyName attributes in NAMS's own camelCase wire casing, which always
+// overrides this bridge's snake_case naming policy -- see the IMPORTANT note further down for how that was
+// found the hard way.
+
+// ---- Conversations: TCK's _conversation_from_dict requires id/session_id/created_at, none of which map
+// 1:1 onto NAMS's conversation model (no session concept; create-response has no created_at at all). ----
+
+internal sealed record TckConversation(
+    string Id,
+    string SessionId,
+    string? Title,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? UpdatedAt);
+
+// ---- Messages: TCK's _message_from_dict requires "timestamp", NAMS's field is "createdAt". ----
+
+internal sealed record TckMessage(
+    string Id,
+    string Role,
+    string Content,
+    DateTimeOffset? Timestamp);
+
+// ---- Context: reflections/observations/recent_messages. TCK's per-item parsers require id/conversation_id;
+// content/created_at are optional -- these are exercised as empty lists by the actual Platinum scenarios
+// (a fresh conversation has none yet), but modeled correctly rather than left untyped. ----
+
+internal sealed record TckReflection(string Id, string? ConversationId, string? Content, string? CreatedAt);
+
+internal sealed record TckObservationEntry(string Id, string? ConversationId, string? Content, string? CreatedAt);
+
+internal sealed record TckContext(
+    IReadOnlyList<TckReflection> Reflections,
+    IReadOnlyList<TckObservationEntry> Observations,
+    IReadOnlyList<TckMessage> RecentMessages);
+
+// ---- Entities: TCK's _entity_from_dict requires id/name/type/created_at. NAMS's POST /entities response
+// NEVER includes created_at (confirmed live, Phase 10j) and, on a "merged" resolution outcome, omits
+// name/type entirely -- Program.cs synthesizes created_at always and falls back to the submitted name/type
+// when NAMS's own response lacks them. ----
+
+internal sealed record TckEntity(string Id, string Name, string Type, string? Description, DateTimeOffset CreatedAt);
+
+// ---- Entity graph: TCK's edge parser requires id/source/target (not sourceId/targetId). ----
+
+internal sealed record TckGraphNode(string Id, string? Name, string? Type);
+
+internal sealed record TckGraphEdge(string Id, string Source, string Target, string? Type);
+
+internal sealed record TckEntityGraph(IReadOnlyList<TckGraphNode> Nodes, IReadOnlyList<TckGraphEdge> Edges);
+
+// ---- Reasoning trace: TCK's _agent_step_from_dict requires conversation_id on EACH step -- confirmed live
+// that NAMS's own /reasoning/trace/{id} response omits conversationId per-step (only the top-level trace
+// object has it), so Program.cs patches it onto every step from the request parameter before returning.
+// _tool_call_from_dict requires id/tool_name -- NamsToolCall.ToolName carries its own explicit
+// JsonPropertyName("toolName") attribute, so (per the IMPORTANT note below) tool calls need the same
+// bridge-local treatment as everything else here; see TckToolCall. ----
+
+internal sealed record TckAgentStep(
+    string Id, string ConversationId, string? Reasoning, string? ActionTaken, string? Result, string? CreatedAt);
+
+// IMPORTANT: reusing a Nams domain record directly as a bridge response type is NOT safe whenever that
+// record has an explicit [JsonPropertyName] attribute -- confirmed the hard way running the real TCK suite:
+// System.Text.Json's PropertyNamingPolicy only applies to properties WITHOUT an explicit JsonPropertyName
+// attribute; an explicit attribute always wins. Every Nams domain record has explicit camelCase attributes
+// matching NAMS's own wire casing (e.g. NamsReasoningStep.ConversationId is tagged "conversationId"), so
+// reusing one directly here would silently emit camelCase instead of the snake_case this bridge's naming
+// policy is supposed to produce -- exactly what broke record_step/get_trace_by_conversation on the first
+// real conformance run. Every bridge-local DTO below deliberately has NO JsonPropertyName attributes of its
+// own, so the naming policy applies uniformly.
+
+internal sealed record TckToolCall(string Id, string? StepId, string ToolName, string? Status);
+
+internal sealed record TckTrace(
+    string ConversationId, IReadOnlyList<TckAgentStep> Steps, IReadOnlyList<TckToolCall> ToolCalls);
+
+internal sealed record TckAgentStepResult(string Id, string ConversationId, string Reasoning, string ActionTaken, string? Result);
+
+internal sealed record TckEntityFeedbackResult(string Id, bool Updated);
+
+internal sealed record TckCypherResult(
+    IReadOnlyList<string> Columns, IReadOnlyList<IReadOnlyList<object?>> Rows, IReadOnlyDictionary<string, object?>? Stats);

--- a/tools/AgentMemory.TckBridge.Nams/Program.cs
+++ b/tools/AgentMemory.TckBridge.Nams/Program.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Client;
+using AgentMemory.Nams.Domain;
+using AgentMemory.TckBridge.Nams;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ---- Config conventions (mirrors AgentMemory.Sample.NamsAgent; NAMS_DEV_WORKSPACE_ID is also accepted
+// since that's the name the live-integration-test credentials use -- see NamsLiveCredentials.cs). ----
+var namsApiKey = builder.Configuration["NAMS_API_KEY"] ?? Environment.GetEnvironmentVariable("NAMS_API_KEY");
+if (string.IsNullOrWhiteSpace(namsApiKey))
+{
+    Console.WriteLine("=== AgentMemory.TckBridge.Nams ===\n");
+    Console.WriteLine("[!] NAMS is not configured. This bridge calls the real NAMS SaaS -- there is no");
+    Console.WriteLine("    offline fallback. Set NAMS_API_KEY and re-run.");
+    return;
+}
+var namsWorkspaceId =
+    builder.Configuration["NAMS_WORKSPACE_ID"] ?? Environment.GetEnvironmentVariable("NAMS_WORKSPACE_ID") ??
+    Environment.GetEnvironmentVariable("NAMS_DEV_WORKSPACE_ID");
+
+// Default listen URL http://localhost:3002 -- distinct from the direct-backend AgentMemory.TckBridge's
+// 3001 default, so both can run side by side. An explicit ASPNETCORE_URLS/--urls always wins.
+var explicitUrlsConfigured =
+    !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_URLS")) ||
+    !string.IsNullOrWhiteSpace(builder.Configuration["urls"]);
+if (!explicitUrlsConfigured)
+{
+    builder.WebHost.UseUrls("http://localhost:3002");
+}
+
+builder.Services.AddNamsAgentMemory(o =>
+{
+    o.Endpoint = NamsWellKnown.Endpoint;
+    o.ApiKey = namsApiKey;
+    o.WorkspaceId = namsWorkspaceId;
+});
+
+// Wire contract is snake_case; ASP.NET defaults to camelCase -- same convention as the direct-backend bridge.
+builder.Services.ConfigureHttpJsonOptions(o =>
+{
+    o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+    o.SerializerOptions.PropertyNameCaseInsensitive = true;
+});
+
+var app = builder.Build();
+
+// ---- Lifecycle: NAMS has no schema/bootstrap step and no bulk-wipe endpoint of any kind (checked the
+// pinned OpenAPI snapshot) -- setup/teardown are no-ops; clear_all_data does best-effort cleanup (delete
+// every conversation found via ListConversationsAsync). Entities/reasoning traces are NOT wiped -- every
+// Platinum assertion is permissive enough that accumulated data across runs doesn't affect the outcome. ----
+
+app.MapPost("/setup", () => Results.Ok(new { ok = true }));
+
+app.MapPost("/teardown", async (INamsClient client, CancellationToken ct) =>
+{
+    await ClearAllConversationsAsync(client, ct).ConfigureAwait(false);
+    return Results.NoContent();
+});
+
+app.MapPost("/clear_all_data", async (INamsClient client, CancellationToken ct) =>
+{
+    await ClearAllConversationsAsync(client, ct).ConfigureAwait(false);
+    return Results.NoContent();
+});
+
+static async Task ClearAllConversationsAsync(INamsClient client, CancellationToken ct)
+{
+    var conversations = await client.ListConversationsAsync(200, ct).ConfigureAwait(false);
+    foreach (var conversation in conversations)
+        await client.DeleteConversationAsync(conversation.Id, ct).ConfigureAwait(false);
+}
+
+// ---- Conversation lifecycle ----
+
+app.MapPost("/create_conversation", async (CreateConversationRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var conversation = await client.CreateConversationAsync(req.UserId, req.Metadata, ct).ConfigureAwait(false);
+    // NAMS's create-response has no session_id (a conversation IS the session) or created_at at all --
+    // synthesize both (confirmed live, Phase 10e/TCK bridge research).
+    return Results.Ok(new TckConversation(conversation.Id, conversation.Id, null, DateTimeOffset.UtcNow, null));
+});
+
+app.MapPost("/list_conversations", async (ListConversationsRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var conversations = await client.ListConversationsAsync(req.Limit ?? 50, ct).ConfigureAwait(false);
+    var dtos = conversations.Select(c => new TckConversation(
+        c.Id, c.Id, c.Title,
+        ParseOrUtcNow(c.CreatedAt),
+        string.IsNullOrEmpty(c.UpdatedAt) ? null : DateTimeOffset.Parse(c.UpdatedAt))).ToList();
+    return Results.Ok(dtos);
+});
+
+app.MapPost("/delete_conversation", async (DeleteConversationRequest req, INamsClient client, CancellationToken ct) =>
+{
+    await client.DeleteConversationAsync(req.ConversationId, ct).ConfigureAwait(false);
+    return Results.NoContent();
+});
+
+app.MapPost("/bulk_add_messages", async (BulkAddMessagesRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var inputs = req.Messages.Select(m => new NamsMessageInput(m.Content, m.Role)).ToList();
+    var messages = await client.AddMessagesAsync(req.ConversationId, inputs, ct).ConfigureAwait(false);
+    return Results.Ok(messages.Select(ToTckMessage).ToList());
+});
+
+// Single-message add, shared with the Bronze-tier wire contract -- session_id here is the conversation id
+// (a NAMS conversation IS the "session"). Needed by test_get_context_shape, which adds one message before
+// checking get_context's shape.
+app.MapPost("/add_message", async (AddMessageRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var messages = await client.AddMessagesAsync(
+        req.SessionId, [new NamsMessageInput(req.Content, req.Role)], ct).ConfigureAwait(false);
+    return Results.Ok(ToTckMessage(messages.Single()));
+});
+
+// ---- Context ----
+
+app.MapPost("/get_context", async (GetContextRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var context = await client.GetContextAsync(req.ConversationId, ct).ConfigureAwait(false);
+    var dto = new TckContext(
+        context.Reflections.Select(r => new TckReflection(r.Id, r.ConversationId, r.Content, r.CreatedAt)).ToList(),
+        context.Observations.Select(o => new TckObservationEntry(o.Id, o.ConversationId, o.Content, o.CreatedAt)).ToList(),
+        context.RecentMessages.Select(ToTckMessage).ToList());
+    return Results.Ok(dto);
+});
+
+app.MapPost("/get_observations", async (GetObservationsRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var observations = await client.GetObservationsAsync(req.ConversationId, req.Limit ?? 50, ct).ConfigureAwait(false);
+    var dtos = observations.Select(o => new TckObservationEntry(o.Id, o.ConversationId, o.Content, o.CreatedAt)).ToList();
+    return Results.Ok(dtos);
+});
+
+// ---- Entities, feedback, graph ----
+
+app.MapPost("/add_entity", async (AddEntityRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var result = await client.CreateEntityAsync(req.Name, req.EntityType, req.Description, ct).ConfigureAwait(false);
+    // NAMS's own response never includes created_at in any resolution outcome, and on a "merged" outcome
+    // (auto-merged into an existing entity) omits name/type/description entirely -- confirmed live, Phase
+    // 10j. Synthesize created_at always; fall back to the submitted name/type/description in that case, since
+    // the TCK client's _entity_from_dict requires all four fields unconditionally.
+    var dto = new TckEntity(
+        result.Id,
+        result.Name ?? req.Name,
+        result.Type ?? req.EntityType,
+        result.Description ?? req.Description,
+        DateTimeOffset.UtcNow);
+    return Results.Ok(dto);
+});
+
+app.MapPost("/set_entity_feedback", async (SetEntityFeedbackRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var result = await client.SetEntityFeedbackAsync(req.EntityId, req.UserScore, req.Confirmed, ct).ConfigureAwait(false);
+    // Deliberately a bridge-local DTO, not a direct NamsEntityFeedbackResult reuse -- see Dtos.cs's own
+    // comment on why reusing a domain record with explicit JsonPropertyName attributes is unsafe here.
+    return Results.Ok(new TckEntityFeedbackResult(result.Id, result.Updated));
+});
+
+app.MapPost("/get_entity_graph", async (INamsClient client, CancellationToken ct) =>
+{
+    var graph = await client.GetEntityGraphAsync(ct).ConfigureAwait(false);
+    var dto = new TckEntityGraph(
+        graph.Nodes.Select(n => new TckGraphNode(n.Id, n.Name, n.Type)).ToList(),
+        // TCK's edge parser requires "source"/"target" (not NAMS's "sourceId"/"targetId") AND requires "id"
+        // to be a parseable UUID -- NAMS's real edge id is a compound "sourceId|TYPE|targetId" string, not a
+        // UUID at all (confirmed live), so synthesize a fresh one; these are display-only ids for the Memory
+        // Browser, never looked up again, so identity stability across calls isn't required.
+        graph.Edges.Select(e => new TckGraphEdge(Guid.NewGuid().ToString(), e.SourceId, e.TargetId, e.Type)).ToList());
+    return Results.Ok(dto);
+});
+
+// ---- Reasoning / provenance ----
+
+app.MapPost("/record_step", async (RecordStepRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var step = await client.RecordReasoningStepAsync(req.ConversationId, req.Reasoning, req.ActionTaken, req.Result, ct)
+        .ConfigureAwait(false);
+    // Deliberately a bridge-local DTO, not a direct NamsReasoningStep reuse -- its ConversationId/ActionTaken
+    // properties carry explicit camelCase JsonPropertyName attributes that bypass this bridge's snake_case
+    // naming policy entirely (confirmed the hard way: this broke both record_step and get_trace_by_conversation
+    // on the first real conformance run). See Dtos.cs's own comment for the general rule.
+    // Use the request's own conversationId rather than step.ConversationId (nullable on the shared domain
+    // type) -- we already know the correct value without needing a null-forgiving operator.
+    return Results.Ok(new TckAgentStepResult(step.Id, req.ConversationId, step.Reasoning, step.ActionTaken, step.Result));
+});
+
+app.MapPost("/get_trace_by_conversation", async (GetTraceRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var trace = await client.GetReasoningTraceAsync(req.ConversationId, ct).ConfigureAwait(false);
+    // Confirmed live: NAMS's own trace response omits conversationId on each individual step (only the
+    // top-level trace object has it), but the TCK client's step parser requires it per-step -- patch it in
+    // from the request parameter, which we already know is correct for every step in this trace.
+    var steps = trace.Steps
+        .Select(s => new TckAgentStep(s.Id, req.ConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt))
+        .ToList();
+    var toolCalls = trace.ToolCalls.Select(tc => new TckToolCall(tc.Id, tc.StepId, tc.ToolName, tc.Status)).ToList();
+    var dto = new TckTrace(trace.ConversationId, steps, toolCalls);
+    return Results.Ok(dto);
+});
+
+// ---- Cypher query console ----
+
+app.MapPost("/cypher_query", async (CypherQueryRequest req, INamsClient client, CancellationToken ct) =>
+{
+    var result = await client.ExecuteCypherQueryAsync(req.Cypher, req.Params, ct).ConfigureAwait(false);
+    // TCK's TCKCypherResult.rows expects each row as a POSITIONAL list of values ordered by columns, not
+    // NAMS's own column-name-keyed dict shape -- confirmed the hard way (a Pydantic validation error on the
+    // first real conformance run: "rows.0 Input should be a valid list").
+    var rows = result.Rows
+        .Select(row => (IReadOnlyList<object?>)result.Columns
+            .Select(col => row.TryGetValue(col, out var value) ? JsonElementToObject(value) : null)
+            .ToList())
+        .ToList();
+    var stats = result.Stats?.ToDictionary(kv => kv.Key, kv => JsonElementToObject(kv.Value));
+    return Results.Ok(new TckCypherResult(result.Columns, rows, stats));
+});
+
+app.Run();
+
+static object? JsonElementToObject(JsonElement element) => element.ValueKind switch
+{
+    JsonValueKind.String => element.GetString(),
+    JsonValueKind.Number => element.TryGetInt64(out var asLong) ? asLong : element.GetDouble(),
+    JsonValueKind.True => true,
+    JsonValueKind.False => false,
+    JsonValueKind.Null or JsonValueKind.Undefined => null,
+    _ => element.Clone(), // nested arrays/objects -- pass through as JsonElement, re-serializes fine as-is
+};
+
+static TckMessage ToTckMessage(NamsMessage m) =>
+    new(m.Id, m.Role, m.Content, string.IsNullOrEmpty(m.CreatedAt) ? null : DateTimeOffset.Parse(m.CreatedAt));
+
+static DateTimeOffset ParseOrUtcNow(string? value) =>
+    string.IsNullOrEmpty(value) ? DateTimeOffset.UtcNow : DateTimeOffset.Parse(value);
+
+// ---- Request DTOs (snake_case on the wire via the same naming policy) ----
+
+internal sealed record CreateConversationRequest(string? UserId, IReadOnlyDictionary<string, string>? Metadata);
+
+internal sealed record ListConversationsRequest(int? Limit);
+
+internal sealed record DeleteConversationRequest(string ConversationId);
+
+internal sealed record BulkMessageInput(string Role, string Content);
+
+internal sealed record BulkAddMessagesRequest(string ConversationId, IReadOnlyList<BulkMessageInput> Messages);
+
+internal sealed record AddMessageRequest(string SessionId, string Role, string Content);
+
+internal sealed record GetContextRequest(string ConversationId);
+
+internal sealed record GetObservationsRequest(string ConversationId, int? Limit);
+
+// Wire key is "entity_type" (matching the TCK client's own add_entity call), not "type".
+internal sealed record AddEntityRequest(string Name, string EntityType, string? Description);
+
+internal sealed record SetEntityFeedbackRequest(string EntityId, double? UserScore, bool? Confirmed);
+
+internal sealed record RecordStepRequest(string ConversationId, string Reasoning, string ActionTaken, string? Result);
+
+internal sealed record GetTraceRequest(string ConversationId);
+
+internal sealed record CypherQueryRequest(string Cypher, IReadOnlyDictionary<string, object?>? Params);

--- a/tools/AgentMemory.TckBridge.Nams/Program.cs
+++ b/tools/AgentMemory.TckBridge.Nams/Program.cs
@@ -67,6 +67,13 @@ app.MapPost("/clear_all_data", async (INamsClient client, CancellationToken ct) 
 
 static async Task ClearAllConversationsAsync(INamsClient client, CancellationToken ct)
 {
+    // 200 is NAMS's own documented hard maximum for this endpoint's limit param (pinned OpenAPI snapshot:
+    // "Max conversations to return (1-200, default 50)") -- there is no offset/cursor param to page beyond
+    // it. A disclosed, known limitation (like the entities/reasoning-traces-not-wiped gap in the planning
+    // doc): if the shared dev workspace ever exceeds 200 conversations, this cleanup only reaches the
+    // newest 200 (confirmed live: list_conversations returns newest-first), leaving an undeleted tail.
+    // Acceptable for the same reason as that other gap -- every Platinum assertion is permissive enough
+    // that accumulated data doesn't affect the outcome.
     var conversations = await client.ListConversationsAsync(200, ct).ConfigureAwait(false);
     foreach (var conversation in conversations)
         await client.DeleteConversationAsync(conversation.Id, ct).ConfigureAwait(false);
@@ -78,8 +85,11 @@ app.MapPost("/create_conversation", async (CreateConversationRequest req, INamsC
 {
     var conversation = await client.CreateConversationAsync(req.UserId, req.Metadata, ct).ConfigureAwait(false);
     // NAMS's create-response has no session_id (a conversation IS the session) or created_at at all --
-    // synthesize both (confirmed live, Phase 10e/TCK bridge research).
-    return Results.Ok(new TckConversation(conversation.Id, conversation.Id, null, DateTimeOffset.UtcNow, null));
+    // synthesize both (confirmed live, Phase 10e/TCK bridge research). Title isn't a first-class field on
+    // the create-response either -- NAMS reads it from metadata["title"] (confirmed, Phase 10f), same as
+    // list_conversations echoes it back -- so echo the submitted metadata here too, for consistency.
+    var title = conversation.Metadata is not null && conversation.Metadata.TryGetValue("title", out var t) ? t : null;
+    return Results.Ok(new TckConversation(conversation.Id, conversation.Id, title, DateTimeOffset.UtcNow, null));
 });
 
 app.MapPost("/list_conversations", async (ListConversationsRequest req, INamsClient client, CancellationToken ct) =>
@@ -236,32 +246,3 @@ static TckMessage ToTckMessage(NamsMessage m) =>
 
 static DateTimeOffset ParseOrUtcNow(string? value) =>
     string.IsNullOrEmpty(value) ? DateTimeOffset.UtcNow : DateTimeOffset.Parse(value);
-
-// ---- Request DTOs (snake_case on the wire via the same naming policy) ----
-
-internal sealed record CreateConversationRequest(string? UserId, IReadOnlyDictionary<string, string>? Metadata);
-
-internal sealed record ListConversationsRequest(int? Limit);
-
-internal sealed record DeleteConversationRequest(string ConversationId);
-
-internal sealed record BulkMessageInput(string Role, string Content);
-
-internal sealed record BulkAddMessagesRequest(string ConversationId, IReadOnlyList<BulkMessageInput> Messages);
-
-internal sealed record AddMessageRequest(string SessionId, string Role, string Content);
-
-internal sealed record GetContextRequest(string ConversationId);
-
-internal sealed record GetObservationsRequest(string ConversationId, int? Limit);
-
-// Wire key is "entity_type" (matching the TCK client's own add_entity call), not "type".
-internal sealed record AddEntityRequest(string Name, string EntityType, string? Description);
-
-internal sealed record SetEntityFeedbackRequest(string EntityId, double? UserScore, bool? Confirmed);
-
-internal sealed record RecordStepRequest(string ConversationId, string Reasoning, string ActionTaken, string? Result);
-
-internal sealed record GetTraceRequest(string ConversationId);
-
-internal sealed record CypherQueryRequest(string Cypher, IReadOnlyDictionary<string, object?>? Params);


### PR DESCRIPTION
## Summary
- New `tools/AgentMemory.TckBridge.Nams` project: implements the upstream `neo4j-labs/agent-memory-tck` Platinum bridge protocol against the real NAMS SaaS via `INamsClient`, letting the **official** `pytest -m platinum` conformance suite run against our NAMS integration (previously only covered by our own hand-written live tests, Phases 10e-10j).
- Separate binary from the existing direct-backend `AgentMemory.TckBridge` since the DI/backend wiring is completely different (`AddNamsAgentMemory` + `INamsClient`, not `AddNeo4jAgentMemory` + Core/Neo4j services).
- Verified against the real upstream suite (not a mock): **10/11 official Platinum scenarios passing**. The 1 remaining failure (`test_create_conversation_returns_uuid`) is independently confirmed as a genuine bug in the upstream TCK suite itself — it asserts `conv.user_id`, but `TCKConversation`'s own Pydantic model declares no such field at all, so no correctly-implemented bridge could ever satisfy it.
- Full research (wire-shape translations cross-referenced against the TCK client's own strict parsers) and the 4 real bugs found+fixed during the conformance run are documented in `docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md`.

## Review
Self-reviewed (2 parallel passes: conventions + correctness). Conventions pass found 2 stale/self-contradictory comments in `Dtos.cs` (left over from an earlier design iteration, before the JsonPropertyName-bypasses-naming-policy gotcha was discovered) — both fixed in this PR, with the fix re-verified against the full unit suite (3283 passing) and a fresh live run of the official Platinum suite (still 10/11, same single confirmed-upstream failure).

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` — 3283 passed, 0 failed
- [x] `pytest -m platinum --bridge-url http://localhost:3002` against the real NAMS SaaS dev workspace — 10/11 passed (1 confirmed upstream-only failure)
- [x] Self-review (conventions + correctness), findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R