### PR TITLE
NAMS round 5: close a redaction-bypass gap in exception logging

### DIFF
--- a/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
+++ b/src/AgentMemory.Nams/Client/NamsClientExceptionMapper.cs
@@ -60,12 +60,24 @@ internal static class NamsClientExceptionMapper
     public static NamsOperationException FromTransportException(Exception ex, string? secretToRedact) => ex switch
     {
         HttpRequestException => new NamsOperationException(
-            NamsFailureKind.Network, Redact($"Network failure calling NAMS: {ex.Message}", secretToRedact), innerException: ex),
+            NamsFailureKind.Network, Redact($"Network failure calling NAMS: {ex.Message}", secretToRedact),
+            innerException: RedactedInnerException(ex, secretToRedact)),
         TaskCanceledException => new NamsOperationException(
-            NamsFailureKind.Timeout, "NAMS request timed out.", innerException: ex),
+            NamsFailureKind.Timeout, "NAMS request timed out.", innerException: RedactedInnerException(ex, secretToRedact)),
         _ => new NamsOperationException(
-            NamsFailureKind.Unknown, Redact($"Unexpected failure calling NAMS: {ex.Message}", secretToRedact), innerException: ex)
+            NamsFailureKind.Unknown, Redact($"Unexpected failure calling NAMS: {ex.Message}", secretToRedact),
+            innerException: RedactedInnerException(ex, secretToRedact))
     };
+
+    // A logger commonly renders an exception's full InnerException chain via Exception.ToString() -- attaching
+    // the raw transport exception here would let its own (unredacted) Message bypass the Redact(...) call
+    // above entirely, defeating this class's own stated redaction guarantee. Preserve the original exception's
+    // type name for diagnostics, but replace its message with a redacted copy and deliberately drop any
+    // further nested InnerException (same reasoning would otherwise apply recursively).
+    // Internal (not private): NamsRetryPolicy's own transient-failure logging needs the identical treatment
+    // for the same reason -- shared here rather than duplicated.
+    internal static Exception RedactedInnerException(Exception ex, string? secretToRedact) =>
+        new Exception($"{ex.GetType().Name}: {Redact(ex.Message, secretToRedact)}");
 
     private static NamsFailureKind ClassifyStatusCode(HttpStatusCode statusCode) => statusCode switch
     {

--- a/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
@@ -15,12 +15,14 @@ internal sealed class NamsRetryPolicy
     private readonly int _maxAttempts;
     private readonly TimeSpan _baseDelay;
     private readonly ILogger? _logger;
+    private readonly string? _secretToRedact;
 
-    public NamsRetryPolicy(int maxAttempts, TimeSpan baseDelay, ILogger? logger = null)
+    public NamsRetryPolicy(int maxAttempts, TimeSpan baseDelay, ILogger? logger = null, string? secretToRedact = null)
     {
         _maxAttempts = Math.Max(0, maxAttempts);
         _baseDelay = baseDelay;
         _logger = logger;
+        _secretToRedact = secretToRedact;
     }
 
     /// <summary><paramref name="requestFactory"/> is invoked once per attempt -- an <see cref="HttpRequestMessage"/>
@@ -62,7 +64,12 @@ internal sealed class NamsRetryPolicy
             {
                 // Network failure, or a per-request timeout (a TaskCanceledException whose token was NOT the
                 // caller's -- caller cancellation is handled by the guarded catch above).
-                _logger?.LogDebug(ex, "Transient NAMS failure; retry {Next}/{Max}.", attempt + 1, _maxAttempts);
+                // A logger renders the passed exception via ToString(), which would bypass redaction if the
+                // raw ex were passed directly (same gap NamsClientExceptionMapper.FromTransportException had,
+                // and the same fix -- a redacted-message-only substitute, never the raw exception object).
+                _logger?.LogDebug(
+                    NamsClientExceptionMapper.RedactedInnerException(ex, _secretToRedact),
+                    "Transient NAMS failure; retry {Next}/{Max}.", attempt + 1, _maxAttempts);
                 onRetry?.Invoke();
                 await Task.Delay(BackoffFor(attempt), cancellationToken).ConfigureAwait(false);
             }

--- a/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
+++ b/src/AgentMemory.Nams/Client/Neo4jNamsClientAdapter.cs
@@ -37,7 +37,7 @@ internal sealed class Neo4jNamsClientAdapter : INamsClient
     {
         _httpClient = httpClient;
         var namsOptions = options.Value;
-        _retryPolicy = new NamsRetryPolicy(namsOptions.MaxRetryAttempts, namsOptions.InitialRetryDelay, logger);
+        _retryPolicy = new NamsRetryPolicy(namsOptions.MaxRetryAttempts, namsOptions.InitialRetryDelay, logger, namsOptions.ApiKey);
         _apiKeyForRedaction = namsOptions.ApiKey;
         _metrics = metrics;
     }

--- a/tests/AgentMemory.Tests.Unit/MetaPackage/MetaPackageDiRegistrationTests.cs
+++ b/tests/AgentMemory.Tests.Unit/MetaPackage/MetaPackageDiRegistrationTests.cs
@@ -5,6 +5,9 @@ using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Extraction.AzureLanguage;
 using AgentMemory.Extraction.Llm;
+using AgentMemory.Nams;
+using AgentMemory.Nams.Persistence;
+using AgentMemory.Nams.Recall;
 using AgentMemory.Neo4j.Infrastructure;
 using AgentMemory.Observability;
 
@@ -300,5 +303,36 @@ public sealed class MetaPackageDiRegistrationTests
         var services = BuildServices();
         var act = () => services.WithAzureLanguageExtraction(null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ── Round 5 review gap: no test anywhere registered BOTH backends in one container ─────────────────
+
+    [Fact]
+    public void AddNeo4jAgentMemory_AndAddNamsAgentMemory_TogetherResolveWithNoCollision()
+    {
+        // Regression guard: the two backends were verified by a review pass to use fully disjoint service
+        // types, typed/named HttpClients, and per-type options validation -- this test locks that in so a
+        // future change (e.g. a shared interface, an unnamed HttpClient) that broke the separation would
+        // actually be caught, rather than relying only on manual inspection.
+        var services = BuildServices(configureNeo4j: o => o.Uri = "bolt://test:7687");
+        services.AddNamsAgentMemory(o =>
+        {
+            o.Endpoint = new Uri("https://nams.test/v1/");
+            o.ApiKey = "nams_key";
+        });
+
+        // Both backends' service types are present together -- descriptor-level, matching this file's
+        // established convention (full IMemoryService construction needs more setup than this minimal
+        // harness provides, per the existing AddNeo4jAgentMemory_RegistersCoreServices test above).
+        services.Should().Contain(d => d.ServiceType == typeof(IMemoryRecall));
+        services.Should().Contain(d => d.ServiceType == typeof(INamsRecallService));
+        services.Should().Contain(d => d.ServiceType == typeof(INamsPersistenceService));
+
+        var provider = services.BuildServiceProvider();
+
+        // Resolving each backend's options must not shadow the other's -- proves the two AddXxxOptions<T>()
+        // registrations didn't collide on the same options type.
+        provider.GetRequiredService<IOptions<Neo4jOptions>>().Value.Uri.Should().Be("bolt://test:7687");
+        provider.GetRequiredService<IOptions<NamsOptions>>().Value.Endpoint.Should().Be(new Uri("https://nams.test/v1/"));
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using AgentMemory.Nams.Client;
 
 namespace AgentMemory.Tests.Unit.Nams;
@@ -10,6 +11,25 @@ public sealed class NamsRetryPolicyTests
 
     private static NamsRetryPolicy CreatePolicy(int maxAttempts = 3) =>
         new(maxAttempts, TimeSpan.FromMilliseconds(1));
+
+    /// <summary>Captures every exception object passed to Log(...), so a test can inspect what a real
+    /// logger would have rendered via Exception.ToString() -- redaction bugs only show up here, not in the
+    /// message template string itself.</summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<Exception> LoggedExceptions { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (exception is not null)
+                LoggedExceptions.Add(exception);
+        }
+    }
 
     [Fact]
     public async Task Idempotent_TransientServerErrorThenSuccess_Retries()
@@ -165,5 +185,27 @@ public sealed class NamsRetryPolicyTests
 
         await act.Should().ThrowAsync<HttpRequestException>();
         fake.Requests.Should().HaveCount(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task Idempotent_TransientNetworkExceptionLogged_RedactsApiKeyFromLoggedException()
+    {
+        // Regression test: the transient-failure LogDebug call passed the raw caught exception straight to
+        // the logger -- a real ILogger provider renders it via Exception.ToString(), which would leak the API
+        // key if it ever appeared in the exception's own message (the same threat model
+        // NamsClientExceptionMapper's redaction already guards against; this call site bypassed it entirely).
+        const string apiKey = "nams_super_secret_12345";
+        var logger = new CapturingLogger();
+        var fake = new FakeHttpMessageHandler(
+            (_, _) => throw new HttpRequestException($"connection refused for key {apiKey}"));
+        using var client = new HttpClient(fake) { BaseAddress = BaseAddress };
+        var policy = new NamsRetryPolicy(maxAttempts: 1, TimeSpan.FromMilliseconds(1), logger, secretToRedact: apiKey);
+
+        var act = () => policy.ExecuteAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, "x"), client, retryEligibility: NamsRetryEligibility.Idempotent, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        logger.LoggedExceptions.Should().NotBeEmpty();
+        logger.LoggedExceptions.Should().OnlyContain(ex => !ex.ToString().Contains(apiKey));
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/Neo4jNamsClientAdapterTests.cs
@@ -736,4 +736,23 @@ public sealed class Neo4jNamsClientAdapterTests
         var exception = await act.Should().ThrowAsync<NamsOperationException>();
         exception.Which.FailureKind.Should().Be(NamsFailureKind.Network);
     }
+
+    [Fact]
+    public async Task NetworkFailure_RedactsApiKeyFromInnerExceptionToo()
+    {
+        // Regression test: FromTransportException redacted the outer NamsOperationException.Message, but
+        // originally attached the raw, unredacted transport exception as InnerException -- a logger calling
+        // Exception.ToString() (which recurses into InnerException) would still leak the secret. The full
+        // ToString() chain, not just the top-level Message, must never contain it.
+        const string apiKey = "nams_super_secret_12345";
+        var fake = new FakeHttpMessageHandler((_, _) => throw new HttpRequestException($"connection refused for key {apiKey}"));
+        var adapter = CreateAdapter(fake, apiKey);
+
+        var act = () => adapter.GetContextAsync("conv-1", CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<NamsOperationException>();
+        exception.Which.ToString().Should().NotContain(apiKey);
+        exception.Which.InnerException.Should().NotBeNull();
+        exception.Which.InnerException!.Message.Should().NotContain(apiKey);
+    }
 }


### PR DESCRIPTION
## Summary

Fifth review round on two genuinely fresh angles: a dedicated security pass over the newest NAMS code (`NamsClientExceptionMapper`, `NamsUntrustedContentGuard`), and a multi-backend DI interaction audit (does registering both the direct Neo4j backend and NAMS in one container collide?).

**Real finding (MEDIUM):** `NamsClientExceptionMapper.FromTransportException` redacted its own `NamsOperationException.Message` but attached the raw, unredacted original transport exception as `InnerException` -- a real `ILogger` provider renders the full exception chain via `ToString()`, so the API key would leak through the logging path even though `.Message` alone was clean. Fixed with a new `RedactedInnerException` helper that constructs a redacted-message-only substitute instead of passing the original exception through.

**Sibling finding, caught during self-review:** the exact same bug existed in `NamsRetryPolicy`'s transient-failure retry loop -- `_logger?.LogDebug(ex, ...)` passed the raw caught exception straight to the logger with **no redaction at all**, on every retryable transient failure (a far more frequently-executed path than the original fix's trigger). Fixed the same way, reusing the same helper (made `internal` for this purpose) rather than duplicating the logic.

**Clean audits:** cancellation/exception-handling elsewhere; `NamsUntrustedContentGuard`'s escaping (non-reversible, matches Core's already-reviewed pattern); API-key handling (never logged, only ever used as an `Authorization` header); URL-building (`Uri.EscapeDataString` used at every one of 9 path-segment call sites); multi-backend DI registration (fully disjoint service types, typed/named `HttpClient`s, per-type options validation, `nams_`-prefixed tool names -- no collision).

**Coverage gap closed:** no test previously registered both the direct Neo4j backend and NAMS backend together in one `IServiceCollection` -- new test proves no collision.

## Review
Self-reviewed (2 parallel passes: correctness + conventions) on the initial fix, plus an additional targeted verification pass after the sibling fix was added. Correctness passes traced the full call/logging chain and confirmed genuine regression tests (verified by inspecting `ILogger` extension-method binding, not just running green). Conventions pass found 2 minor cosmetic naming nits -- assessed and left, not worth further churn.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3371 passed, 0 failed (3 new regression tests)
- [x] Self-review (correctness + conventions) x2 passes, findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R