### PR TITLE
NAMS round 6: fix an unbounded-backoff crash bug shared with Enrichment

### DIFF
--- a/src/AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs
+++ b/src/AgentMemory.Enrichment/Http/RetryHttpMessageHandler.cs
@@ -73,6 +73,27 @@ internal sealed class RetryHttpMessageHandler : DelegatingHandler
         }
     }
 
-    private TimeSpan BackoffFor(int attempt) =>
-        TimeSpan.FromMilliseconds(_baseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+    // A cap, not just a formula: maxRetries only has a lower bound (Math.Max(0, ...) above) enforced by the
+    // ctor -- with no ceiling here, a caller-configured large retry count would grow this exponential past
+    // Task.Delay's ~49.7-day argument limit (ArgumentOutOfRangeException) or even overflow
+    // TimeSpan.FromMilliseconds itself (OverflowException), both escaping as a raw, unhandled exception
+    // instead of the graceful retry behavior this handler exists to provide. Same bug found and fixed in the
+    // NAMS backend's own mirror of this class, AgentMemory.Nams.Client.NamsRetryPolicy.
+    // Internal (not private): lets a unit test verify the cap directly instead of waiting through real
+    // multi-attempt delays.
+    internal static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+    // NaN is reachable and not caught by an uncapped >= comparison alone: baseDelay has no validation floor
+    // (unlike maxRetries), so baseDelay=0 combined with a large enough attempt that Math.Pow(2, attempt)
+    // itself overflows to +Infinity produces 0 * Infinity = NaN, and every comparison against NaN is false --
+    // TimeSpan.FromMilliseconds(NaN) would then throw ArgumentException, the same class of bug this cap
+    // exists to prevent. (+Infinity alone IS already caught by the >= comparison, since any comparison
+    // against +Infinity other than NaN is well-defined under IEEE 754 -- no separate IsInfinity check needed.)
+    internal TimeSpan BackoffFor(int attempt)
+    {
+        var uncapped = _baseDelay.TotalMilliseconds * Math.Pow(2, attempt);
+        return double.IsNaN(uncapped) || uncapped >= MaxBackoff.TotalMilliseconds
+            ? MaxBackoff
+            : TimeSpan.FromMilliseconds(uncapped);
+    }
 }

--- a/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
+++ b/src/AgentMemory.McpServer.Nams/Tools/NamsReasoningReadTools.cs
@@ -93,6 +93,14 @@ internal sealed class NamsReasoningReadTools
             return NamsMcpToolJson.Serialize(new { error = "entityId is required." });
 
         var provenance = await client.GetEntityProvenanceAsync(entityId, cancellationToken).ConfigureAwait(false);
+        // SECURITY (flagged, not mitigated): Provenance is raw, untyped JsonElement[] -- its real shape was
+        // never live-confirmed (only ever observed as an empty array; see NamsEntityProvenance's own doc
+        // comment), so it can't safely get the same Delimit/IsInstructionLike treatment nams_reasoning_trace's
+        // tool-call Input/Output got (that helper is string-typed; arbitrary JSON can't be escaped the same
+        // way without knowing its shape). This is the same untrusted-content risk class -- if the provenance
+        // chain is ever populated with content derived from reasoning steps that themselves recorded
+        // untrusted tool output, it would flow back here unescaped. Revisit once the real populated shape is
+        // observed live, matching this project's own "verify real behavior, don't guess" discipline.
         return NamsMcpToolJson.Serialize(new { provenance.EntityId, provenance.Provenance });
     }
 }

--- a/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
+++ b/src/AgentMemory.Nams/Client/NamsRetryPolicy.cs
@@ -79,26 +79,53 @@ internal sealed class NamsRetryPolicy
     private static bool IsTransient(HttpStatusCode status) =>
         status == HttpStatusCode.TooManyRequests || (int)status is >= 500 and < 600;
 
-    private TimeSpan RetryDelayFor(HttpResponseMessage response, int attempt)
+    // Internal (not private): lets a unit test verify the Retry-After capping directly.
+    internal TimeSpan RetryDelayFor(HttpResponseMessage response, int attempt)
     {
         // Retry-After has two legal forms (RFC 9110 §10.2.3): delta-seconds or an absolute HTTP-date. They're
         // mutually exclusive on RetryConditionHeaderValue -- check both, since NAMS's use of one form over the
         // other isn't confirmed (strategy/NAMS/Neo4j_Questions.md #24).
+        // Both forms are server-supplied and capped at MaxBackoff too -- an absurd or misconfigured
+        // Retry-After (e.g. many days out) would otherwise bypass the cap entirely, since neither value
+        // originates from BackoffFor's own formula. Both are also floored at zero before capping -- RFC 9110
+        // forbids a negative delta-seconds value, but RetryConditionHeaderValue's own constructor doesn't
+        // enforce that, and Task.Delay throws ArgumentOutOfRangeException for any negative TimeSpan.
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
             var retryAfter = response.Headers.RetryAfter;
             if (retryAfter?.Delta is { } delta)
-                return delta;
+                return Cap(delta > TimeSpan.Zero ? delta : TimeSpan.Zero);
             if (retryAfter?.Date is { } date)
             {
                 var untilDate = date - DateTimeOffset.UtcNow;
-                return untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero;
+                return Cap(untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero);
             }
         }
 
         return BackoffFor(attempt);
     }
 
-    private TimeSpan BackoffFor(int attempt) =>
-        TimeSpan.FromMilliseconds(_baseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+    // A cap, not just a formula: MaxRetryAttempts only has a lower bound (>= 0) enforced by
+    // NamsOptionValidator -- with no ceiling here, a misconfigured large attempt count would grow this
+    // exponential past Task.Delay's ~49.7-day argument limit (ArgumentOutOfRangeException) or even overflow
+    // TimeSpan.FromMilliseconds itself (OverflowException), both escaping this class's own
+    // NamsOperationException/NamsFailureKind error contract as a raw, unclassified framework exception.
+    // Internal (not private): lets a unit test verify the cap directly instead of waiting through real
+    // multi-attempt delays.
+    internal static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+    internal TimeSpan BackoffFor(int attempt) => Cap(_baseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+
+    // NaN is reachable and not caught by an uncapped >= comparison alone: baseDelay has no validation floor
+    // (unlike maxAttempts), so baseDelay=0 combined with a large enough attempt that Math.Pow(2, attempt)
+    // itself overflows to +Infinity produces 0 * Infinity = NaN, and every comparison against NaN is false --
+    // TimeSpan.FromMilliseconds(NaN) would then throw ArgumentException, the same class of bug this cap
+    // exists to prevent. (+Infinity alone IS already caught by the >= comparison, since any comparison
+    // against +Infinity other than NaN is well-defined under IEEE 754 -- no separate IsInfinity check needed.)
+    private static TimeSpan Cap(double milliseconds) =>
+        double.IsNaN(milliseconds) || milliseconds >= MaxBackoff.TotalMilliseconds
+            ? MaxBackoff
+            : TimeSpan.FromMilliseconds(milliseconds);
+
+    private static TimeSpan Cap(TimeSpan delay) => delay >= MaxBackoff ? MaxBackoff : delay;
 }

--- a/tests/AgentMemory.Tests.Unit/Enrichment/RetryHttpMessageHandlerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Enrichment/RetryHttpMessageHandlerTests.cs
@@ -173,4 +173,20 @@ public sealed class RetryHttpMessageHandlerTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         stub.Calls.Should().Be(2); // initial 503 + one retry → the retry handler is wired into the pipeline
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    [InlineData(1000)]
+    public void BackoffFor_NeverExceedsMaxBackoff_EvenForALargeAttemptCount(int attempt)
+    {
+        // Regression test: same unbounded-exponential-backoff bug found and fixed in this handler's NAMS
+        // mirror (AgentMemory.Nams.Client.NamsRetryPolicy) -- with no ceiling, a large attempt count would
+        // grow past Task.Delay's ~49.7-day argument limit or overflow TimeSpan.FromMilliseconds outright.
+        var handler = new RetryHttpMessageHandler(maxRetries: 3, logger: null, baseDelay: FastDelay);
+
+        var delay = handler.BackoffFor(attempt);
+
+        delay.Should().BeLessThanOrEqualTo(RetryHttpMessageHandler.MaxBackoff);
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Nams/NamsRetryPolicyTests.cs
@@ -208,4 +208,79 @@ public sealed class NamsRetryPolicyTests
         logger.LoggedExceptions.Should().NotBeEmpty();
         logger.LoggedExceptions.Should().OnlyContain(ex => !ex.ToString().Contains(apiKey));
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    [InlineData(1000)]
+    public void BackoffFor_NeverExceedsMaxBackoff_EvenForALargeAttemptCount(int attempt)
+    {
+        // Regression test: BackoffFor's exponential formula had no ceiling -- NamsOptionValidator only
+        // enforces MaxRetryAttempts >= 0, no upper bound, so a misconfigured large attempt count would grow
+        // past Task.Delay's ~49.7-day argument limit (ArgumentOutOfRangeException) or overflow
+        // TimeSpan.FromMilliseconds (OverflowException), both escaping this class's own NamsOperationException
+        // contract. attempt=1000 alone would previously throw when constructing the TimeSpan; now it must
+        // just return the cap.
+        var delay = CreatePolicy().BackoffFor(attempt);
+
+        delay.Should().BeLessThanOrEqualTo(NamsRetryPolicy.MaxBackoff);
+    }
+
+    [Fact]
+    public void BackoffFor_ZeroBaseDelayWithExtremeAttempt_DoesNotProduceNaN()
+    {
+        // Regression test: baseDelay has no validation floor (unlike maxAttempts) -- a zero baseDelay
+        // combined with an attempt large enough that Math.Pow(2, attempt) itself overflows to +Infinity
+        // produces 0 * Infinity = NaN, which an uncapped ">=" comparison alone does not catch (every
+        // comparison against NaN is false). TimeSpan.FromMilliseconds(NaN) would previously throw
+        // ArgumentException -- the same class of bug this whole fix exists to prevent.
+        var policy = new NamsRetryPolicy(maxAttempts: 3, TimeSpan.Zero);
+
+        var delay = policy.BackoffFor(2000);
+
+        delay.Should().Be(NamsRetryPolicy.MaxBackoff);
+    }
+
+    [Fact]
+    public void RetryDelayFor_AbsurdRetryAfterDeltaHeader_IsCapped()
+    {
+        // Regression test: the Retry-After header path returned the server-supplied delay directly, never
+        // routing through BackoffFor/MaxBackoff -- a misconfigured or hostile server sending an absurd
+        // Retry-After (e.g. many days out) would bypass the cap entirely, even though the raw value itself
+        // doesn't overflow anything.
+        var policy = CreatePolicy();
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromDays(1));
+
+        var delay = policy.RetryDelayFor(response, attempt: 0);
+
+        delay.Should().Be(NamsRetryPolicy.MaxBackoff);
+    }
+
+    [Fact]
+    public void RetryDelayFor_NegativeRetryAfterDeltaHeader_IsFlooredToZero_NotPassedNegativeToTaskDelay()
+    {
+        // Regression test: RFC 9110 forbids a negative delta-seconds value, but RetryConditionHeaderValue's
+        // own constructor doesn't enforce that -- a non-conformant/hostile server sending one would otherwise
+        // reach Task.Delay with a negative TimeSpan, which throws ArgumentOutOfRangeException.
+        var policy = CreatePolicy();
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(-5));
+
+        var delay = policy.RetryDelayFor(response, attempt: 0);
+
+        delay.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void RetryDelayFor_AbsurdRetryAfterDateHeader_IsCapped()
+    {
+        var policy = CreatePolicy();
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddDays(1));
+
+        var delay = policy.RetryDelayFor(response, attempt: 0);
+
+        delay.Should().Be(NamsRetryPolicy.MaxBackoff);
+    }
 }


### PR DESCRIPTION
## Summary

Sixth review round on two fresh angles: a public API/SemVer surface audit of everything the NAMS push added this week, and a correctness deep-dive on the newest, highest-churn files from rounds 3-5.

**Public API audit: completely clean.** Every new type across `AgentMemory.Nams`/`.AgentFramework.Nams`/`.McpServer.Nams` is correctly scoped `internal`, verified by both source inspection and reflecting over the built assemblies. No SemVer violations -- high-stakes check given this project's explicit 1.0 API-surface lockdown discipline.

**Real bug (MEDIUM):** `NamsRetryPolicy.BackoffFor` computed an exponential backoff delay with no ceiling. Since `MaxRetryAttempts` only has a lower-bound validation, a misconfigured large attempt count could grow the delay past `Task.Delay`'s ~49.7-day argument limit or overflow `TimeSpan.FromMilliseconds` itself -- both escaping as a raw framework exception instead of this class's own error contract. **The exact same bug already existed in the sibling `AgentMemory.Enrichment.Http.RetryHttpMessageHandler`** (which `NamsRetryPolicy`'s own doc comment says it deliberately mirrors) -- fixed identically in both, same precedent as round 3's cross-package fix.

**Self-review found two more real gaps in that fix, both closed:**
- A NaN edge case: `baseDelay=0` combined with an extreme attempt count produces `0 * Infinity = NaN`, which the original cap check doesn't catch (every comparison against NaN is false).
- A completely separate bypass: `NamsRetryPolicy`'s `Retry-After` header path never routed through the cap at all -- a misconfigured/hostile server could send an absurd delay and have it honored uncapped. Fixing that surfaced one more adjacent gap: a negative `Retry-After` delta (not forbidden by `RetryConditionHeaderValue`'s own constructor despite RFC 9110) would crash `Task.Delay` -- floored to zero, matching the existing pattern for the header's date-form branch.

**Also closed:** a thread flagged in an earlier round but never finished -- `nams_entity_provenance` passes raw, untyped JSON through with no escaping and no documentation of the gap, unlike its sibling `nams_reasoning_trace` (which got real mitigation). Added a SECURITY comment matching the established pattern, since the field's real shape has never been live-confirmed and can't be safely mitigated without guessing it.

## Review
Self-reviewed (2 parallel passes: correctness + conventions) plus one more targeted verification pass after the NaN/Retry-After fixes were added. All findings from all three passes fixed and re-verified.

## Test plan
- [x] `dotnet build AgentMemory.slnx -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test tests/AgentMemory.Tests.Unit` -- 3381 passed, 0 failed (10 new regression tests)
- [x] Self-review x3 passes, findings fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ8o6pxUWvEjeti6iws28R