### PR TITLE
NAMS MCP tools: entity-graph and reasoning/provenance operations

### DIFF
--- a/docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md
@@ -1,0 +1,116 @@
+# NAMS MCP Tools: Entity and Reasoning Operations — Planning & Implementation Plan
+
+## Purpose
+
+`INamsClient` grew from 7 to 21 operations across the Phase 10e-10j / TCK-bridge push (#145-153), but
+`AgentMemory.McpServer.Nams` still only exposes the original two tools from Phase 8 (`nams_recall`,
+`nams_remember`). Every newer operation's own doc comment says "deliberately not wired into any higher-level
+service or MCP tool yet -- a separate, later exposure decision." This phase makes that decision for the
+operations that are safe to make autonomously, and explicitly defers the one that isn't.
+
+## Scope
+
+**In scope** (9 new tools, all "administrative/introspection" operations -- entity graph/feedback/creation,
+reasoning steps/tool calls/traces/provenance):
+
+| Tool | `INamsClient` method | Tier |
+|---|---|---|
+| `nams_entity_graph` | `GetEntityGraphAsync` | read |
+| `nams_expand_graph` | `ExpandGraphAsync` | read |
+| `nams_create_entity` | `CreateEntityAsync` | write |
+| `nams_entity_feedback` | `SetEntityFeedbackAsync` | write |
+| `nams_list_reasoning_steps` | `ListReasoningStepsAsync` | read |
+| `nams_reasoning_trace` | `GetReasoningTraceAsync` | read |
+| `nams_entity_provenance` | `GetEntityProvenanceAsync` | read |
+| `nams_record_reasoning_step` | `RecordReasoningStepAsync` | write |
+| `nams_record_tool_call` | `RecordToolCallAsync` | write |
+
+**Deliberately OUT of scope: `nams_graph_query` (`ExecuteCypherQueryAsync`).** `INamsClient`'s own doc comment
+on this method says it "is the last TCK Platinum capability added deliberately behind explicit user approval
+(like Phase 12) rather than the general autonomous-execution authorization... exposing this to an
+agent/end-user is a separate, later decision from adding the client capability itself." That gate was never
+lifted for the MCP-exposure decision specifically -- only for adding the client method. Building an MCP tool
+that lets an LLM agent execute arbitrary (server-enforced-read-only) Cypher is a materially different risk
+than a C# caller doing so, and deserves the same explicit go-ahead Phase 10i itself required. Not built here;
+flagged to the user as a follow-up decision.
+
+## Why these 9 are safe for autonomous execution
+
+Unlike `nams_recall`/`nams_remember`, these 9 operations are workspace-metadata and provenance-trail
+operations (create/score an entity, inspect the entity graph, record/read a reasoning trail) with no bearing
+on the #92 trust-boundary threat model -- with one caught-and-fixed exception. **Self-review found that
+`nams_expand_graph` is NOT actually exempt**: `ExpandGraphAsync` can surface non-Entity nodes, and Phase 10e's
+live probe confirmed a `Message` node can appear with raw, unescaped conversation content in its `properties`
+bag -- the exact class of untrusted content `NamsRecalledItem`'s own SECURITY doc comment says must never
+reach a model without admission/delimiting. Fixed by eliding `properties` for any node labeled `"Message"`
+before this tool's response is built (see `NamsEntityReadTools.NamsExpandGraph`'s own SECURITY comment) --
+id/labels alone are harmless metadata, so the tool's main use case (exploring the entity-graph neighborhood)
+still works. Every other one of the 9 tools matches the risk tier of the direct backend's own `EntityTools`/
+`ReasoningTools`/`GraphQueryTools` (`AgentMemory.McpServer`), which are already shipped and ungated beyond the
+write/read split (`GraphQueryTools` itself IS separately gated, behind `AgentMemoryMcpOptions.EnableGraphQuery`
+-- consistent with excluding `nams_graph_query` above).
+
+## Design decisions
+
+1. **`INamsClient` accessed directly from the new tool classes, not through a new public service.** The
+   existing pattern for `nams_recall`/`nams_remember` is to go through `INamsRecallService`/
+   `INamsPersistenceService` -- but those exist specifically *because* Phase 4-6 needed a security-gating
+   layer between raw NAMS data and an LLM context, not as a generic API-layering convention. These 9
+   operations don't need that layer, and the codebase already has a precedent for a narrow, justified
+   `InternalsVisibleTo` grant straight to `INamsClient` when a whole service layer isn't warranted:
+   `AgentMemory.TckBridge.Nams` (#153) does exactly this. Adds one more explicit grant line to
+   `AgentMemory.Nams.csproj`, following the same pattern. Deliberately avoids committing new public API
+   surface (a real design cost under this repo's SemVer lock) for a thin MCP-tool-only need.
+2. **Split into 4 new tool classes by read/write tier**, matching `AddNamsAgentMemoryMcpTools`/
+   `AddNamsAgentMemoryMcpWriteTools`'s existing two-method opt-in split (an `[McpServerToolType]` class is the
+   unit `WithTools<T>()` registers, so tier separation has to happen at the class boundary):
+   `NamsEntityReadTools`, `NamsEntityWriteTools`, `NamsReasoningReadTools`, `NamsReasoningWriteTools`. Both
+   existing extension methods are extended to also register the new classes for their tier -- no new
+   extension method, no new opt-in surface for the host to learn.
+3. **`nams_expand_graph`'s `loadedIds` parameter takes a comma-separated string, not a list.** No existing MCP
+   tool in either package takes a list/array-typed parameter; rather than being the first to find out whether
+   the MCP SDK's schema generation handles that cleanly, this follows the codebase's own established
+   "keep tool parameters to primitives" pattern and splits internally.
+4. **Explicit field projection, not raw domain-record passthrough**, matching `NamsRecallTools`/
+   `NamsPersistenceTools`'s own style -- protects the MCP wire contract from silently changing if a domain
+   record's shape changes, and keeps `NamsMcpToolJson`'s camelCase output intentional rather than incidental.
+   Most Nams domain records used here happen to already carry explicit camelCase `[JsonPropertyName]`
+   attributes, so passthrough would mostly coincide with the intended output anyway -- but not universally:
+   `NamsCreateEntityResult.DuplicateOf`/`MergedInto` are explicitly `snake_case` (`duplicate_of`/`merged_into`,
+   NAMS's own real wire inconsistency, see that record's doc comment), which passthrough would have leaked
+   verbatim. Explicit projection avoids that class of bug entirely, not just here but for any future field this
+   package projects.
+5. **Same defensive-argument-validation discipline as the existing tools**: every string/id parameter is
+   checked for null/whitespace and returns a clean JSON `{ "error": "..." }` response rather than throwing,
+   since MCP argument binding for a plain `string` parameter isn't guaranteed to reject a missing/null value
+   before the tool body runs.
+
+## Test plan
+
+- New `NamsMcpToolRegistryTests` assertions covering all 11 tools (2 existing + 9 new) and their
+  read/write classification.
+- New `NamsEntityToolsTests.cs`/`NamsReasoningToolsTests.cs` unit tests using the existing
+  `ThrowingNamsClientStub` pattern (`tests/AgentMemory.Tests.Unit/Nams/ThrowingNamsClientStub.cs`), covering
+  the happy path and every validation-error path for each of the 9 new tool methods -- closing a pre-existing
+  gap where `NamsRecallTools`/`NamsPersistenceTools` themselves (as opposed to the services they call) had no
+  direct unit test coverage.
+- Full `dotnet build AgentMemory.slnx -c Release` (0 warnings) + full unit suite before merge.
+- No live-NAMS integration test added for this phase -- these are thin wrappers around already-live-tested
+  `INamsClient` methods (Phase 10e-10j), so the coverage that matters (does the real NAMS endpoint behave as
+  documented) already exists at the client layer; this phase only tests the wrapping/projection logic.
+
+## Self-review result
+
+Two parallel self-review agents (correctness+security, conventions) found 2 real, fixed issues, both covered
+above in "Why these 9 are safe for autonomous execution" and the design-decision notes:
+
+1. **Security (substantive): `nams_expand_graph` could leak raw message content.** Caught before merge --
+   fixed by eliding `properties` for any `"Message"`-labeled node. New regression test:
+   `NamsExpandGraph_MessageLabeledNode_ElidesProperties`.
+2. **Convention (minor): `nams_entity_feedback`'s error response dropped the `updated` key** that its success
+   path always includes, unlike `nams_remember`'s established `persisted`-present-on-both-paths precedent.
+   Fixed; test updated to assert `updated: false` on the validation-error path.
+
+No other findings survived review -- parameter order/types, JSON projections, `Truncated`/`Provenance`
+null-handling, `ConfigureAwait` consistency, and the deliberate non-reference of `ExecuteCypherQueryAsync`
+were all independently confirmed correct.

--- a/src/AgentMemory.McpServer.Nams/NamsMcpServiceCollectionExtensions.cs
+++ b/src/AgentMemory.McpServer.Nams/NamsMcpServiceCollectionExtensions.cs
@@ -13,21 +13,27 @@ namespace AgentMemory.McpServer.Nams;
 /// </summary>
 public static class NamsMcpServiceCollectionExtensions
 {
-    /// <summary>Registers the read-only <c>nams_recall</c> tool. Routine automatic recall/persistence
+    /// <summary>Registers every read-only NAMS tool: <c>nams_recall</c> plus the entity-graph and
+    /// reasoning/provenance tools added alongside it. Routine automatic recall/persistence
     /// (<c>NamsMemoryContextProvider</c>) works identically whether or not this is ever called.</summary>
     public static IMcpServerBuilder AddNamsAgentMemoryMcpTools(this IMcpServerBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        return builder.WithTools<NamsRecallTools>();
+        return builder.WithTools<NamsRecallTools>()
+            .WithTools<NamsEntityReadTools>()
+            .WithTools<NamsReasoningReadTools>();
     }
 
-    /// <summary>Additionally registers the write <c>nams_remember</c> tool -- a separate, explicit opt-in
-    /// from <see cref="AddNamsAgentMemoryMcpTools"/>, per the plan's "write tools never automatic" rule.
+    /// <summary>Additionally registers every write NAMS tool (<c>nams_remember</c> plus entity-creation/
+    /// feedback and reasoning-step/tool-call recording) -- a separate, explicit opt-in from
+    /// <see cref="AddNamsAgentMemoryMcpTools"/>, per the plan's "write tools never automatic" rule.
     /// Calling this without first calling <see cref="AddNamsAgentMemoryMcpTools"/> registers only the write
-    /// tool; call both if you want the full NAMS MCP surface.</summary>
+    /// tools; call both if you want the full NAMS MCP surface.</summary>
     public static IMcpServerBuilder AddNamsAgentMemoryMcpWriteTools(this IMcpServerBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        return builder.WithTools<NamsPersistenceTools>();
+        return builder.WithTools<NamsPersistenceTools>()
+            .WithTools<NamsEntityWriteTools>()
+            .WithTools<NamsReasoningWriteTools>();
     }
 }

--- a/src/AgentMemory.McpServer.Nams/NamsMcpToolRegistry.cs
+++ b/src/AgentMemory.McpServer.Nams/NamsMcpToolRegistry.cs
@@ -11,7 +11,16 @@ public static class NamsMcpToolRegistry
     public static IReadOnlyList<NamsMcpToolDescriptor> AllTools { get; } =
     [
         new NamsMcpToolDescriptor { Name = "nams_recall", IsWriteTool = false, IsSupported = () => true },
-        new NamsMcpToolDescriptor { Name = "nams_remember", IsWriteTool = true, IsSupported = () => true }
+        new NamsMcpToolDescriptor { Name = "nams_remember", IsWriteTool = true, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_entity_graph", IsWriteTool = false, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_expand_graph", IsWriteTool = false, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_create_entity", IsWriteTool = true, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_entity_feedback", IsWriteTool = true, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_list_reasoning_steps", IsWriteTool = false, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_reasoning_trace", IsWriteTool = false, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_entity_provenance", IsWriteTool = false, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_record_reasoning_step", IsWriteTool = true, IsSupported = () => true },
+        new NamsMcpToolDescriptor { Name = "nams_record_tool_call", IsWriteTool = true, IsSupported = () => true }
     ];
 
     /// <summary>Names of every tool this registry currently reports as supported.</summary>

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsEntityReadTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsEntityReadTools.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.McpServer.Nams.Tools;
+
+/// <summary>
+/// Read-only NAMS entity-graph tools. Registered by <c>AddNamsAgentMemoryMcpTools</c>. Unlike
+/// <see cref="NamsRecallTools"/>, these resolve <see cref="INamsClient"/> directly rather than through a
+/// dedicated public service -- see
+/// docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md for why a service layer isn't
+/// warranted for this operation tier.
+/// </summary>
+[McpServerToolType]
+internal sealed class NamsEntityReadTools
+{
+    [McpServerTool(Name = "nams_entity_graph"),
+     Description("Get the full workspace entity graph: every extracted entity and the relationships between " +
+                  "them. Workspace-wide, not scoped to a single conversation -- matches how NAMS's own " +
+                  "entity search/list operations are already workspace-scoped.")]
+    public static async Task<string> NamsEntityGraph(
+        INamsClient client,
+        CancellationToken cancellationToken = default)
+    {
+        var graph = await client.GetEntityGraphAsync(cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new
+        {
+            nodes = graph.Nodes.Select(n => new { n.Id, n.Name, n.Type, n.Description, n.Confidence }),
+            edges = graph.Edges.Select(e => new { e.Id, e.SourceId, e.TargetId, e.Type, e.Confidence })
+        });
+    }
+
+    [McpServerTool(Name = "nams_expand_graph"),
+     Description("Expand a single graph node's 1-hop neighborhood. Can surface non-entity nodes (e.g. a " +
+                  "Message node), which is why nodes here carry generic labels rather than fixed entity " +
+                  "fields; properties are omitted for any node labeled \"Message\" since those can carry raw, " +
+                  "unvetted conversation content that must not flow back to a model unescaped.")]
+    public static async Task<string> NamsExpandGraph(
+        INamsClient client,
+        [Description("The node id to expand from.")] string nodeId,
+        [Description("Optional comma-separated node ids the caller already has, to elide them from the response.")]
+        string? loadedIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(nodeId))
+            return NamsMcpToolJson.Serialize(new { error = "nodeId is required." });
+
+        var loadedIdList = string.IsNullOrWhiteSpace(loadedIds)
+            ? []
+            : loadedIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var expansion = await client.ExpandGraphAsync(nodeId, loadedIdList, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new
+        {
+            // SECURITY: `ExpandGraphAsync` can surface non-Entity nodes -- confirmed live (Phase 10e) that a
+            // "Message" node's properties can carry raw, unescaped conversation content, the same class of
+            // untrusted data NamsRecalledItem's own SECURITY doc comment (src/AgentMemory.Nams/Recall/
+            // NamsRecalledItem.cs) says must never reach a model without admission/delimiting. This tool has
+            // no access to that gating machinery (AgentMemory.McpServer.Nams doesn't reference Core/
+            // AgentFramework), so it elides properties for "Message"-labeled nodes entirely rather than
+            // passing them through unfiltered -- id/labels alone are harmless metadata.
+            nodes = expansion.Nodes.Select(n => new
+            {
+                n.Id,
+                n.Labels,
+                properties = n.Labels.Contains("Message") ? null : n.Properties
+            }),
+            edges = expansion.Edges.Select(e => new { e.Id, e.SourceId, e.TargetId, e.Type, e.Confidence }),
+            truncated = expansion.Truncated is null
+                ? null
+                : new { expansion.Truncated.NodeId, expansion.Truncated.Shown, expansion.Truncated.Total }
+        });
+    }
+}

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsEntityWriteTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsEntityWriteTools.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.McpServer.Nams.Tools;
+
+/// <summary>
+/// Write NAMS entity tools. Registered only by <c>AddNamsAgentMemoryMcpWriteTools</c> -- a separate, explicit
+/// opt-in from <c>AddNamsAgentMemoryMcpTools</c> (the read-only registration), matching the plan's own rule
+/// that write tools are never automatically enabled. See <see cref="NamsEntityReadTools"/> for why these
+/// resolve <see cref="INamsClient"/> directly rather than through a dedicated public service.
+/// </summary>
+[McpServerToolType]
+internal sealed class NamsEntityWriteTools
+{
+    [McpServerTool(Name = "nams_create_entity"),
+     Description("Explicitly create a NAMS entity. Entities are normally created by the async extraction " +
+                  "pipeline -- use this only when an explicit, synchronous write is needed. NAMS's own " +
+                  "fuzzy-duplicate resolution may return a different id/shape than the submitted name/type; " +
+                  "check \"resolution\" in the result (\"created\", \"review_pending\", or \"merged\").")]
+    public static async Task<string> NamsCreateEntity(
+        INamsClient client,
+        [Description("The entity's name.")] string name,
+        [Description("The entity's type (e.g. \"Person\", \"Product\").")] string type,
+        [Description("Optional free-text description.")] string? description,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return NamsMcpToolJson.Serialize(new { error = "name is required." });
+        if (string.IsNullOrWhiteSpace(type))
+            return NamsMcpToolJson.Serialize(new { error = "type is required." });
+
+        var result = await client.CreateEntityAsync(name, type, description, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new
+        {
+            result.Id,
+            result.Resolution,
+            result.Name,
+            result.Type,
+            result.Description,
+            result.DuplicateOf,
+            result.MergedInto,
+            result.Confidence
+        });
+    }
+
+    [McpServerTool(Name = "nams_entity_feedback"),
+     Description("Score and/or confirm an existing NAMS entity.")]
+    public static async Task<string> NamsEntityFeedback(
+        INamsClient client,
+        [Description("The entity id to update.")] string entityId,
+        [Description("Optional confidence score between 0 and 1; omit to leave unset.")] double? userScore,
+        [Description("Optional human-verified flag; omit to leave unset.")] bool? confirmed,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(entityId))
+            return NamsMcpToolJson.Serialize(new { updated = false, error = "entityId is required." });
+
+        var result = await client.SetEntityFeedbackAsync(entityId, userScore, confirmed, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new { result.Id, result.Updated });
+    }
+}

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.McpServer.Nams.Tools;
+
+/// <summary>
+/// Read-only NAMS reasoning/provenance tools. Registered by <c>AddNamsAgentMemoryMcpTools</c>. See
+/// <see cref="NamsEntityReadTools"/> for why these resolve <see cref="INamsClient"/> directly rather than
+/// through a dedicated public service.
+/// </summary>
+[McpServerToolType]
+internal sealed class NamsReasoningReadTools
+{
+    [McpServerTool(Name = "nams_list_reasoning_steps"),
+     Description("List recorded reasoning steps for a NAMS conversation.")]
+    public static async Task<string> NamsListReasoningSteps(
+        INamsClient client,
+        [Description("The resolved NAMS conversation ID.")] string namsConversationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(namsConversationId))
+            return NamsMcpToolJson.Serialize(new { error = "namsConversationId is required." });
+
+        var steps = await client.ListReasoningStepsAsync(namsConversationId, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new
+        {
+            steps = steps.Select(s => new { s.Id, s.ConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt })
+        });
+    }
+
+    [McpServerTool(Name = "nams_reasoning_trace"),
+     Description("Get the full reasoning trace for a NAMS conversation -- every recorded step and tool call, " +
+                  "in order.")]
+    public static async Task<string> NamsReasoningTrace(
+        INamsClient client,
+        [Description("The resolved NAMS conversation ID.")] string namsConversationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(namsConversationId))
+            return NamsMcpToolJson.Serialize(new { error = "namsConversationId is required." });
+
+        var trace = await client.GetReasoningTraceAsync(namsConversationId, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new
+        {
+            trace.ConversationId,
+            steps = trace.Steps.Select(s => new { s.Id, s.ConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt }),
+            toolCalls = trace.ToolCalls.Select(c => new { c.Id, c.StepId, c.ToolName, c.Status, c.Input, c.Output, c.DurationMs, c.CreatedAt })
+        });
+    }
+
+    [McpServerTool(Name = "nams_entity_provenance"),
+     Description("Get the reasoning chain that influenced an entity's creation, if any was recorded. May be " +
+                  "empty -- provenance links are populated asynchronously and are not guaranteed to appear " +
+                  "shortly after related reasoning steps are recorded.")]
+    public static async Task<string> NamsEntityProvenance(
+        INamsClient client,
+        [Description("The entity id.")] string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(entityId))
+            return NamsMcpToolJson.Serialize(new { error = "entityId is required." });
+
+        var provenance = await client.GetEntityProvenanceAsync(entityId, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new { provenance.EntityId, provenance.Provenance });
+    }
+}

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningWriteTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningWriteTools.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using AgentMemory.Nams.Client;
+
+namespace AgentMemory.McpServer.Nams.Tools;
+
+/// <summary>
+/// Write NAMS reasoning/provenance tools. Registered only by <c>AddNamsAgentMemoryMcpWriteTools</c> -- a
+/// separate, explicit opt-in from <c>AddNamsAgentMemoryMcpTools</c>, matching the plan's own rule that write
+/// tools are never automatically enabled. See <see cref="NamsEntityReadTools"/> for why these resolve
+/// <see cref="INamsClient"/> directly rather than through a dedicated public service.
+/// </summary>
+[McpServerToolType]
+internal sealed class NamsReasoningWriteTools
+{
+    [McpServerTool(Name = "nams_record_reasoning_step"),
+     Description("Record a reasoning step for a NAMS conversation's provenance trail.")]
+    public static async Task<string> NamsRecordReasoningStep(
+        INamsClient client,
+        [Description("The resolved NAMS conversation ID.")] string namsConversationId,
+        [Description("The reasoning text.")] string reasoning,
+        [Description("The action taken as a result of this reasoning.")] string actionTaken,
+        [Description("Optional outcome/result text.")] string? result,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(namsConversationId))
+            return NamsMcpToolJson.Serialize(new { error = "namsConversationId is required." });
+        if (string.IsNullOrWhiteSpace(reasoning))
+            return NamsMcpToolJson.Serialize(new { error = "reasoning is required." });
+        if (string.IsNullOrWhiteSpace(actionTaken))
+            return NamsMcpToolJson.Serialize(new { error = "actionTaken is required." });
+
+        var step = await client.RecordReasoningStepAsync(namsConversationId, reasoning, actionTaken, result, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new { step.Id, step.ConversationId, step.Reasoning, step.ActionTaken, step.Result, step.CreatedAt });
+    }
+
+    [McpServerTool(Name = "nams_record_tool_call"),
+     Description("Record a tool call, optionally linked to a reasoning step. input/output must be JSON-encoded " +
+                  "strings, not raw objects -- NAMS stores them as scalar string properties.")]
+    public static async Task<string> NamsRecordToolCall(
+        INamsClient client,
+        [Description("Optional reasoning step id this tool call belongs to.")] string? stepId,
+        [Description("The tool's name.")] string toolName,
+        [Description("The tool call's input, as a JSON-encoded string.")] string input,
+        [Description("Optional output, as a JSON-encoded string.")] string? output,
+        [Description("Optional status (e.g. \"success\", \"error\").")] string? status,
+        [Description("Optional duration in milliseconds.")] int? durationMs,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return NamsMcpToolJson.Serialize(new { error = "toolName is required." });
+        if (string.IsNullOrWhiteSpace(input))
+            return NamsMcpToolJson.Serialize(new { error = "input is required." });
+
+        var call = await client.RecordToolCallAsync(stepId, toolName, input, output, status, durationMs, cancellationToken).ConfigureAwait(false);
+        return NamsMcpToolJson.Serialize(new { call.Id, call.StepId, call.ToolName, call.Status, call.Input, call.Output, call.DurationMs, call.CreatedAt });
+    }
+}

--- a/src/AgentMemory.Nams/AgentMemory.Nams.csproj
+++ b/src/AgentMemory.Nams/AgentMemory.Nams.csproj
@@ -24,6 +24,12 @@
          AgentMemory.TckBridge, which src/Directory.Build.props already grants under that exact name;
          this is a DIFFERENT project name, so it needs its own explicit grant here). -->
     <InternalsVisibleTo Include="AgentMemory.TckBridge.Nams" />
+    <!-- The entity/reasoning MCP tools (nams_entity_graph, nams_create_entity, nams_reasoning_trace, etc.)
+         resolve INamsClient directly, the same as AgentMemory.TckBridge.Nams above, since these operations
+         sit outside the security-gated recall/persistence pipeline Phases 4 to 6 built (no untrusted content
+         flows into an LLM context through them), so a dedicated public service wrapper isn't warranted; a
+         different project name needs its own explicit grant here. -->
+    <InternalsVisibleTo Include="AgentMemory.McpServer.Nams" />
   </ItemGroup>
 
 </Project>

--- a/tests/AgentMemory.Tests.Unit/McpServer/NamsEntityToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/NamsEntityToolsTests.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using FluentAssertions;
+using AgentMemory.McpServer.Nams.Tools;
+using AgentMemory.Nams.Domain;
+using AgentMemory.Tests.Unit.Nams;
+
+namespace AgentMemory.Tests.Unit.McpServer;
+
+public sealed class NamsEntityToolsTests
+{
+    private sealed class FakeNamsClient : ThrowingNamsClientStub
+    {
+        public Func<CancellationToken, Task<NamsEntityGraph>>? OnGetEntityGraph { get; set; }
+        public Func<string, IReadOnlyList<string>, CancellationToken, Task<NamsGraphExpansion>>? OnExpandGraph { get; set; }
+        public Func<string, string, string?, CancellationToken, Task<NamsCreateEntityResult>>? OnCreateEntity { get; set; }
+        public Func<string, double?, bool?, CancellationToken, Task<NamsEntityFeedbackResult>>? OnSetEntityFeedback { get; set; }
+        public IReadOnlyList<string>? LastExpandGraphLoadedIds { get; private set; }
+
+        public override Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken) =>
+            (OnGetEntityGraph ?? (_ => Task.FromResult(new NamsEntityGraph([], []))))(cancellationToken);
+
+        public override Task<NamsGraphExpansion> ExpandGraphAsync(
+            string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken)
+        {
+            LastExpandGraphLoadedIds = loadedIds;
+            return (OnExpandGraph ?? ((_, _, _) => Task.FromResult(new NamsGraphExpansion([], [], null))))(nodeId, loadedIds, cancellationToken);
+        }
+
+        public override Task<NamsCreateEntityResult> CreateEntityAsync(
+            string name, string type, string? description, CancellationToken cancellationToken) =>
+            (OnCreateEntity ?? ((_, _, _, _) => Task.FromResult(new NamsCreateEntityResult("e1", "created", name, type, description, null, null, null))))
+            (name, type, description, cancellationToken);
+
+        public override Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
+            string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken) =>
+            (OnSetEntityFeedback ?? ((_, _, _, _) => Task.FromResult(new NamsEntityFeedbackResult(entityId, true))))
+            (entityId, userScore, confirmed, cancellationToken);
+    }
+
+    // ---- nams_entity_graph ----
+
+    [Fact]
+    public async Task NamsEntityGraph_ReturnsNodesAndEdges()
+    {
+        var client = new FakeNamsClient
+        {
+            OnGetEntityGraph = _ => Task.FromResult(new NamsEntityGraph(
+                [new NamsEntity("e1", "Alice", "Person", null, 0.9, null, null, null, null)],
+                [new NamsGraphEdge("e1|KNOWS|e2", "e1", "e2", "KNOWS", null, 0.8, null, null, null)]))
+        };
+
+        var json = await NamsEntityReadTools.NamsEntityGraph(client, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("nodes")[0].GetProperty("name").GetString().Should().Be("Alice");
+        doc.RootElement.GetProperty("edges")[0].GetProperty("type").GetString().Should().Be("KNOWS");
+    }
+
+    // ---- nams_expand_graph ----
+
+    [Fact]
+    public async Task NamsExpandGraph_MissingNodeId_ReturnsError()
+    {
+        var json = await NamsEntityReadTools.NamsExpandGraph(new FakeNamsClient(), "  ", null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("nodeId");
+    }
+
+    [Fact]
+    public async Task NamsExpandGraph_NoLoadedIds_PassesEmptyList()
+    {
+        var client = new FakeNamsClient();
+
+        await NamsEntityReadTools.NamsExpandGraph(client, "n1", null, CancellationToken.None);
+
+        client.LastExpandGraphLoadedIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NamsExpandGraph_CommaSeparatedLoadedIds_SplitsAndTrims()
+    {
+        var client = new FakeNamsClient();
+
+        await NamsEntityReadTools.NamsExpandGraph(client, "n1", " n2, n3 ,n4", CancellationToken.None);
+
+        client.LastExpandGraphLoadedIds.Should().BeEquivalentTo(["n2", "n3", "n4"]);
+    }
+
+    [Fact]
+    public async Task NamsExpandGraph_ReturnsNodesEdgesAndTruncation()
+    {
+        var client = new FakeNamsClient
+        {
+            OnExpandGraph = (_, _, _) => Task.FromResult(new NamsGraphExpansion(
+                [new NamsExpandNode("n1", ["Entity"], new Dictionary<string, JsonElement>())],
+                [],
+                new NamsExpandTruncation("n1", 5, 10)))
+        };
+
+        var json = await NamsEntityReadTools.NamsExpandGraph(client, "n1", null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("nodes")[0].GetProperty("id").GetString().Should().Be("n1");
+        doc.RootElement.GetProperty("truncated").GetProperty("total").GetInt32().Should().Be(10);
+    }
+
+    [Fact]
+    public async Task NamsExpandGraph_MessageLabeledNode_ElidesProperties()
+    {
+        // SECURITY regression test: a "Message" node's properties can carry raw, unescaped conversation
+        // content (confirmed live, Phase 10e) -- this tool must never pass that through unfiltered.
+        var properties = new Dictionary<string, JsonElement>
+        {
+            ["content"] = JsonDocument.Parse("\"raw unvetted message text\"").RootElement
+        };
+        var client = new FakeNamsClient
+        {
+            OnExpandGraph = (_, _, _) => Task.FromResult(new NamsGraphExpansion(
+                [
+                    new NamsExpandNode("msg-1", ["Message"], properties),
+                    new NamsExpandNode("ent-1", ["Entity"], properties)
+                ],
+                [],
+                null))
+        };
+
+        var json = await NamsEntityReadTools.NamsExpandGraph(client, "n1", null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var nodes = doc.RootElement.GetProperty("nodes").EnumerateArray().ToList();
+        nodes.Single(n => n.GetProperty("id").GetString() == "msg-1").TryGetProperty("properties", out _).Should().BeFalse();
+        nodes.Single(n => n.GetProperty("id").GetString() == "ent-1").GetProperty("properties").GetProperty("content").GetString()
+            .Should().Be("raw unvetted message text");
+    }
+
+    // ---- nams_create_entity ----
+
+    [Theory]
+    [InlineData("", "Person")]
+    [InlineData("Alice", "")]
+    public async Task NamsCreateEntity_MissingRequiredField_ReturnsError(string name, string type)
+    {
+        var json = await NamsEntityWriteTools.NamsCreateEntity(new FakeNamsClient(), name, type, null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NamsCreateEntity_MergedResolution_OmitsNameAndType()
+    {
+        var client = new FakeNamsClient
+        {
+            OnCreateEntity = (_, _, _, _) => Task.FromResult(new NamsCreateEntityResult(
+                "existing-1", "merged", null, null, null, null, "existing-1", 0.95))
+        };
+
+        var json = await NamsEntityWriteTools.NamsCreateEntity(client, "Alice", "Person", "desc", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("resolution").GetString().Should().Be("merged");
+        doc.RootElement.GetProperty("mergedInto").GetString().Should().Be("existing-1");
+        doc.RootElement.TryGetProperty("name", out _).Should().BeFalse(); // WhenWritingNull elides it
+    }
+
+    // ---- nams_entity_feedback ----
+
+    [Fact]
+    public async Task NamsEntityFeedback_MissingEntityId_ReturnsError()
+    {
+        var json = await NamsEntityWriteTools.NamsEntityFeedback(new FakeNamsClient(), " ", 0.5, true, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("entityId");
+        doc.RootElement.GetProperty("updated").GetBoolean().Should().BeFalse(); // matches nams_remember's stable-key-on-error convention
+    }
+
+    [Fact]
+    public async Task NamsEntityFeedback_ValidRequest_ReturnsUpdatedResult()
+    {
+        var client = new FakeNamsClient
+        {
+            OnSetEntityFeedback = (id, _, _, _) => Task.FromResult(new NamsEntityFeedbackResult(id, true))
+        };
+
+        var json = await NamsEntityWriteTools.NamsEntityFeedback(client, "e1", 0.7, true, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("id").GetString().Should().Be("e1");
+        doc.RootElement.GetProperty("updated").GetBoolean().Should().BeTrue();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/McpServer/NamsMcpToolRegistryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/NamsMcpToolRegistryTests.cs
@@ -5,22 +5,37 @@ namespace AgentMemory.Tests.Unit.McpServer;
 
 public sealed class NamsMcpToolRegistryTests
 {
+    private static readonly string[] ReadToolNames =
+    [
+        "nams_recall", "nams_entity_graph", "nams_expand_graph",
+        "nams_list_reasoning_steps", "nams_reasoning_trace", "nams_entity_provenance"
+    ];
+
+    private static readonly string[] WriteToolNames =
+    [
+        "nams_remember", "nams_create_entity", "nams_entity_feedback",
+        "nams_record_reasoning_step", "nams_record_tool_call"
+    ];
+
     [Fact]
-    public void AllTools_ListsExactlyTheTwoNamsTools()
+    public void AllTools_ListsExactlyTheElevenNamsTools()
     {
-        NamsMcpToolRegistry.AllTools.Select(t => t.Name).Should().BeEquivalentTo("nams_recall", "nams_remember");
+        NamsMcpToolRegistry.AllTools.Select(t => t.Name).Should().BeEquivalentTo(ReadToolNames.Concat(WriteToolNames));
     }
 
     [Fact]
-    public void AllTools_OnlyNamsRememberIsAWriteTool()
+    public void AllTools_ClassifiesReadAndWriteToolsCorrectly()
     {
-        NamsMcpToolRegistry.AllTools.Single(t => t.Name == "nams_recall").IsWriteTool.Should().BeFalse();
-        NamsMcpToolRegistry.AllTools.Single(t => t.Name == "nams_remember").IsWriteTool.Should().BeTrue();
+        foreach (var name in ReadToolNames)
+            NamsMcpToolRegistry.AllTools.Single(t => t.Name == name).IsWriteTool.Should().BeFalse(because: $"{name} is a read tool");
+
+        foreach (var name in WriteToolNames)
+            NamsMcpToolRegistry.AllTools.Single(t => t.Name == name).IsWriteTool.Should().BeTrue(because: $"{name} is a write tool");
     }
 
     [Fact]
-    public void SupportedToolNames_DeterministicallyListsBothTools()
+    public void SupportedToolNames_DeterministicallyListsAllElevenTools()
     {
-        NamsMcpToolRegistry.SupportedToolNames.Should().BeEquivalentTo("nams_recall", "nams_remember");
+        NamsMcpToolRegistry.SupportedToolNames.Should().BeEquivalentTo(ReadToolNames.Concat(WriteToolNames));
     }
 }

--- a/tests/AgentMemory.Tests.Unit/McpServer/NamsReasoningToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/NamsReasoningToolsTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using FluentAssertions;
+using AgentMemory.McpServer.Nams.Tools;
+using AgentMemory.Nams.Domain;
+using AgentMemory.Tests.Unit.Nams;
+
+namespace AgentMemory.Tests.Unit.McpServer;
+
+public sealed class NamsReasoningToolsTests
+{
+    private sealed class FakeNamsClient : ThrowingNamsClientStub
+    {
+        public Func<string, CancellationToken, Task<IReadOnlyList<NamsReasoningStep>>>? OnListReasoningSteps { get; set; }
+        public Func<string, CancellationToken, Task<NamsReasoningTrace>>? OnGetReasoningTrace { get; set; }
+        public Func<string, CancellationToken, Task<NamsEntityProvenance>>? OnGetEntityProvenance { get; set; }
+        public Func<string, string, string, string?, CancellationToken, Task<NamsReasoningStep>>? OnRecordReasoningStep { get; set; }
+        public Func<string?, string, string, string?, string?, int?, CancellationToken, Task<NamsToolCall>>? OnRecordToolCall { get; set; }
+
+        public override Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken) =>
+            (OnListReasoningSteps ?? ((_, _) => Task.FromResult<IReadOnlyList<NamsReasoningStep>>([])))(conversationId, cancellationToken);
+
+        public override Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken) =>
+            (OnGetReasoningTrace ?? ((id, _) => Task.FromResult(new NamsReasoningTrace(id, [], []))))(conversationId, cancellationToken);
+
+        public override Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken) =>
+            (OnGetEntityProvenance ?? ((id, _) => Task.FromResult(new NamsEntityProvenance(id, []))))(entityId, cancellationToken);
+
+        public override Task<NamsReasoningStep> RecordReasoningStepAsync(
+            string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken) =>
+            (OnRecordReasoningStep ?? ((cid, r, a, res, _) => Task.FromResult(new NamsReasoningStep("s1", cid, r, a, res, "2026-01-01"))))
+            (conversationId, reasoning, actionTaken, result, cancellationToken);
+
+        public override Task<NamsToolCall> RecordToolCallAsync(
+            string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
+            CancellationToken cancellationToken) =>
+            (OnRecordToolCall ?? ((sid, name, i, o, st, dur, _) => Task.FromResult(new NamsToolCall("tc1", sid, name, st ?? "success", i, o, dur, "2026-01-01"))))
+            (stepId, toolName, input, output, status, durationMs, cancellationToken);
+    }
+
+    // ---- nams_list_reasoning_steps ----
+
+    [Fact]
+    public async Task NamsListReasoningSteps_MissingConversationId_ReturnsError()
+    {
+        var json = await NamsReasoningReadTools.NamsListReasoningSteps(new FakeNamsClient(), "", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("namsConversationId");
+    }
+
+    [Fact]
+    public async Task NamsListReasoningSteps_ReturnsSteps()
+    {
+        var client = new FakeNamsClient
+        {
+            OnListReasoningSteps = (cid, _) => Task.FromResult<IReadOnlyList<NamsReasoningStep>>(
+                [new NamsReasoningStep("s1", cid, "because X", "did Y", "worked", "2026-01-01")])
+        };
+
+        var json = await NamsReasoningReadTools.NamsListReasoningSteps(client, "conv-1", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("steps")[0].GetProperty("reasoning").GetString().Should().Be("because X");
+    }
+
+    // ---- nams_reasoning_trace ----
+
+    [Fact]
+    public async Task NamsReasoningTrace_MissingConversationId_ReturnsError()
+    {
+        var json = await NamsReasoningReadTools.NamsReasoningTrace(new FakeNamsClient(), null!, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("namsConversationId");
+    }
+
+    [Fact]
+    public async Task NamsReasoningTrace_ReturnsStepsAndToolCalls()
+    {
+        var client = new FakeNamsClient
+        {
+            OnGetReasoningTrace = (cid, _) => Task.FromResult(new NamsReasoningTrace(
+                cid,
+                [new NamsReasoningStep("s1", cid, "r", "a", null, "2026-01-01")],
+                [new NamsToolCall("tc1", "s1", "search", "success", "{}", "{}", 12, "2026-01-01")]))
+        };
+
+        var json = await NamsReasoningReadTools.NamsReasoningTrace(client, "conv-1", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("conversationId").GetString().Should().Be("conv-1");
+        doc.RootElement.GetProperty("steps")[0].GetProperty("id").GetString().Should().Be("s1");
+        doc.RootElement.GetProperty("toolCalls")[0].GetProperty("toolName").GetString().Should().Be("search");
+    }
+
+    // ---- nams_entity_provenance ----
+
+    [Fact]
+    public async Task NamsEntityProvenance_MissingEntityId_ReturnsError()
+    {
+        var json = await NamsReasoningReadTools.NamsEntityProvenance(new FakeNamsClient(), " ", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("entityId");
+    }
+
+    [Fact]
+    public async Task NamsEntityProvenance_EmptyProvenance_ReturnsEmptyArray()
+    {
+        var json = await NamsReasoningReadTools.NamsEntityProvenance(new FakeNamsClient(), "e1", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("entityId").GetString().Should().Be("e1");
+        doc.RootElement.GetProperty("provenance").GetArrayLength().Should().Be(0);
+    }
+
+    // ---- nams_record_reasoning_step ----
+
+    [Theory]
+    [InlineData("", "reasoning", "action")]
+    [InlineData("conv-1", "", "action")]
+    [InlineData("conv-1", "reasoning", "")]
+    public async Task NamsRecordReasoningStep_MissingRequiredField_ReturnsError(string conversationId, string reasoning, string actionTaken)
+    {
+        var json = await NamsReasoningWriteTools.NamsRecordReasoningStep(
+            new FakeNamsClient(), conversationId, reasoning, actionTaken, null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NamsRecordReasoningStep_ValidRequest_ReturnsRecordedStep()
+    {
+        var json = await NamsReasoningWriteTools.NamsRecordReasoningStep(
+            new FakeNamsClient(), "conv-1", "because X", "did Y", "worked", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("conversationId").GetString().Should().Be("conv-1");
+        doc.RootElement.GetProperty("reasoning").GetString().Should().Be("because X");
+    }
+
+    // ---- nams_record_tool_call ----
+
+    [Fact]
+    public async Task NamsRecordToolCall_MissingToolName_ReturnsError()
+    {
+        var json = await NamsReasoningWriteTools.NamsRecordToolCall(
+            new FakeNamsClient(), null, "", "{}", null, null, null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("toolName");
+    }
+
+    [Fact]
+    public async Task NamsRecordToolCall_MissingInput_ReturnsError()
+    {
+        var json = await NamsReasoningWriteTools.NamsRecordToolCall(
+            new FakeNamsClient(), null, "search", " ", null, null, null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("input");
+    }
+
+    [Fact]
+    public async Task NamsRecordToolCall_ValidRequest_ReturnsRecordedCall()
+    {
+        var json = await NamsReasoningWriteTools.NamsRecordToolCall(
+            new FakeNamsClient(), "s1", "search", "{\"q\":\"x\"}", "{\"r\":1}", "success", 42, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("toolName").GetString().Should().Be("search");
+        doc.RootElement.GetProperty("stepId").GetString().Should().Be("s1");
+        doc.RootElement.GetProperty("durationMs").GetInt32().Should().Be(42);
+    }
+}


### PR DESCRIPTION
## Summary
- Wires 9 of `INamsClient`'s previously-unwired operations into `AgentMemory.McpServer.Nams` as new MCP tools: entity graph (`nams_entity_graph`, `nams_expand_graph`), entity creation/feedback (`nams_create_entity`, `nams_entity_feedback`), and reasoning/provenance (`nams_record_reasoning_step`, `nams_record_tool_call`, `nams_list_reasoning_steps`, `nams_reasoning_trace`, `nams_entity_provenance`).
- Follows the package's established two-tier read/write opt-in split (`AddNamsAgentMemoryMcpTools`/`AddNamsAgentMemoryMcpWriteTools`), split across 4 new tool classes.
- `INamsClient` is resolved directly (new `InternalsVisibleTo` grant), not through a new public service — these operations sit outside the security-gated recall/persistence pipeline Phases 4-6 built, so a dedicated service layer isn't warranted (mirrors the existing `AgentMemory.TckBridge.Nams` precedent).
- **Deliberately excludes `nams_graph_query` (Cypher passthrough).** `ExecuteCypherQueryAsync`'s own doc comment reserves the MCP-exposure decision for explicit user go-ahead, the same gate Phase 10i itself required for adding the client method — that gate was never lifted for exposing it as an agent-callable tool. Flagged as a follow-up decision, not built here.
- Full design writeup: `docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md`.

## Review
Self-reviewed (2 parallel passes: correctness+security, conventions). Found and fixed 2 real issues before merge:
1. **Security**: `nams_expand_graph` could surface a `"Message"`-labeled node's raw, unescaped conversation content (confirmed live in Phase 10e) — the same untrusted-content class `NamsRecalledItem`'s SECURITY doc comment warns must never reach a model ungated. Fixed by eliding `properties` for `Message`-labeled nodes; added a regression test.
2. **Convention**: `nams_entity_feedback`'s error response dropped the `updated` key its success path always includes, unlike `nams_remember`'s established stable-key-on-both-paths precedent. Fixed.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` — 3307 passed, 0 failed
- [x] `dotnet test tests/AgentMemory.Tests.Integration --filter Category=Integration` — 331 passed, 0 failed (no live-NAMS test added for this phase; these are thin wrappers around already-live-tested `INamsClient` methods)
- [x] Self-review (correctness+security, conventions), findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R