### PR TITLE
NAMS: fix real bugs found by a fresh code-review round

### DIFF
--- a/src/AgentMemory.McpServer.Nams/Tools/NamsEntityReadTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsEntityReadTools.cs
@@ -33,8 +33,9 @@ internal sealed class NamsEntityReadTools
     [McpServerTool(Name = "nams_expand_graph"),
      Description("Expand a single graph node's 1-hop neighborhood. Can surface non-entity nodes (e.g. a " +
                   "Message node), which is why nodes here carry generic labels rather than fixed entity " +
-                  "fields; properties are omitted for any node labeled \"Message\" since those can carry raw, " +
-                  "unvetted conversation content that must not flow back to a model unescaped.")]
+                  "fields; properties are omitted for any node labeled \"Message\", \"Observation\", or " +
+                  "\"Reflection\" since those can carry raw, unvetted conversation content that must not flow " +
+                  "back to a model unescaped.")]
     public static async Task<string> NamsExpandGraph(
         INamsClient client,
         [Description("The node id to expand from.")] string nodeId,
@@ -50,20 +51,28 @@ internal sealed class NamsEntityReadTools
             : loadedIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var expansion = await client.ExpandGraphAsync(nodeId, loadedIdList, cancellationToken).ConfigureAwait(false);
+        // SECURITY: `ExpandGraphAsync` can surface non-Entity nodes -- confirmed live (Phase 10e) that a
+        // "Message" node's properties can carry raw, unescaped conversation content, the same class of
+        // untrusted data NamsRecalledItem's own SECURITY doc comment (src/AgentMemory.Nams/Recall/
+        // NamsRecalledItem.cs) says must never reach a model without admission/delimiting. This tool has no
+        // access to that gating machinery (AgentMemory.McpServer.Nams doesn't reference Core/AgentFramework),
+        // so it elides properties for any node labeled "Message", "Observation", or "Reflection" -- the same
+        // raw-content risk class NamsRecallCategory enumerates for the recall pipeline (its RecentMessage/
+        // RelevantMessage/Observation/Reflection members), even though the graph's own node-label strings
+        // don't literally match those C# enum member names -- rather than passing them through unfiltered --
+        // id/labels alone are harmless metadata. Only "Message" has been live-confirmed as an actual
+        // expand-graph label so far; "Observation"/"Reflection" are included defensively (same content-risk
+        // class, not yet observed on this specific endpoint) -- this is deliberately a denylist, not an
+        // allowlist, since NAMS's exact "Entity" label string was never live-confirmed either, so allowlisting
+        // on it risked over-eliding legitimate entity data.
+        var messageLikeLabels = new[] { "Message", "Observation", "Reflection" };
         return NamsMcpToolJson.Serialize(new
         {
-            // SECURITY: `ExpandGraphAsync` can surface non-Entity nodes -- confirmed live (Phase 10e) that a
-            // "Message" node's properties can carry raw, unescaped conversation content, the same class of
-            // untrusted data NamsRecalledItem's own SECURITY doc comment (src/AgentMemory.Nams/Recall/
-            // NamsRecalledItem.cs) says must never reach a model without admission/delimiting. This tool has
-            // no access to that gating machinery (AgentMemory.McpServer.Nams doesn't reference Core/
-            // AgentFramework), so it elides properties for "Message"-labeled nodes entirely rather than
-            // passing them through unfiltered -- id/labels alone are harmless metadata.
             nodes = expansion.Nodes.Select(n => new
             {
                 n.Id,
                 n.Labels,
-                properties = n.Labels.Contains("Message") ? null : n.Properties
+                properties = n.Labels.Any(messageLikeLabels.Contains) ? null : n.Properties
             }),
             edges = expansion.Edges.Select(e => new { e.Id, e.SourceId, e.TargetId, e.Type, e.Confidence }),
             truncated = expansion.Truncated is null

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
@@ -25,7 +25,10 @@ internal sealed class NamsReasoningReadTools
         var steps = await client.ListReasoningStepsAsync(namsConversationId, cancellationToken).ConfigureAwait(false);
         return NamsMcpToolJson.Serialize(new
         {
-            steps = steps.Select(s => new { s.Id, s.ConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt })
+            // NAMS's own response omits conversationId per-step (confirmed live) -- substitute the caller's
+            // already-known namsConversationId rather than echoing the (always-null) domain field, the same
+            // fix tools/AgentMemory.TckBridge.Nams/Program.cs's get_trace_by_conversation route already applies.
+            steps = steps.Select(s => new { s.Id, ConversationId = namsConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt })
         });
     }
 
@@ -44,7 +47,20 @@ internal sealed class NamsReasoningReadTools
         return NamsMcpToolJson.Serialize(new
         {
             trace.ConversationId,
-            steps = trace.Steps.Select(s => new { s.Id, s.ConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt }),
+            // NAMS's own response omits conversationId per-step (confirmed live) -- substitute the caller's
+            // already-known namsConversationId, same fix as NamsListReasoningSteps above and matching
+            // tools/AgentMemory.TckBridge.Nams/Program.cs's get_trace_by_conversation route.
+            steps = trace.Steps.Select(s => new { s.Id, ConversationId = namsConversationId, s.Reasoning, s.ActionTaken, s.Result, s.CreatedAt }),
+            // SECURITY GAP (flagged, not yet mitigated): Input/Output are caller-supplied, pre-serialized JSON
+            // strings (see INamsClient.RecordToolCallAsync) that can carry arbitrary content -- e.g. the text
+            // of a fetched web page an agent tool call returned. Unlike NamsExpandGraph's Message-node
+            // elision, this tool passes them through completely raw with no admission/escaping, the same
+            // untrusted-content risk NamsRecalledItem's SECURITY comment describes for the recall pipeline.
+            // No mitigation applied here yet -- unlike the expand-graph case, Input/Output are this tool's
+            // entire value, so blanket eliding them would defeat its purpose; a real fix needs the same kind
+            // of delimiting/escaping decision Phase 4-6 made for recall, which this package cannot build alone
+            // (AgentMemory.McpServer.Nams has no Core/AgentFramework reference). Needs an explicit decision,
+            // not a unilateral patch.
             toolCalls = trace.ToolCalls.Select(c => new { c.Id, c.StepId, c.ToolName, c.Status, c.Input, c.Output, c.DurationMs, c.CreatedAt })
         });
     }

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -96,8 +96,7 @@ internal interface INamsClient
     /// Scores/confirms an entity (<c>PUT /v1/entities/{id}/feedback</c>) -- confirmed live as part of the
     /// Phase 10e TCK Platinum probe. Both <paramref name="userScore"/> (0-1 confidence) and
     /// <paramref name="confirmed"/> (human-verified flag) are optional; pass <see langword="null"/> to leave
-    /// either unset. Deliberately not wired into any higher-level service or MCP tool yet -- low-level client
-    /// capability only.
+    /// either unset. Wired into the <c>nams_entity_feedback</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsEntityFeedbackResult> SetEntityFeedbackAsync(
         string entityId, double? userScore, bool? confirmed, CancellationToken cancellationToken);
@@ -106,15 +105,16 @@ internal interface INamsClient
     /// Gets the full workspace entity graph (<c>GET /v1/entities/graph</c>, no parameters) -- confirmed live as
     /// part of the Phase 10e TCK Platinum probe. Nodes reuse <see cref="NamsEntity"/> (confirmed identical
     /// shape); see <see cref="ExpandGraphAsync"/> for the genuinely different node shape that endpoint returns.
-    /// Deliberately not wired into any higher-level service or MCP tool yet -- low-level client capability only.
+    /// Wired into the <c>nams_entity_graph</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsEntityGraph> GetEntityGraphAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Expands a graph node's 1-hop neighborhood (<c>POST /v1/graph/expand</c>) -- confirmed live as part of
     /// the Phase 10e TCK Platinum probe. A POST verb but read-only (no server-side side effects per its own
-    /// description), so treated as idempotent-for-retry like <see cref="SearchEntitiesAsync"/>. Deliberately not
-    /// wired into any higher-level service or MCP tool yet -- low-level client capability only.
+    /// description), so treated as idempotent-for-retry like <see cref="SearchEntitiesAsync"/>. Wired into the
+    /// <c>nams_expand_graph</c> MCP tool (PR #154) -- see that tool's own SECURITY comment for the Message-node
+    /// content-elision mitigation it applies, since this method itself performs no gating.
     /// </summary>
     Task<NamsGraphExpansion> ExpandGraphAsync(
         string nodeId, IReadOnlyList<string> loadedIds, CancellationToken cancellationToken);
@@ -123,8 +123,8 @@ internal interface INamsClient
     /// Records a reasoning step (<c>POST /v1/reasoning/steps</c>) -- confirmed live as part of the Phase 10e TCK
     /// Platinum probe. Unlike every other addition in Phase 10e-10g, this is the first method touching an
     /// entirely new domain -- reasoning/provenance -- this client has never exposed before. A genuine write
-    /// (resending would create a duplicate step), not idempotent-for-retry. Deliberately not wired into any
-    /// higher-level service or MCP tool yet -- low-level client capability only.
+    /// (resending would create a duplicate step), not idempotent-for-retry. Wired into the
+    /// <c>nams_record_reasoning_step</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsReasoningStep> RecordReasoningStepAsync(
         string conversationId, string reasoning, string actionTaken, string? result, CancellationToken cancellationToken);
@@ -133,7 +133,9 @@ internal interface INamsClient
     /// Lists reasoning steps for a conversation (<c>GET /v1/reasoning/steps?conversation_id=</c>) -- confirmed
     /// live as part of the Phase 10e TCK Platinum probe. Unlike Phase 10f's observations, recording and
     /// immediately listing a step is NOT subject to any async worker delay -- confirmed live to be immediately
-    /// visible. Deliberately not wired into any higher-level service or MCP tool yet.
+    /// visible. Wired into the <c>nams_list_reasoning_steps</c> MCP tool (PR #154) -- that tool substitutes the
+    /// caller's own known conversation id for each step's <see cref="NamsReasoningStep.ConversationId"/> rather
+    /// than echoing this method's response verbatim, since NAMS's response omits it per-step.
     /// </summary>
     Task<IReadOnlyList<NamsReasoningStep>> ListReasoningStepsAsync(string conversationId, CancellationToken cancellationToken);
 
@@ -141,8 +143,7 @@ internal interface INamsClient
     /// Records a tool call, optionally linked to a step (<c>POST /v1/reasoning/tool-calls</c>) -- confirmed
     /// live as part of the Phase 10e TCK Platinum probe. <paramref name="input"/>/<paramref name="output"/>
     /// must be pre-serialized JSON strings, not objects -- NAMS stores them as scalar string properties. A
-    /// genuine write, not idempotent-for-retry. Deliberately not wired into any higher-level service or MCP
-    /// tool yet.
+    /// genuine write, not idempotent-for-retry. Wired into the <c>nams_record_tool_call</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsToolCall> RecordToolCallAsync(
         string? stepId, string toolName, string input, string? output, string? status, int? durationMs,
@@ -152,8 +153,10 @@ internal interface INamsClient
     /// Gets the full reasoning trace for a conversation -- all steps and tool calls, in order
     /// (<c>GET /v1/reasoning/trace/{conversationId}</c>) -- confirmed live as part of the Phase 10e TCK
     /// Platinum probe. Flat shape (steps and toolCalls as parallel arrays), not steps-with-nested-toolCalls
-    /// despite the endpoint's own prose description implying nesting. Deliberately not wired into any
-    /// higher-level service or MCP tool yet.
+    /// despite the endpoint's own prose description implying nesting. Wired into the <c>nams_reasoning_trace</c>
+    /// MCP tool (PR #154) -- that tool substitutes the caller's own known conversation id for each step's
+    /// <see cref="NamsReasoningStep.ConversationId"/> rather than echoing this method's response verbatim, for
+    /// the same per-step-omission reason as <see cref="ListReasoningStepsAsync"/>.
     /// </summary>
     Task<NamsReasoningTrace> GetReasoningTraceAsync(string conversationId, CancellationToken cancellationToken);
 
@@ -161,8 +164,8 @@ internal interface INamsClient
     /// Gets the reasoning chain that influenced an entity's creation (<c>GET /v1/reasoning/provenance/{entityId}</c>)
     /// -- confirmed live as part of the Phase 10e TCK Platinum probe. Like Phase 10f's observations, this links
     /// to async entity-extraction machinery -- callers should not assume a call shortly after recording
-    /// reasoning steps will see a populated provenance chain for any particular entity. Deliberately not wired
-    /// into any higher-level service or MCP tool yet.
+    /// reasoning steps will see a populated provenance chain for any particular entity. Wired into the
+    /// <c>nams_entity_provenance</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsEntityProvenance> GetEntityProvenanceAsync(string entityId, CancellationToken cancellationToken);
 
@@ -192,8 +195,8 @@ internal interface INamsClient
     /// <see cref="NamsEntity"/> -- confirmed live that NAMS's own fuzzy entity-resolution can return a
     /// genuinely different, minimal response shape (no name/type/description at all) when it auto-merges the
     /// submission into an existing entity rather than creating a new one; see that type's own doc comment for
-    /// the full three-shape breakdown. A genuine write, not idempotent-for-retry. Deliberately not wired into
-    /// any higher-level service or MCP tool yet.
+    /// the full three-shape breakdown. A genuine write, not idempotent-for-retry. Wired into the
+    /// <c>nams_create_entity</c> MCP tool (PR #154).
     /// </summary>
     Task<NamsCreateEntityResult> CreateEntityAsync(
         string name, string type, string? description, CancellationToken cancellationToken);

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -369,22 +369,29 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
         [property: JsonPropertyName("nodeId")] string NodeId,
         [property: JsonPropertyName("loadedIds")] IReadOnlyList<string> LoadedIds);
 
+    // WhenWritingNull on this record's optional field (and on RecordToolCallRequestBody's below), same
+    // reasoning as EntityFeedbackRequestBody above: without it, passing null serializes an explicit JSON null
+    // in the POST body rather than omitting the key, which risks NAMS's request schema rejecting the call if
+    // it models these as "may be absent" without also being "may be null" (a real, review-caught
+    // inconsistency -- these two request bodies were the only ones in this push missing the annotation their
+    // siblings already carry).
     private sealed record RecordReasoningStepRequestBody(
         [property: JsonPropertyName("conversationId")] string ConversationId,
         [property: JsonPropertyName("reasoning")] string Reasoning,
         [property: JsonPropertyName("actionTaken")] string ActionTaken,
-        [property: JsonPropertyName("result")] string? Result);
+        [property: JsonPropertyName("result"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Result);
 
     private sealed record ListReasoningStepsResponseBody(
         [property: JsonPropertyName("steps")] IReadOnlyList<NamsReasoningStep> Steps);
 
+    // See RecordReasoningStepRequestBody's comment above for why these are WhenWritingNull.
     private sealed record RecordToolCallRequestBody(
-        [property: JsonPropertyName("stepId")] string? StepId,
+        [property: JsonPropertyName("stepId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? StepId,
         [property: JsonPropertyName("toolName")] string ToolName,
         [property: JsonPropertyName("input")] string Input,
-        [property: JsonPropertyName("output")] string? Output,
-        [property: JsonPropertyName("status")] string? Status,
-        [property: JsonPropertyName("durationMs")] int? DurationMs);
+        [property: JsonPropertyName("output"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Output,
+        [property: JsonPropertyName("status"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Status,
+        [property: JsonPropertyName("durationMs"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? DurationMs);
 
     private sealed record ExecuteCypherQueryRequestBody(
         [property: JsonPropertyName("cypher")] string Cypher,

--- a/tests/AgentMemory.Tests.Unit/McpServer/NamsEntityToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/NamsEntityToolsTests.cs
@@ -134,6 +134,32 @@ public sealed class NamsEntityToolsTests
             .Should().Be("raw unvetted message text");
     }
 
+    [Theory]
+    [InlineData("Observation")]
+    [InlineData("Reflection")]
+    public async Task NamsExpandGraph_ObservationOrReflectionLabeledNode_ElidesProperties(string label)
+    {
+        // Regression test: broadened denylist -- Observation/Reflection are the same raw-content-carrying
+        // categories NamsRecallCategory enumerates for the recall pipeline, even though only "Message" has
+        // been live-confirmed as an actual expand-graph label so far.
+        var properties = new Dictionary<string, JsonElement>
+        {
+            ["content"] = JsonDocument.Parse("\"raw unvetted content\"").RootElement
+        };
+        var client = new FakeNamsClient
+        {
+            OnExpandGraph = (_, _, _) => Task.FromResult(new NamsGraphExpansion(
+                [new NamsExpandNode("n-1", [label], properties)],
+                [],
+                null))
+        };
+
+        var json = await NamsEntityReadTools.NamsExpandGraph(client, "n1", null, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("nodes")[0].TryGetProperty("properties", out _).Should().BeFalse();
+    }
+
     // ---- nams_create_entity ----
 
     [Theory]

--- a/tests/AgentMemory.Tests.Unit/McpServer/NamsReasoningToolsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/NamsReasoningToolsTests.cs
@@ -63,6 +63,23 @@ public sealed class NamsReasoningToolsTests
         doc.RootElement.GetProperty("steps")[0].GetProperty("reasoning").GetString().Should().Be("because X");
     }
 
+    [Fact]
+    public async Task NamsListReasoningSteps_StepConversationIdOmittedByNams_UsesCallerSuppliedConversationId()
+    {
+        // Regression test: NAMS's own response omits conversationId per-step (confirmed live) -- this tool
+        // must substitute the caller's known namsConversationId, not echo the (null) domain field verbatim.
+        var client = new FakeNamsClient
+        {
+            OnListReasoningSteps = (_, _) => Task.FromResult<IReadOnlyList<NamsReasoningStep>>(
+                [new NamsReasoningStep("s1", null, "because X", "did Y", "worked", "2026-01-01")])
+        };
+
+        var json = await NamsReasoningReadTools.NamsListReasoningSteps(client, "conv-1", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("steps")[0].GetProperty("conversationId").GetString().Should().Be("conv-1");
+    }
+
     // ---- nams_reasoning_trace ----
 
     [Fact]
@@ -91,6 +108,25 @@ public sealed class NamsReasoningToolsTests
         doc.RootElement.GetProperty("conversationId").GetString().Should().Be("conv-1");
         doc.RootElement.GetProperty("steps")[0].GetProperty("id").GetString().Should().Be("s1");
         doc.RootElement.GetProperty("toolCalls")[0].GetProperty("toolName").GetString().Should().Be("search");
+    }
+
+    [Fact]
+    public async Task NamsReasoningTrace_StepConversationIdOmittedByNams_UsesCallerSuppliedConversationId()
+    {
+        // Regression test: NAMS's own trace response omits conversationId per-step (confirmed live) -- this
+        // tool must substitute the caller's known namsConversationId, not echo the (null) domain field verbatim.
+        var client = new FakeNamsClient
+        {
+            OnGetReasoningTrace = (cid, _) => Task.FromResult(new NamsReasoningTrace(
+                cid,
+                [new NamsReasoningStep("s1", null, "r", "a", null, "2026-01-01")],
+                []))
+        };
+
+        var json = await NamsReasoningReadTools.NamsReasoningTrace(client, "conv-1", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("steps")[0].GetProperty("conversationId").GetString().Should().Be("conv-1");
     }
 
     // ---- nams_entity_provenance ----

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -376,6 +376,26 @@ public sealed class Neo4jNamsClientAdapterTests
     }
 
     [Fact]
+    public async Task RecordReasoningStepAsync_NullResult_OmitsResultFieldEntirely()
+    {
+        // Regression test: without an explicit JsonIgnoreCondition, a null `result` would serialize as an
+        // explicit "result":null in the POST body rather than omitting the key -- this and RecordToolCallAsync
+        // below were the only two request bodies in this push missing the annotation their siblings
+        // (EntityFeedbackRequestBody, ExecuteCypherQueryRequestBody, CreateEntityRequestBody) already carry.
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created, """
+            {"id":"s1","conversationId":"conv-1","reasoning":"thinking","actionTaken":"search"}
+            """));
+        var adapter = CreateAdapter(fake);
+
+        await adapter.RecordReasoningStepAsync("conv-1", "thinking", "search", null, CancellationToken.None);
+
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        using var requestJson = System.Text.Json.JsonDocument.Parse(requestBody);
+        requestJson.RootElement.TryGetProperty("result", out _).Should().BeFalse(
+            "result: null must omit the key entirely, not serialize an explicit JSON null");
+    }
+
+    [Fact]
     public async Task RecordReasoningStepAsync_ServerError_DoesNotRetry()
     {
         var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
@@ -422,6 +442,27 @@ public sealed class Neo4jNamsClientAdapterTests
         requestJson.RootElement.GetProperty("input").GetString().Should().Be("{\"query\":\"foo\"}",
             "input must be a pre-serialized JSON string value, not a nested object");
         requestJson.RootElement.GetProperty("durationMs").GetInt32().Should().Be(150);
+    }
+
+    [Fact]
+    public async Task RecordToolCallAsync_AllOptionalArgumentsNull_OmitsThoseFieldsEntirely()
+    {
+        // Regression test: stepId/output/status/durationMs are all optional -- without an explicit
+        // JsonIgnoreCondition on each, passing null would serialize explicit JSON nulls rather than omitting
+        // the keys (same class of gap as RecordReasoningStepAsync's `result` above).
+        var fake = new FakeHttpMessageHandler(() => Json(HttpStatusCode.Created,
+            """{"id":"t1","toolName":"web_search","status":"success"}"""));
+        var adapter = CreateAdapter(fake);
+
+        await adapter.RecordToolCallAsync(
+            stepId: null, "web_search", "{\"query\":\"foo\"}", output: null, status: null, durationMs: null, CancellationToken.None);
+
+        var requestBody = await fake.Requests.Single().Content!.ReadAsStringAsync();
+        using var requestJson = System.Text.Json.JsonDocument.Parse(requestBody);
+        requestJson.RootElement.TryGetProperty("stepId", out _).Should().BeFalse("stepId: null must omit the key entirely");
+        requestJson.RootElement.TryGetProperty("output", out _).Should().BeFalse("output: null must omit the key entirely");
+        requestJson.RootElement.TryGetProperty("status", out _).Should().BeFalse("status: null must omit the key entirely");
+        requestJson.RootElement.TryGetProperty("durationMs", out _).Should().BeFalse("durationMs: null must omit the key entirely");
     }
 
     [Fact]

--- a/tools/AgentMemory.TckBridge.Nams/Program.cs
+++ b/tools/AgentMemory.TckBridge.Nams/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using AgentMemory.Nams;
 using AgentMemory.Nams.Client;
@@ -75,8 +76,9 @@ static async Task ClearAllConversationsAsync(INamsClient client, CancellationTok
     // Acceptable for the same reason as that other gap -- every Platinum assertion is permissive enough
     // that accumulated data doesn't affect the outcome.
     var conversations = await client.ListConversationsAsync(200, ct).ConfigureAwait(false);
-    foreach (var conversation in conversations)
-        await client.DeleteConversationAsync(conversation.Id, ct).ConfigureAwait(false);
+    // Independent deletes -- same efficiency reasoning already applied elsewhere in this push
+    // (e.g. NamsConversationLifecycleTests): no need to await each round trip before starting the next.
+    await Task.WhenAll(conversations.Select(c => client.DeleteConversationAsync(c.Id, ct))).ConfigureAwait(false);
 }
 
 // ---- Conversation lifecycle ----
@@ -98,7 +100,7 @@ app.MapPost("/list_conversations", async (ListConversationsRequest req, INamsCli
     var dtos = conversations.Select(c => new TckConversation(
         c.Id, c.Id, c.Title,
         ParseOrUtcNow(c.CreatedAt),
-        string.IsNullOrEmpty(c.UpdatedAt) ? null : DateTimeOffset.Parse(c.UpdatedAt))).ToList();
+        string.IsNullOrEmpty(c.UpdatedAt) ? null : ParseIso8601(c.UpdatedAt))).ToList();
     return Results.Ok(dtos);
 });
 
@@ -130,9 +132,13 @@ app.MapPost("/add_message", async (AddMessageRequest req, INamsClient client, Ca
 app.MapPost("/get_context", async (GetContextRequest req, INamsClient client, CancellationToken ct) =>
 {
     var context = await client.GetContextAsync(req.ConversationId, ct).ConfigureAwait(false);
+    // NamsReflection/NamsObservation.ConversationId are nullable domain fields (confirmed live: NAMS's own
+    // response can omit them), but the TCK's TCKReflection/TCKObservation Pydantic models require a non-
+    // Optional conversation_id: UUID -- substitute the caller's own known req.ConversationId, the same
+    // fallback pattern get_trace_by_conversation below already applies to reasoning steps.
     var dto = new TckContext(
-        context.Reflections.Select(r => new TckReflection(r.Id, r.ConversationId, r.Content, r.CreatedAt)).ToList(),
-        context.Observations.Select(o => new TckObservationEntry(o.Id, o.ConversationId, o.Content, o.CreatedAt)).ToList(),
+        context.Reflections.Select(r => new TckReflection(r.Id, req.ConversationId, r.Content, r.CreatedAt)).ToList(),
+        context.Observations.Select(o => new TckObservationEntry(o.Id, req.ConversationId, o.Content, o.CreatedAt)).ToList(),
         context.RecentMessages.Select(ToTckMessage).ToList());
     return Results.Ok(dto);
 });
@@ -140,7 +146,8 @@ app.MapPost("/get_context", async (GetContextRequest req, INamsClient client, Ca
 app.MapPost("/get_observations", async (GetObservationsRequest req, INamsClient client, CancellationToken ct) =>
 {
     var observations = await client.GetObservationsAsync(req.ConversationId, req.Limit ?? 50, ct).ConfigureAwait(false);
-    var dtos = observations.Select(o => new TckObservationEntry(o.Id, o.ConversationId, o.Content, o.CreatedAt)).ToList();
+    // Same ConversationId-null-propagation fix as /get_context above.
+    var dtos = observations.Select(o => new TckObservationEntry(o.Id, req.ConversationId, o.Content, o.CreatedAt)).ToList();
     return Results.Ok(dtos);
 });
 
@@ -173,8 +180,11 @@ app.MapPost("/set_entity_feedback", async (SetEntityFeedbackRequest req, INamsCl
 app.MapPost("/get_entity_graph", async (INamsClient client, CancellationToken ct) =>
 {
     var graph = await client.GetEntityGraphAsync(ct).ConfigureAwait(false);
+    // NamsEntity.Type is nullable (an entity can be unclassified), but the TCK's TCKEntityGraphNode.type is a
+    // required (non-Optional) str -- unlike /add_entity there's no submitted request value to fall back to
+    // for a read, so fall back to a display sentinel rather than propagating null.
     var dto = new TckEntityGraph(
-        graph.Nodes.Select(n => new TckGraphNode(n.Id, n.Name, n.Type)).ToList(),
+        graph.Nodes.Select(n => new TckGraphNode(n.Id, n.Name, n.Type ?? "Unknown")).ToList(),
         // TCK's edge parser requires "source"/"target" (not NAMS's "sourceId"/"targetId") AND requires "id"
         // to be a parseable UUID -- NAMS's real edge id is a compound "sourceId|TYPE|targetId" string, not a
         // UUID at all (confirmed live), so synthesize a fresh one; these are display-only ids for the Memory
@@ -242,7 +252,13 @@ static object? JsonElementToObject(JsonElement element) => element.ValueKind swi
 };
 
 static TckMessage ToTckMessage(NamsMessage m) =>
-    new(m.Id, m.Role, m.Content, string.IsNullOrEmpty(m.CreatedAt) ? null : DateTimeOffset.Parse(m.CreatedAt));
+    new(m.Id, m.Role, m.Content, string.IsNullOrEmpty(m.CreatedAt) ? null : ParseIso8601(m.CreatedAt));
 
 static DateTimeOffset ParseOrUtcNow(string? value) =>
-    string.IsNullOrEmpty(value) ? DateTimeOffset.UtcNow : DateTimeOffset.Parse(value);
+    string.IsNullOrEmpty(value) ? DateTimeOffset.UtcNow : ParseIso8601(value);
+
+// Repo convention (PR #69/#150): parse with an explicit invariant culture, not the host's default culture --
+// under a non-Gregorian-calendar culture (e.g. th-TH), DateTimeOffset.Parse(string) without this either
+// throws FormatException or silently misinterprets the year against the wrong calendar system.
+static DateTimeOffset ParseIso8601(string value) =>
+    DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);


### PR DESCRIPTION
## Summary

The user asked for a full code-review round over the entire NAMS TCK Platinum + MCP tools push (PRs #145-#155, ~3800 insertions across 55 files). Ran 7 independent review angles in parallel (line-by-line, removed-behavior, cross-file tracing, C#/.NET pitfalls, wrapper/proxy correctness, reuse/efficiency, conventions/altitude) since each prior PR's own self-review only ever looked at its own diff, not the combined whole. Verified every candidate finding by hand against the actual source, test fixtures, and the upstream TCK's real Pydantic models (checked out at `/c/tmp/agent-memory-tck`) before fixing.

**Fixes:**
- `nams_list_reasoning_steps`/`nams_reasoning_trace` always returned `null` `conversationId` per step -- NAMS's response omits it per-step, and the tools echoed the domain field instead of the caller's already-known `namsConversationId` (the sibling TCK bridge route already had this exact fix, just never applied here).
- `nams_expand_graph`'s raw-content elision denylist only covered `"Message"`-labeled nodes; broadened to `"Observation"`/`"Reflection"` (same raw-content risk category NAMS's own recall categories enumerate).
- 9 `INamsClient` doc comments still said "not wired into any MCP tool yet" after PR #154 wired them in -- updated each to name the actual MCP tool.
- `RecordReasoningStepRequestBody`/`RecordToolCallRequestBody` were missing `JsonIgnore(WhenWritingNull)`, unlike their sibling request bodies in the same file -- risked NAMS's schema rejecting a null optional field with a 400.
- 3 `DateTimeOffset.Parse` calls in the TCK bridge lacked `CultureInfo.InvariantCulture`, breaking this repo's own established convention (PR #69/#150).
- `/get_context`, `/get_observations`, `/get_entity_graph` passed nullable domain fields straight through to TCK DTOs that require non-null values (confirmed against the actual upstream Pydantic models: `conversation_id: UUID`, `type: str`) -- now fall back to the request's known value / a display sentinel, matching `/get_trace_by_conversation`'s existing pattern.
- `ClearAllConversationsAsync` deleted conversations one at a time sequentially -- switched to `Task.WhenAll`, matching this same push's own established efficiency pattern elsewhere.

**Deliberately NOT fixed, flagged instead:** `nams_reasoning_trace`'s tool-call `Input`/`Output` fields pass through completely unescaped -- the same untrusted-content risk class as the Message-node case, but blanket-eliding them would defeat the tool's purpose. This needs an explicit decision on delimiting/escaping (the kind of trust-boundary call this project reserves for the user), not a unilateral patch. Flagged with a SECURITY comment in the code.

**Also noted but out of scope for this PR:** the correctness reviewer found other pre-existing `DateTimeOffset.Parse(s, null, DateTimeStyles.RoundtripKind)` call sites elsewhere in the repo (`Neo4jDateTimeHelper.cs`, some tests) that pass `null` as the culture provider, which falls back to `CurrentCulture`, not invariant -- the same latent bug class, just outside this diff's touched files.

## Review
Self-reviewed (2 parallel passes: correctness + conventions) before this commit. Correctness pass verified every fix against the actual TCK Pydantic source and empirically confirmed the new regression tests fail without the fix (stashed the source changes, reran, confirmed all 6 new tests fail as expected, then restored). Conventions pass found 2 minor doc-comment issues (a shared-but-misplaced comment, an imprecise enum-name reference) -- both fixed.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3335 passed, 0 failed (6 new regression tests)
- [x] `dotnet test tests/AgentMemory.Tests.Integration` -- 337 passed, 0 failed (unaffected by these fixes, run for full confidence)
- [x] Re-ran the actual official upstream `pytest -m platinum` suite live against the real NAMS SaaS dev workspace after the TCK bridge fixes -- still 10/11 passing, unchanged
- [x] Self-review (correctness + conventions), findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R