### PR TITLE
perf(M-14): measure six-message response persistence

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -141,8 +141,8 @@ as independent. `--iterations` must therefore be a multiple of six and at least 
 The initial configuration grammar accepts `default` plus `Recall.Max*` and
 `Recall.MinSimilarityScore` assignments. `PERF-R-04` measures a full default recall, while
 `PERF-R-01` is a greeting-only control that locks the work performed by the shipped default recall
-policy. State-mutating scenarios such as `PERF-W-02` are rejected because shared write state would
-invalidate paired-sample independence.
+policy. State-mutating scenarios such as `PERF-W-02` and `PERF-W-03` are rejected because shared write
+state would invalidate paired-sample independence.
 
 The rendered markdown reports exact counter ranges, retrieval and extraction quality, and the
 candidate/control bootstrap interval together. Only `iteration total` is the pre-registered timing

--- a/docs/performance/baseline-1.3.0.md
+++ b/docs/performance/baseline-1.3.0.md
@@ -61,6 +61,29 @@ relevant message is returned. This is a control for selective/task-aware recall:
 target is to drive all recall work to zero on a skipped greeting while the retrieval quality guard
 remains unchanged. Hermetic milliseconds are intentionally not used for this claim.
 
+### Six-message tool-heavy ingestion control
+
+`PERF-W-03` holds the scripted extraction result constant while increasing response messages from one
+to six. This isolates the structural fan-out of a tool-heavy MAF turn:
+
+| Counter | One message (`W-02`) | Six messages (`W-03`) | Change |
+|---|---:|---:|---:|
+| Messages persisted | 1 | **6** | +5 |
+| Embedding requests | 4 | **9** | +5 |
+| Neo4j read transactions | 4 | **4** | 0 |
+| Neo4j write transactions | 18 | **48** | +30 |
+| Neo4j queries | 43 | **88** | +45 |
+| Model completions | 4 | **4** | 0 |
+| Model input tokens | 947 | **1,170** | +223 |
+| Persisted entities / facts / preferences | 2 / 2 / 1 | **2 / 2 / 1** | 0 |
+
+The write increase is larger than the five extra message nodes. The same five extracted memories
+remain guarded, and each gains an `EXTRACTED_FROM` link to each of the five additional source
+messages: **5 message writes + (5 memories × 5 provenance links) = 30 additional writes**. Query
+growth similarly consists of four message-persistence queries per additional message plus those 25
+provenance queries: **(5 × 4) + 25 = 45**. This control makes true batch response-message persistence
+measurable while also exposing the separate provenance fan-out it will not remove.
+
 ### How these scale
 
 Worth knowing before you tune anything:

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -63,6 +63,25 @@
         "persist.relationships": 0,
         "store.messages": 1
       }
+    },
+    "PERF-W-03": {
+      "counters": {
+        "embed.chars": 378,
+        "embed.items": 9,
+        "embed.requests": 9,
+        "extract.candidate_entities": 2,
+        "llm.calls": 4,
+        "llm.tokens_in": 1170,
+        "llm.tokens_out": 668,
+        "neo4j.queries": 88,
+        "neo4j.tx.read": 4,
+        "neo4j.tx.write": 48,
+        "persist.entities": 2,
+        "persist.facts": 2,
+        "persist.preferences": 1,
+        "persist.relationships": 0,
+        "store.messages": 6
+      }
     }
   },
   "quality": {

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -24,4 +24,24 @@ public sealed class PerfScenarioCatalogTests
         selected.Should().ContainSingle();
         selected[0].Id.Should().Be("PERF-R-01");
     }
+
+    [Fact]
+    public void Catalog_ContainsToolHeavyWriteScenario_WithStableContract()
+    {
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-W-03");
+
+        scenario.Description.Should().ContainEquivalentOf("six");
+        scenario.Description.Should().ContainEquivalentOf("tool-heavy");
+        scenario.SupportsInterleavedAb.Should().BeFalse(
+            "the scenario persists response messages and cannot share mutable state between A/B arms");
+    }
+
+    [Fact]
+    public void Select_ToolHeavyWriteScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-W-03");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-W-03");
+    }
 }

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -36,9 +36,9 @@ public sealed record ScenarioContext(
     CancellationToken CancellationToken);
 
 /// <summary>
-/// The Step 1 scenario catalog: one read-path scenario and one write-path scenario, both at shipped
-/// defaults. Between them they cover the two questions the roadmap's estimates most need replaced with
-/// facts — what a recall costs before the model runs, and what a turn costs after it.
+/// The versioned performance scenario catalog covers read- and write-path controls at shipped
+/// defaults. Together they replace estimates with facts about recall cost before the model runs and
+/// ingestion cost after it, including turns that exercise policy and workload extremes.
 /// </summary>
 public static class PerfScenarios
 {
@@ -53,6 +53,11 @@ public static class PerfScenarios
             "PERF-W-02",
             "Single response message, extraction enabled (shipped defaults)",
             StoreAndExtractAsync,
+            SupportsInterleavedAb: false),
+        new(
+            "PERF-W-03",
+            "Six-message tool-heavy response turn, extraction enabled",
+            StoreToolHeavyAndExtractAsync,
             SupportsInterleavedAb: false),
     ];
 
@@ -208,6 +213,54 @@ public static class PerfScenarios
             ctx.CancellationToken,
             PerfFixture.OwnerId).ConfigureAwait(false);
 
+        AssertScriptedExtraction(ctx, "PERF-W-02");
+    }
+
+    /// <summary>
+    /// PERF-W-03 — a tool-heavy turn with six non-empty response messages. The current provider
+    /// persists each response separately, so this captures the fan-out that matrix rank 9 must batch.
+    /// </summary>
+    private static async Task StoreToolHeavyAndExtractAsync(ScenarioContext ctx)
+    {
+        var sessionId = $"perf-w03-{ctx.Phase}-{ctx.Iteration}";
+        var conversationId = $"{sessionId}-conv";
+        var requestMessages = new[]
+        {
+            new ChatMessage(ChatRole.User, StoreProbeUserMessage),
+        };
+        var responseMessages = new[]
+        {
+            new ChatMessage(ChatRole.Assistant, "I'll check the account details."),
+            new ChatMessage(ChatRole.Tool, "Account lookup completed for Acme Corporation."),
+            new ChatMessage(ChatRole.Assistant, "I'll inspect the platform deployment."),
+            new ChatMessage(ChatRole.Tool, "Deployment lookup completed: all services are healthy."),
+            new ChatMessage(ChatRole.Assistant, "I'll verify the notification settings."),
+            new ChatMessage(ChatRole.Tool, "Notification lookup completed: concise written updates are preferred."),
+        };
+
+        await ctx.Provider.PerformStoreAsync(
+            requestMessages,
+            responseMessages,
+            sessionId,
+            conversationId,
+            ctx.CancellationToken,
+            PerfFixture.OwnerId).ConfigureAwait(false);
+
+        var storedMessages = ctx.Turn.Counter("store.messages");
+        if (storedMessages != responseMessages.Length)
+        {
+            throw new InvalidOperationException(
+                $"PERF-W-03 stored {storedMessages} response messages but expected " +
+                $"{responseMessages.Length}. The scenario would not exercise multi-message " +
+                "persistence, so it cannot grade rank 9. Check that every fixture response has " +
+                "non-empty text and reaches StoreResponseMessagesAsync.");
+        }
+
+        AssertScriptedExtraction(ctx, "PERF-W-03");
+    }
+
+    private static void AssertScriptedExtraction(ScenarioContext ctx, string scenarioId)
+    {
         // The mirror of the recall self-check: a scripted model returning unparseable output would make
         // extraction yield nothing, persistence write nothing, and this scenario measure a no-op. Model
         // calls alone are not evidence: an empty-but-valid response still records all four calls.
@@ -218,7 +271,7 @@ public static class PerfScenarios
         if (modelCalls == 0 || entities == 0 || facts == 0 || preferences == 0)
         {
             throw new InvalidOperationException(
-                $"PERF-W-02 did not persist the scripted extraction (llm.calls={modelCalls}, " +
+                $"{scenarioId} did not persist the scripted extraction (llm.calls={modelCalls}, " +
                 $"persist.entities={entities}, persist.facts={facts}, " +
                 $"persist.preferences={preferences}). The scenario would measure a no-op. Check that " +
                 "LLM extraction is opted in, AutoExtractOnPersist is true, and the scripted client " +


### PR DESCRIPTION
## M-14 — six-message tool-heavy ingestion scenario

Harness-only Phase C task. Adds stable scenario `PERF-W-03` for one user request followed by six
non-empty assistant/tool response messages. It exposes the current per-message persistence fan-out
that optimization-matrix rank 9 must batch; it does not implement that optimization.

## Pre-registered prediction

Recorded before implementation.

`Neo4jMemoryContextProvider.StoreResponseMessagesAsync` currently loops over response messages and
calls `AddMessageAsync` once per message. Each message generates one embedding request and one write
transaction containing four Neo4j queries: create the message, set its embedding, create the
first-message link if applicable, and link it to the preceding message.

The committed `PERF-W-02` baseline contains one response message. Holding its scripted extraction
payload constant and adding five response messages therefore predicted:

| Counter | `PERF-W-02` baseline | Predicted `PERF-W-03` |
|---|---:|---:|
| `store.messages` | 1 | **6** |
| `embed.requests` | 4 | **9** |
| `neo4j.tx.read` | 4 | **4** |
| `neo4j.tx.write` | 18 | **23** |
| `neo4j.queries` | 43 | **63** |
| `llm.calls` | 4 | **4** |
| `persist.entities` | 2 | **2** |
| `persist.facts` | 2 | **2** |
| `persist.preferences` | 1 | **1** |

Input-token and embedded-character counters were expected to increase because the five additional
texts are real extraction and embedding inputs. No hermetic-profile millisecond value is treated as
deployment performance.

Guards:

- `PERF-R-01`, `PERF-R-04`, and `PERF-W-02` remain at their committed counter baselines;
- retrieval Recall@K/MRR and extraction precision/recall remain 1.000, forbidden/false-positive counts
  remain zero;
- the new scenario must still persist the same scripted entities, facts, and preference, proving that
  a lower cost was not manufactured by skipping extraction.

## Measured result

The message-persistence prediction was correct, but it missed a second multiplicative fan-out:
`PersistenceStage` creates one `EXTRACTED_FROM` relationship for every extracted memory × every source
message. W-03 still produces five memories (2 entities + 2 facts + 1 preference), but has five more
source messages than W-02, adding **25 provenance writes and 25 queries**.

| Counter | W-02 | Predicted W-03 | Measured W-03 | Explanation |
|---|---:|---:|---:|---|
| `store.messages` | 1 | 6 | **6** | +5 response messages |
| `embed.requests` | 4 | 9 | **9** | +5 message embeddings |
| `neo4j.tx.read` | 4 | 4 | **4** | extraction reads unchanged |
| `neo4j.tx.write` | 18 | 23 | **48** | +5 messages +25 provenance links |
| `neo4j.queries` | 43 | 63 | **88** | +(5 × 4) message queries +25 provenance queries |
| `llm.calls` | 4 | 4 | **4** | unchanged |
| `llm.tokens_in` | 947 | increase | **1,170** | six response texts enter all extractor prompts |
| `persist.entities` | 2 | 2 | **2** | guard held |
| `persist.facts` | 2 | 2 | **2** | guard held |
| `persist.preferences` | 1 | 1 | **1** | guard held |

This is a baseline finding, not a fixture adjustment. Rank 9 can batch response persistence, while the
separate provenance fan-out remains visible for a later optimization.

Standard three-warm-up counters were identical across fresh-container runs
`20260726T134905Z__m14-determinism-warm-1__hermetic-S-zero` and
`20260726T134943Z__m14-determinism-warm-2__hermetic-S-zero`. Two diagnostic cold runs with no warm-up
also matched each other exactly, but recorded four additional entity-resolution embeddings and are
not used as the committed warm baseline.

Combined run `20260726T135433Z__m14-baseline__hermetic-S-zero` rendered all four scenarios in
`summary.json` and `report.md`; `perf gate` passes against the updated baseline. Existing scenario
counters are unchanged, and all retrieval/extraction quality scores remain 1.000 with zero forbidden
retrievals and zero extraction false positives.

## Acceptance evidence

- Red-first proof: both new catalog tests failed before `PERF-W-03` was registered, then passed after
  implementation.
- The scenario self-asserts exactly six persisted responses and non-zero scripted extraction outcomes.
- Unit tests: **3,419 passed, 0 failed**.
- Release solution build: **0 warnings, 0 errors**.
- Integration tests: **311 passed**; the same **29 pre-existing NAMS failures** report
  `workspace_not_provisioned` / `deprovisioned`.
- Public cost-model documentation records portable counters and the provenance attribution; hermetic
  milliseconds are not presented as deployment performance.
