### PR TITLE
perf(M-13): measure default recall on greeting-only turns

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -139,9 +139,10 @@ bootstrap unit, preserving the Docker/driver timing correlation instead of treat
 as independent. `--iterations` must therefore be a multiple of six and at least 12; 30 is the default.
 
 The initial configuration grammar accepts `default` plus `Recall.Max*` and
-`Recall.MinSimilarityScore` assignments. The default scenario is `PERF-R-04`. State-mutating
-scenarios such as `PERF-W-02` are rejected because shared write state would invalidate paired-sample
-independence.
+`Recall.MinSimilarityScore` assignments. `PERF-R-04` measures a full default recall, while
+`PERF-R-01` is a greeting-only control that locks the work performed by the shipped default recall
+policy. State-mutating scenarios such as `PERF-W-02` are rejected because shared write state would
+invalidate paired-sample independence.
 
 The rendered markdown reports exact counter ranges, retrieval and extraction quality, and the
 candidate/control bootstrap interval together. Only `iteration total` is the pre-registered timing
@@ -153,9 +154,10 @@ The harness uses a deterministic embedding function and a scripted model, so cou
 The judged quality fixtures had zero observed variance across five complete runs, which is why their
 tolerance is zero rather than a guessed allowance.
 
-Both measured scenarios also **self-assert**: the recall scenario fails the run if it retrieves fewer
-items than the configured limits, and the ingestion scenario fails if extraction never ran. Those
-failures are otherwise silent and would produce a confident, wrong number.
+All measured scenarios also **self-assert**. The full recall scenario fails if it retrieves fewer
+items than the configured limits, the greeting scenario locks its current default-policy item shape,
+and the ingestion scenario fails if extraction never ran. Those failures are otherwise silent and
+would produce a confident, wrong number.
 
 ### Pull-request regression gate
 

--- a/docs/performance/baseline-1.3.0.md
+++ b/docs/performance/baseline-1.3.0.md
@@ -43,6 +43,24 @@ completion of *latency* but four completions of *spend*. The four embedding requ
 extracted memory. The 18 writes are the message plus the extracted entities, facts, preferences, and
 their provenance edges.
 
+### Greeting-only default-policy control
+
+`PERF-R-01` sends “thanks, that's great” through the shipped default recall policy. Even though the
+turn does not need memory, the policy still performs the recall pipeline:
+
+| Counter | Per greeting turn |
+|---|---:|
+| Neo4j read / write transactions | 6 / 1 |
+| Neo4j queries | 7 |
+| Embedding provider requests | 1 |
+| Items retrieved | 11 |
+| Access timestamps updated | 1 |
+
+The 11 items are 10 recent messages plus one deterministic preference-bucket match; no semantically
+relevant message is returned. This is a control for selective/task-aware recall: the optimization
+target is to drive all recall work to zero on a skipped greeting while the retrieval quality guard
+remains unchanged. Hermetic milliseconds are intentionally not used for this claim.
+
 ### How these scale
 
 Worth knowing before you tune anything:

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -3,6 +3,27 @@
   "profile": "hermetic-S",
   "qualityTolerance": 0,
   "scenarios": {
+    "PERF-R-01": {
+      "counters": {
+        "access_tracking.items": 1,
+        "context.chars": 1784,
+        "context.messages": 12,
+        "embed.chars": 20,
+        "embed.items": 1,
+        "embed.requests": 1,
+        "items.entities": 0,
+        "items.facts": 0,
+        "items.preferences": 1,
+        "items.recent": 10,
+        "items.relevant": 0,
+        "items.retrieved": 11,
+        "items.traces": 0,
+        "neo4j.queries": 7,
+        "neo4j.tx.read": 6,
+        "neo4j.tx.write": 1,
+        "recall.chars": 1261
+      }
+    },
     "PERF-R-04": {
       "counters": {
         "access_tracking.items": 25,

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -1,0 +1,27 @@
+using AgentMemory.Cli.Perf;
+using FluentAssertions;
+
+namespace AgentMemory.Tests.Unit.Cli;
+
+public sealed class PerfScenarioCatalogTests
+{
+    [Fact]
+    public void Catalog_ContainsGreetingScenario_WithStableContract()
+    {
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-R-01");
+
+        scenario.Description.Should().ContainEquivalentOf("greeting");
+        scenario.Description.Should().ContainEquivalentOf("shipped default");
+        scenario.SupportsInterleavedAb.Should().BeTrue(
+            "the greeting scenario is read-only apart from the same access tracking isolated by perf ab");
+    }
+
+    [Fact]
+    public void Select_GreetingScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-R-01");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-R-01");
+    }
+}

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -1,6 +1,7 @@
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,10 @@ public static class PerfScenarios
 {
     public static IReadOnlyList<PerfScenario> All { get; } =
     [
+        new(
+            "PERF-R-01",
+            "Greeting-only turn at the shipped default recall policy",
+            GreetingRecallAsync),
         new("PERF-R-04", "Full multi-category recall at shipped defaults", RecallAsync),
         new(
             "PERF-W-02",
@@ -76,6 +81,57 @@ public static class PerfScenarios
     }
 
     /// <summary>
+    /// PERF-R-01 — a greeting/acknowledgement turn with no memory-retrieval intent. The shipped default
+    /// policy still recalls, so this captures the work that matrix rank 1 must eliminate.
+    /// </summary>
+    private static async Task GreetingRecallAsync(ScenarioContext ctx)
+    {
+        var identity = ctx.Variant is null
+            ? PerfFixture.DefaultIdentity
+            : PerfFixture.ForVariant(ctx.Variant);
+        var messages = new[]
+        {
+            new ChatMessage(ChatRole.User, "thanks, that's great"),
+        };
+
+        var context = await ctx.Provider.BuildContextAsync(
+            messages,
+            identity.SessionId,
+            identity.ConversationId,
+            ctx.CancellationToken,
+            identity.OwnerId).ConfigureAwait(false);
+
+        RecordContext(ctx.Turn, context);
+
+        // This scenario measures today's shipped policy, not a fixture-configured skipping policy.
+        // Ten recent messages are guaranteed by the scale-S fixture and are independent of semantic
+        // similarity, so they provide a robust proof that the recall path really ran.
+        var recent = ctx.Turn.Counter("items.recent");
+        var retrieved = ctx.Turn.Counter("items.retrieved");
+        var reads = ctx.Turn.Counter("neo4j.tx.read");
+        var embeddings = ctx.Turn.Counter("embed.requests");
+        var preferences = ctx.Turn.Counter("items.preferences");
+        var accessTracked = ctx.Turn.Counter("access_tracking.items");
+        var unexpectedSemantic =
+            ctx.Turn.Counter("items.relevant") +
+            ctx.Turn.Counter("items.entities") +
+            ctx.Turn.Counter("items.facts") +
+            ctx.Turn.Counter("items.traces");
+        if (recent != 10 || preferences != 1 || unexpectedSemantic != 0 ||
+            retrieved != 11 || accessTracked != 1 || reads == 0 || embeddings == 0)
+        {
+            throw new InvalidOperationException(
+                $"PERF-R-01 did not exercise shipped-default recall (items.recent={recent}/10, " +
+                $"items.preferences={preferences}/1, items.other_semantic={unexpectedSemantic}/0, " +
+                $"items.retrieved={retrieved}/11, access_tracking.items={accessTracked}/1, " +
+                $"neo4j.tx.read={reads}, embed.requests={embeddings}). The deterministic fixture's " +
+                "current hash-bucket overlap is part of this locked scenario shape. Do not configure " +
+                "a skipping policy inside this fixture: rank 1 must change product behavior and update " +
+                "this expectation explicitly.");
+        }
+    }
+
+    /// <summary>
     /// PERF-R-04 — the reference read turn: everything the MAF provider does before the model is called.
     /// </summary>
     private static async Task RecallAsync(ScenarioContext ctx)
@@ -92,11 +148,7 @@ public static class PerfScenarios
             ctx.CancellationToken,
             identity.OwnerId).ConfigureAwait(false);
 
-        // Materialized once: AIContext.Messages is an enumerable, so counting and summing it separately
-        // would enumerate it twice.
-        var contextMessages = context.Messages?.ToList() ?? [];
-        ctx.Turn.Add("context.messages", contextMessages.Count);
-        ctx.Turn.Add("context.chars", contextMessages.Sum(m => (long)(m.Text?.Length ?? 0)));
+        RecordContext(ctx.Turn, context);
 
         // Self-check, not decoration. A fixture whose vectors drift below MinSimilarityScore produces an
         // empty recall that still "succeeds" — and a baseline recorded from that would understate the
@@ -112,6 +164,15 @@ public static class PerfScenarios
                 $"({breakdown}). The fixture is not exercising the configured recall shape, so this " +
                 "measurement would be misleading. Check MinSimilarityScore and the seeded embeddings.");
         }
+    }
+
+    private static void RecordContext(TurnRecord turn, AIContext context)
+    {
+        // Materialized once: AIContext.Messages is an enumerable, so counting and summing it separately
+        // would enumerate it twice.
+        var contextMessages = context.Messages?.ToList() ?? [];
+        turn.Add("context.messages", contextMessages.Count);
+        turn.Add("context.chars", contextMessages.Sum(m => (long)(m.Text?.Length ?? 0)));
     }
 
     /// <summary>


### PR DESCRIPTION
## M-13 — greeting-only recall scenario

Harness-only Phase C task. Adds stable scenario `PERF-R-01` for a turn whose user content is
`thanks, that's great`. This measures the waste that optimization-matrix rank 1 must remove; it does
not implement the optimization.

## Pre-registered prediction

Recorded before implementation.

The shipped `ConfiguredAutomaticRecallPolicy` always recalls, so a greeting-only turn is expected to
execute the full six-category recall fan-out even though the content has no memory-retrieval intent.
The deterministic query has no lexical overlap with the scale-S semantic fixture, while recent-message
recall is query-independent.

| Counter | Expected `PERF-R-01` value |
|---|---:|
| `neo4j.tx.read` | 6 |
| `neo4j.tx.write` | 0 |
| `neo4j.queries` | 6 |
| `embed.requests` | 1 |
| `llm.calls` | 0 |
| `items.recent` | 10 |
| semantic entities/facts/preferences/messages/traces | 0 |
| `items.retrieved` | 10 |
| `access_tracking.items` | 0 |

If deterministic hash-bucket overlap produces a semantic hit, the exact item/access/write values may
differ; that is an observed baseline finding, not a result to tune away. The invariant prediction is
that the shipped default does non-zero recall work and returns at least the ten recent messages. Rank 1
must drive the scenario to zero by changing the policy, not by configuring a skipping policy inside the
fixture.

Guards:

- `PERF-R-04` and `PERF-W-02` counters remain at their committed baseline;
- retrieval Recall@K/MRR and extraction precision/recall remain 1.000, forbidden/false-positive counts
  remain zero;
- no hermetic-profile millisecond value is treated as deployment performance.

## Measured result

The preregistered collision caveat occurred: the deterministic greeting vector shares a bucket with
one stored preference. That creates one access update and therefore one write/query beyond the
no-collision estimate.

| Counter | Predicted | Measured |
|---|---:|---:|
| `neo4j.tx.read` | 6 | **6** |
| `neo4j.tx.write` | 0 | **1** |
| `neo4j.queries` | 6 | **7** |
| `embed.requests` | 1 | **1** |
| `llm.calls` | 0 | **0** |
| `items.recent` | 10 | **10** |
| `items.preferences` | 0, unless collision | **1** |
| all other semantic item categories | 0 | **0** |
| `items.retrieved` | 10, unless collision | **11** |
| `access_tracking.items` | 0, unless collision | **1** |

The exact values were identical in fresh-container runs
`20260726T105613Z__m13-determinism-1__hermetic-S-zero` and
`20260726T105654Z__m13-determinism-2__hermetic-S-zero`. A combined five-iteration baseline run
`20260726T132123Z__m13-baseline__hermetic-S-zero` rendered all three scenarios in `summary.json` and
`report.md`; `perf gate` passes against the updated committed baseline. Existing `PERF-R-04` and
`PERF-W-02` counters are unchanged, and all retrieval/extraction quality metrics remain 1.000 with
zero forbidden retrievals and zero extraction false positives.

## Acceptance evidence

- Red-first proof: both new catalog tests failed before `PERF-R-01` was registered, then passed after
  implementation.
- The scenario self-asserts its exact current default-policy item shape and fails rather than recording
  a silent no-op.
- Unit tests: **3,417 passed, 0 failed**.
- Release solution build: **0 warnings, 0 errors**.
- Integration tests: **311 passed**; the same **29 pre-existing NAMS failures** report
  `workspace_not_provisioned` / `deprovisioned`.
- Public cost-model documentation records portable counters only; hermetic milliseconds are not
  presented as deployment performance.
