### PR TITLE
NAMS round 4: fix a real body-stream exception-handling gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-request) trust attribution, monotonic trust for shared/global facts, `ReasoningTrace` trust stamping,
   observed/inferred/verified knowledge distinctions, and richer telemetry are future phases.
 
+- **NAMS (Neo4j Agent Memory as a Service) backend support (#128) — a new, opt-in hosted-backend alternative
+  to the direct Neo4j implementation.** Three new additive packages: `AgentMemory.Nams` (a dedicated `HttpClient`-based
+  REST client against the NAMS SaaS API — `AddNamsAgentMemory()` — with identity/conversation-resolution,
+  recall, and post-turn persistence subsystems, zero dependency on Core/Neo4j), `AgentMemory.AgentFramework.Nams`
+  (`NamsMemoryContextProvider`, a dedicated Microsoft Agent Framework adapter wiring NAMS's recalled content
+  through the same #92 trust-boundary protections — delimiting/escaping, admission policy, trust-level mapping
+  — the direct backend already applies), and `AgentMemory.McpServer.Nams` (11 MCP tools across a two-tier read/
+  write opt-in split: `nams_recall`/`nams_remember` for automatic-recall-equivalent access, plus entity-graph
+  (`nams_entity_graph`/`nams_expand_graph`/`nams_create_entity`/`nams_entity_feedback`) and reasoning/provenance
+  (`nams_record_reasoning_step`/`nams_record_tool_call`/`nams_list_reasoning_steps`/`nams_reasoning_trace`/
+  `nams_entity_provenance`) tools resolving `INamsClient` directly). A new sample,
+  `AgentMemory.Sample.NamsAgent`, demonstrates the full recall/persistence lifecycle against a real, live NAMS
+  SaaS workspace with no local embedding generator or schema bootstrapper needed. Verified against the actual
+  official upstream `neo4j-labs/agent-memory-tck` conformance suite via a new `tools/AgentMemory.TckBridge.Nams`
+  bridge — **10/11 Platinum scenarios pass** (the 1 failure is a confirmed bug in the upstream TCK's own test
+  model, not fixable by any bridge). Deliberately excluded: `nams_graph_query` (raw Cypher passthrough via MCP)
+  — `INamsClient.ExecuteCypherQueryAsync` exists at the client layer, but exposing it as an agent-callable tool
+  needs an explicit, separate decision, the same gate this project applies to its own preview-release cut.
+  Fully additive: existing direct-Neo4j behavior is completely unchanged, and NAMS is a purely opt-in backend
+  choice.
+
 ## [1.2.0] - 2026-07-15
 
 ### Added

--- a/docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_McpEntityReasoningTools_PlanningAndImplementationPlan.md
@@ -114,3 +114,15 @@ above in "Why these 9 are safe for autonomous execution" and the design-decision
 No other findings survived review -- parameter order/types, JSON projections, `Truncated`/`Provenance`
 null-handling, `ConfigureAwait` consistency, and the deliberate non-reference of `ExecuteCypherQueryAsync`
 were all independently confirmed correct.
+
+> **UPDATE (PR #156, one day later): this "no other findings" claim didn't hold up.** A fresh, independent
+> review of the whole push (not scoped to this PR alone) found several more real bugs in this PR's own code:
+> `nams_list_reasoning_steps`/`nams_reasoning_trace` always returned `null` `conversationId` per step;
+> `nams_expand_graph`'s Message-node elision (item 1 above) was narrower than it should have been (missed
+> `"Observation"`/`"Reflection"`); and the doc comments this plan added to `INamsClient.cs` calling these
+> operations "not wired into any higher-level service or MCP tool yet" went stale the moment this very PR
+> wired them in. **Lesson: a same-PR self-review, however thorough, can't catch a fix pattern established in
+> a sibling PR from the same push that this code should have picked up on** (the TCK bridge, built earlier
+> in the same push, had already learned the conversationId-omission fix this PR's tools needed). See PR
+> #156/#157 in `strategy/STATUS.md` for the full account -- "no other findings" should be read as "no other findings
+> this specific review pass caught," not as a durable completeness guarantee.

--- a/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
+++ b/docs/reviews/NAMS_TckPlatinumBridge_PlanningAndImplementationPlan.md
@@ -141,3 +141,10 @@ NAMS SaaS dev workspace already *is* the verification — a parallel in-process 
 (defeating the point: catching real wire-shape mismatches, as the JsonPropertyName-bypass bug above shows) or
 need live NAMS credentials in CI, which the direct bridge's local-Neo4j-backed tests don't require. Left as a
 disclosed gap rather than added speculatively.
+
+> **UPDATE (PR #155, the next day): this gap was revisited and closed.** A fast, offline DTO wire-contract
+> unit test (`NamsTckBridgeWireContractTests.cs`) was added -- it doesn't replace the live pytest
+> conformance run (still the real verification for actual wire-shape correctness against NAMS), but it does
+> lock the DTO-to-JSON shape at the C# level so a future refactor gets fast, local feedback before needing a
+> live run at all. The "would either mock NAMS or need live credentials" framing above missed this third
+> option: testing the DTO layer's own serialization in isolation, with no NAMS involved at all.

--- a/samples/AgentMemory.Sample.NamsAgent/Program.cs
+++ b/samples/AgentMemory.Sample.NamsAgent/Program.cs
@@ -14,9 +14,11 @@
 //      <recalled_memory> blocks NamsMemoryContextProvider injects before each live model call.
 //
 // Unlike the direct Neo4j samples, there is no local embedding generator, schema bootstrapper, or
-// memory tools to wire up — NAMS performs extraction/embedding/reflection server-side, and no MCP
-// tool surface for NAMS exists yet (that's engineering plan Phase 8, not built). This sample calls a
-// REAL Azure OpenAI chat model — no mock. Requires:
+// memory tools to wire up — NAMS performs extraction/embedding/reflection server-side. AgentMemory.
+// McpServer.Nams now ships 11 MCP tools (nams_recall/nams_remember plus entity-graph/reasoning-
+// provenance tools), but this sample deliberately doesn't use any of them — routine memory must never
+// depend on a model deciding to call a tool. This sample calls a REAL Azure OpenAI chat model — no
+// mock. Requires:
 //   AZURE_OPENAI_ENDPOINT   (required, e.g. https://<resource>.openai.azure.com/)
 //   AZURE_OPENAI_API_KEY    (required — no live-model fallback)
 //   AZURE_OPENAI_DEPLOYMENT (chat deployment name; default: gpt-4o-mini)

--- a/src/AgentMemory.Nams/Client/INamsClient.cs
+++ b/src/AgentMemory.Nams/Client/INamsClient.cs
@@ -39,8 +39,10 @@ internal interface INamsClient
     /// Lists entities in the workspace with no query -- confirmed against the live NAMS REST API
     /// (<c>GET /v1/entities</c>) as part of Phase 9. Unlike <see cref="SearchEntitiesAsync"/> (which requires
     /// a non-empty query -- NAMS returns 400 for an empty one), this needs no precondition and no existing
-    /// conversation, making it the one safe, side-effect-free read this client can use for a connectivity
-    /// health probe.
+    /// conversation, making it a safe, side-effect-free read this client can use for a connectivity health
+    /// probe -- used with <c>limit: 1</c> by <see cref="AgentMemory.Nams.Observability.NamsHealthCheck"/> for
+    /// exactly that, since it bounds the result unlike the also-qualifying but unbounded
+    /// <see cref="GetEntityGraphAsync"/>.
     /// </summary>
     Task<IReadOnlyList<NamsEntity>> ListEntitiesAsync(int limit, CancellationToken cancellationToken);
 

--- a/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
+++ b/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
@@ -33,6 +33,18 @@ internal static class NamsClientExceptionMapper
                     Redact($"NAMS returned a response that could not be parsed: {ex.Message}", secretToRedact),
                     (int)response.StatusCode);
             }
+            // A 200 OK's body stream can still fail mid-read (truncated/reset connection) -- SafeReadBodyAsync
+            // below already anticipates exactly this exception set for the failure-path body reader; the
+            // success path was missing the same guard, letting a raw, unclassified exception escape this
+            // mapper entirely (bypassing redaction, failure-kind classification, and every caller's
+            // NamsOperationException-based graceful-degradation logic).
+            catch (Exception ex) when (ex is HttpRequestException or IOException or ObjectDisposedException)
+            {
+                return NamsOperationResult<T>.Failure(
+                    NamsFailureKind.Network,
+                    Redact($"NAMS response body could not be read: {ex.Message}", secretToRedact),
+                    (int)response.StatusCode);
+            }
         }
 
         var kind = ClassifyStatusCode(response.StatusCode);

--- a/src/AgentMemory.Nams/Domain/NamsFailureKind.cs
+++ b/src/AgentMemory.Nams/Domain/NamsFailureKind.cs
@@ -3,7 +3,8 @@ namespace AgentMemory.Nams.Domain;
 /// <summary>Coarse classification of a failed NAMS operation, independent of the HTTP status code that produced it.</summary>
 internal enum NamsFailureKind
 {
-    /// <summary>A network-level failure (connection reset, DNS, etc.) with no HTTP response.</summary>
+    /// <summary>A network-level failure (connection reset, DNS, etc.) with no HTTP response, or a successful
+    /// response whose headers arrived but whose body stream failed mid-read (a truncated/reset connection).</summary>
     Network,
 
     /// <summary>The request timed out before a response was received.</summary>

--- a/src/AgentMemory.Nams/Observability/NamsHealthCheck.cs
+++ b/src/AgentMemory.Nams/Observability/NamsHealthCheck.cs
@@ -28,9 +28,10 @@ internal sealed class NamsHealthCheck : INamsHealthCheck
         var stopwatch = Stopwatch.StartNew();
         try
         {
-            // The one safe, side-effect-free, no-precondition read this client exposes -- see
-            // INamsClient.ListEntitiesAsync's own doc for why SearchEntitiesAsync/GetContextAsync don't work
-            // as a probe (a required non-empty query, and a pre-existing conversation, respectively).
+            // A safe, side-effect-free, no-precondition read (limit: 1 keeps the result bounded, unlike the
+            // also-qualifying but unbounded GetEntityGraphAsync) -- see INamsClient.ListEntitiesAsync's own
+            // doc for why SearchEntitiesAsync/GetContextAsync don't work as a probe (a required non-empty
+            // query, and a pre-existing conversation, respectively).
             await _namsClient.ListEntitiesAsync(1, cancellationToken).ConfigureAwait(false);
             return new NamsHealthCheckResult
             {

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -25,6 +25,15 @@ public sealed class Neo4jNamsClientAdapterTests
         return new Neo4jNamsClientAdapter(httpClient, options, NullLogger<Neo4jNamsClientAdapter>.Instance, new NamsMetrics());
     }
 
+    // A 200 OK whose body stream fails mid-read (e.g. a truncated/reset connection) -- used to regression-test
+    // that this doesn't escape as a raw, unclassified exception (see NamsClientExceptionMapperTests too).
+    private sealed class StreamFailsOnReadContent : HttpContent
+    {
+        protected override Task<Stream> CreateContentReadStreamAsync() => throw new IOException("connection reset mid-read");
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) => throw new IOException("connection reset mid-read");
+        protected override bool TryComputeLength(out long length) { length = 0; return false; }
+    }
+
     private static HttpResponseMessage Json(HttpStatusCode statusCode, string json) =>
         new(statusCode) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
 
@@ -107,6 +116,24 @@ public sealed class Neo4jNamsClientAdapterTests
 
         context.RecentMessages.Should().BeEmpty();
         fake.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetContextAsync_SuccessResponseWithBodyStreamFailure_ThrowsMappedNetworkException()
+    {
+        // Regression test: a 200 OK whose body stream fails mid-read (truncated/reset connection) must be
+        // mapped to a proper NamsOperationException(FailureKind.Network) -- not escape as a raw, unclassified
+        // IOException that bypasses redaction and every caller's NamsOperationException-based handling.
+        var fake = new FakeHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamFailsOnReadContent()
+        });
+        var adapter = CreateAdapter(fake);
+
+        var act = () => adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.FailureKind.Should().Be(NamsFailureKind.Network);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fourth review-and-fix round over the NAMS integration, this time targeting angles the first three rounds didn't cover: cancellation-token propagation, exception-handling completeness, observability/telemetry parity, and remaining doc/sample/CHANGELOG staleness.

**The real bug (HIGH):** `NamsClientExceptionMapper.MapResponseAsync`'s success-path (200 OK) body read/deserialize only caught `JsonException`, but the sibling `SafeReadBodyAsync` helper in the same file already anticipated `HttpRequestException`/`IOException`/`ObjectDisposedException` from body-stream reads on the failure path. A connection dropping/truncating mid-body-read on an otherwise-successful response let a raw, unclassified exception escape the entire NAMS error-classification/redaction system -- bypassing `NamsRecallService`/`NamsPersistenceService`'s `NamsOperationException`-based graceful-degradation logic entirely. Fixed by widening the success-path catch to match the failure-path's exception set, mapping to `NamsFailureKind.Network` -- traced and confirmed this correctly routes into `NamsPersistenceService`'s existing Network/Timeout-keyed `UnknownWriteOutcome` degradation path, since a body-read failure means the write may have already succeeded server-side with no way to confirm it.

**Clean audits (no findings):** cancellation-token propagation across every async method; MCP tool exception safety (no divergence between the older Phase-8 tools and the newer Phase-154 ones); observability/telemetry parity (all 19 `INamsClient` operations route through one shared `InvokeAsync` helper, so nothing added since Phase 9 could bypass instrumentation).

**Doc/staleness fixes:**
- 2 stale "the one safe read" doc-comment superlatives (`INamsClient.cs`, `NamsHealthCheck.cs`) -- a second qualifying read (`GetEntityGraphAsync`) now exists.
- A stale sample code comment (`samples/AgentMemory.Sample.NamsAgent/Program.cs`) previously claimed no MCP tools existed for NAMS.
- 2 planning-doc amendments (`NAMS_TckPlatinumBridge_...md`, `NAMS_McpEntityReasoningTools_...md`) noting where later PRs (#155, #156) reversed/contradicted claims those docs originally made -- honest corrections, not rewrites.
- A new `CHANGELOG.md` entry (#128) for the whole NAMS backend feature, which had zero changelog entries despite ~20 merged PRs.

## Review
Self-reviewed (2 parallel passes: correctness + conventions) before this commit. Correctness pass traced the full call chain to confirm no double-handling and independently verified `NamsFailureKind.Network`'s downstream routing into the persistence service's degradation logic. Conventions pass found 2 minor nits (missing issue number on the CHANGELOG entry, a broken cross-reference path) -- both fixed.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3368 passed, 0 failed (1 new regression test)
- [x] `dotnet test tests/AgentMemory.Tests.Integration` -- 308 passed, 29 failed, all 29 exclusively in the `Nams.*` namespace with the same external cause (`503 workspace_not_provisioned/deprovisioned` from the live NAMS SaaS dev workspace) -- **not a regression from this change**, every non-NAMS test passes clean
- [x] Self-review (correctness + conventions), findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R