### PR TITLE
perf(M-15): add degraded dependency recall scenario

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -107,6 +107,10 @@ dotnet run --project tools/AgentMemory.Cli -- perf --label mine --iterations 10
 # Reproduces the shape of a remote deployment (embedding 120 ms, model 900 ms)
 dotnet run --project tools/AgentMemory.Cli -- perf --label mine --latency remote --iterations 10
 
+# Exercises the scenario-scoped degraded control (embedding 2 s, each DB transaction 250 ms)
+dotnet run --project tools/AgentMemory.Cli -- perf --label degraded \
+  --scenarios PERF-R-07 --iterations 3
+
 # Compare two in-process recall configurations, with quality in the same report
 dotnet run --project tools/AgentMemory.Cli -- perf ab \
   --control default \
@@ -154,10 +158,11 @@ The harness uses a deterministic embedding function and a scripted model, so cou
 The judged quality fixtures had zero observed variance across five complete runs, which is why their
 tolerance is zero rather than a guessed allowance.
 
-All measured scenarios also **self-assert**. The full recall scenario fails if it retrieves fewer
-items than the configured limits, the greeting scenario locks its current default-policy item shape,
-and the ingestion scenario fails if extraction never ran. Those failures are otherwise silent and
-would produce a confident, wrong number.
+All measured scenarios also **self-assert**. The full and degraded recall scenarios fail if they
+retrieve fewer items than the configured limits; the degraded scenario additionally verifies that its
+embedding and database waits occurred inside recorded stage spans. The greeting scenario locks its
+current default-policy item shape, while both ingestion scenarios verify message persistence and
+extraction outcomes. Those failures are otherwise silent and would produce a confident, wrong number.
 
 ### Pull-request regression gate
 

--- a/docs/performance/baseline-1.3.0.md
+++ b/docs/performance/baseline-1.3.0.md
@@ -61,6 +61,29 @@ relevant message is returned. This is a control for selective/task-aware recall:
 target is to drive all recall work to zero on a skipped greeting while the retrieval quality guard
 remains unchanged. Hermetic milliseconds are intentionally not used for this claim.
 
+### Degraded-dependency recall control
+
+`PERF-R-07` applies a scenario-scoped deterministic stimulus: 2,000 ms for query embedding and 250 ms
+inside each database transaction. Current behavior has no recall deadline, so it waits and returns the
+same complete shape as `PERF-R-04`:
+
+| Counter | Normal full recall (`R-04`) | Degraded (`R-07`) |
+|---|---:|---:|
+| Neo4j read / write transactions | 6 / 1 | **6 / 1** |
+| Neo4j queries | 9 | **9** |
+| Embedding requests | 1 | **1** |
+| Items retrieved | 43 | **43** |
+| Access timestamps updated | 25 | **25** |
+| Configured embedding wait | – | **1 × 2,000 ms** |
+| Configured database wait | – | **7 × 250 ms** |
+
+In the five-iteration hermetic run, the embedding span had a 2,009 ms median, the seven transaction
+spans summed to 1,958 ms, and elapsed turn time was 2,566 ms because the six reads overlap. These are
+controlled-stimulus validation figures—not deployment performance. The portable finding is that the
+entire 43-item result is preserved and both degraded stages are now observable. Timeout/deadline work
+can use this control to prove bounded completion; graceful-degradation work must additionally report
+which categories were omitted rather than silently returning less.
+
 ### Six-message tool-heavy ingestion control
 
 `PERF-W-03` holds the scripted extraction result constant while increasing response messages from one

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -45,6 +45,31 @@
         "recall.chars": 3823
       }
     },
+    "PERF-R-07": {
+      "counters": {
+        "access_tracking.items": 25,
+        "context.chars": 3906,
+        "context.messages": 14,
+        "embed.chars": 95,
+        "embed.items": 1,
+        "embed.requests": 1,
+        "injected.database_delay.calls": 7,
+        "injected.database_delay.ms": 1750,
+        "injected.embedding_delay.calls": 1,
+        "injected.embedding_delay.ms": 2000,
+        "items.entities": 10,
+        "items.facts": 10,
+        "items.preferences": 5,
+        "items.recent": 10,
+        "items.relevant": 5,
+        "items.retrieved": 43,
+        "items.traces": 3,
+        "neo4j.queries": 9,
+        "neo4j.tx.read": 6,
+        "neo4j.tx.write": 1,
+        "recall.chars": 3823
+      }
+    },
     "PERF-W-02": {
       "counters": {
         "embed.chars": 201,

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -138,6 +138,7 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
             float[]? queryEmbedding = null;
             try
             {
+                using var embeddingSpan = AgentMemoryDiagnostics.Source.StartActivity("memory.recall.embedding");
                 queryEmbedding = await _embeddingOrchestrator
                     .EmbedQueryAsync(queryText, cancellationToken)
                     .ConfigureAwait(false);

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfDependencyLatencyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfDependencyLatencyTests.cs
@@ -1,0 +1,49 @@
+using AgentMemory.Cli.Perf;
+using FluentAssertions;
+
+namespace AgentMemory.Tests.Unit.Cli;
+
+public sealed class PerfDependencyLatencyTests
+{
+    [Fact]
+    public void ResolveEmbeddingDelay_WithoutScenarioPreset_UsesRunWideDelay()
+    {
+        var sut = new PerfDependencyLatency();
+        var runWide = TimeSpan.FromMilliseconds(120);
+
+        sut.Current.Should().BeNull();
+        sut.ResolveEmbeddingDelay(runWide).Should().Be(runWide);
+    }
+
+    [Fact]
+    public async Task Push_FlowsAcrossAsyncWork_AndRestoresPreviousPreset()
+    {
+        var sut = new PerfDependencyLatency();
+        var outer = PerfDependencyLatencyPreset.Degraded;
+        var inner = new PerfDependencyLatencyPreset(
+            "inner",
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(20));
+
+        using (sut.Push(outer))
+        {
+            sut.Current.Should().BeSameAs(outer);
+            sut.ResolveEmbeddingDelay(TimeSpan.Zero).Should().Be(outer.EmbeddingDelay);
+
+            var flowed = await Task.Run(() => sut.Current);
+            flowed.Should().BeSameAs(outer);
+
+            using (sut.Push(inner))
+            {
+                sut.Current.Should().BeSameAs(inner);
+                sut.ResolveEmbeddingDelay(TimeSpan.Zero).Should().Be(inner.EmbeddingDelay);
+            }
+
+            sut.Current.Should().BeSameAs(outer);
+        }
+
+        sut.Current.Should().BeNull();
+        sut.ResolveEmbeddingDelay(TimeSpan.FromMilliseconds(7))
+            .Should().Be(TimeSpan.FromMilliseconds(7));
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -44,4 +44,24 @@ public sealed class PerfScenarioCatalogTests
         selected.Should().ContainSingle();
         selected[0].Id.Should().Be("PERF-W-03");
     }
+
+    [Fact]
+    public void Catalog_ContainsDegradedRecallScenario_WithStableContract()
+    {
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-R-07");
+
+        scenario.Description.Should().ContainEquivalentOf("degraded");
+        scenario.Description.Should().ContainEquivalentOf("dependency");
+        scenario.SupportsInterleavedAb.Should().BeTrue(
+            "the recall fixture is isolated per A/B arm and the dependency preset is scenario-scoped");
+    }
+
+    [Fact]
+    public void Select_DegradedRecallScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-R-07");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-R-07");
+    }
 }

--- a/tools/AgentMemory.Cli/Commands/PerfAbCommand.cs
+++ b/tools/AgentMemory.Cli/Commands/PerfAbCommand.cs
@@ -292,7 +292,7 @@ public sealed class PerfAbCommand
         CancellationToken cancellationToken)
     {
         using var turn = collector.BeginTurn($"{scenario.Id}/{variant}", iteration, phase);
-        await scenario.RunAsync(new ScenarioContext(
+        await scenario.ExecuteAsync(new ScenarioContext(
             profile,
             provider,
             turn.Record,

--- a/tools/AgentMemory.Cli/Commands/PerfCommand.cs
+++ b/tools/AgentMemory.Cli/Commands/PerfCommand.cs
@@ -176,7 +176,7 @@ public sealed class PerfCommand
         for (var i = 0; i < warmup; i++)
         {
             using var turn = collector.BeginTurn(scenario.Id, i, "warmup");
-            await scenario.RunAsync(new ScenarioContext(
+            await scenario.ExecuteAsync(new ScenarioContext(
                 profile, provider, turn.Record, i, "warmup", null,
                 AgentMemory.Abstractions.Options.RecallOptions.Default, cancellationToken)).ConfigureAwait(false);
         }
@@ -184,7 +184,7 @@ public sealed class PerfCommand
         for (var i = 0; i < iterations; i++)
         {
             using var turn = collector.BeginTurn(scenario.Id, i, "measure");
-            await scenario.RunAsync(new ScenarioContext(
+            await scenario.ExecuteAsync(new ScenarioContext(
                 profile, provider, turn.Record, i, "measure", null,
                 AgentMemory.Abstractions.Options.RecallOptions.Default, cancellationToken)).ConfigureAwait(false);
         }
@@ -200,6 +200,16 @@ public sealed class PerfCommand
             profile = "hermetic",
             scale = "S",
             scenarios = scenarios.Select(s => s.Id).ToArray(),
+            scenarioDependencyLatency = scenarios
+                .Where(s => s.DependencyLatency is not null)
+                .ToDictionary(
+                    s => s.Id,
+                    s => new
+                    {
+                        name = s.DependencyLatency!.Name,
+                        embeddingDelayMs = s.DependencyLatency.EmbeddingDelay.TotalMilliseconds,
+                        databaseDelayMs = s.DependencyLatency.DatabaseDelay.TotalMilliseconds,
+                    }),
             iterations,
             warmup,
             // The fingerprint is what makes two reports comparable — or, more importantly, what makes it
@@ -341,6 +351,8 @@ public sealed class PerfCommand
         "context.chars" or "recall.chars" => "characters",
         "items.retrieved" => "memory items",
         _ when counter.StartsWith("items.", StringComparison.Ordinal) => "memory items",
+        _ when counter.EndsWith("_delay.calls", StringComparison.Ordinal) => "injected waits",
+        _ when counter.EndsWith("_delay.ms", StringComparison.Ordinal) => "configured milliseconds",
         _ => "count",
     };
 

--- a/tools/AgentMemory.Cli/Perf/HermeticProfile.cs
+++ b/tools/AgentMemory.Cli/Perf/HermeticProfile.cs
@@ -48,6 +48,9 @@ public sealed class HermeticProfile : IAsyncDisposable
     /// <summary>Raw driver, for bulk fixture seeding that would be pointlessly slow through the services.</summary>
     public IDriver Driver { get; private set; } = null!;
 
+    /// <summary>Scenario-scoped dependency latency; unset outside an explicitly degraded scenario.</summary>
+    public PerfDependencyLatency DependencyLatency { get; } = new();
+
     public static async Task<HermeticProfile> StartAsync(
         int dimensions,
         TimeSpan embeddingLatency,
@@ -92,13 +95,17 @@ public sealed class HermeticProfile : IAsyncDisposable
             // stay registered and a post-turn scenario would measure extraction that never happens.
             llm => { });
 
+        DecorateTransactionRunner(services, DependencyLatency);
+
         // Counting wrappers sit outermost so they observe every call the product makes, including the
         // ones issued from inside the extraction pipeline.
         services.RemoveAll<IEmbeddingGenerator<string, Embedding<float>>>();
         services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(
             new CountingEmbeddingGenerator(
                 new LatencyInjectingEmbeddingGenerator(
-                    new DeterministicEmbeddingGenerator(Dimensions), embeddingLatency)));
+                    new DeterministicEmbeddingGenerator(Dimensions),
+                    embeddingLatency,
+                    DependencyLatency)));
 
         services.RemoveAll<IChatClient>();
         services.AddSingleton<IChatClient>(
@@ -125,6 +132,40 @@ public sealed class HermeticProfile : IAsyncDisposable
         if (_container is not null) await _container.DisposeAsync().ConfigureAwait(false);
     }
 
+    private static void DecorateTransactionRunner(
+        IServiceCollection services,
+        PerfDependencyLatency dependencyLatency)
+    {
+        var descriptor = services.LastOrDefault(
+            item => item.ServiceType == typeof(INeo4jTransactionRunner))
+            ?? throw new InvalidOperationException("Neo4j transaction runner was not registered.");
+
+        services.Remove(descriptor);
+        services.Add(new ServiceDescriptor(
+            typeof(INeo4jTransactionRunner),
+            provider => new LatencyInjectingTransactionRunner(
+                CreateTransactionRunner(provider, descriptor),
+                dependencyLatency),
+            descriptor.Lifetime));
+    }
+
+    private static INeo4jTransactionRunner CreateTransactionRunner(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is INeo4jTransactionRunner instance)
+            return instance;
+
+        if (descriptor.ImplementationFactory is not null)
+            return (INeo4jTransactionRunner)descriptor.ImplementationFactory(provider);
+
+        if (descriptor.ImplementationType is not null)
+            return (INeo4jTransactionRunner)ActivatorUtilities.CreateInstance(
+                provider, descriptor.ImplementationType);
+
+        throw new InvalidOperationException("Neo4j transaction runner registration has no implementation.");
+    }
+
     /// <summary>
     /// Adds a fixed delay to every embedding request so the hermetic profile can reproduce the latency
     /// shape of a remote provider without a network. Separate from the counting decorator so latency and
@@ -133,13 +174,17 @@ public sealed class HermeticProfile : IAsyncDisposable
     private sealed class LatencyInjectingEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
     {
         private readonly IEmbeddingGenerator<string, Embedding<float>> _inner;
-        private readonly TimeSpan _delay;
+        private readonly TimeSpan _runWideDelay;
+        private readonly PerfDependencyLatency _dependencyLatency;
 
         public LatencyInjectingEmbeddingGenerator(
-            IEmbeddingGenerator<string, Embedding<float>> inner, TimeSpan delay)
+            IEmbeddingGenerator<string, Embedding<float>> inner,
+            TimeSpan runWideDelay,
+            PerfDependencyLatency dependencyLatency)
         {
             _inner = inner;
-            _delay = delay;
+            _runWideDelay = runWideDelay;
+            _dependencyLatency = dependencyLatency;
         }
 
         public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
@@ -147,8 +192,19 @@ public sealed class HermeticProfile : IAsyncDisposable
             EmbeddingGenerationOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            if (_delay > TimeSpan.Zero)
-                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            var preset = _dependencyLatency.Current;
+            var delay = _dependencyLatency.ResolveEmbeddingDelay(_runWideDelay);
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                if (preset is not null)
+                {
+                    PerfCollector.Current?.Add("injected.embedding_delay.calls");
+                    PerfCollector.Current?.Add(
+                        "injected.embedding_delay.ms",
+                        checked((long)delay.TotalMilliseconds));
+                }
+            }
             return await _inner.GenerateAsync(values, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -156,5 +212,79 @@ public sealed class HermeticProfile : IAsyncDisposable
             serviceType.IsInstanceOfType(this) ? this : _inner.GetService(serviceType, serviceKey);
 
         public void Dispose() => _inner.Dispose();
+    }
+
+    /// <summary>
+    /// Inserts deterministic waiting inside the real transaction span. The original work delegate still
+    /// receives the product's instrumented query runner, so query counting and behavior are unchanged.
+    /// </summary>
+    private sealed class LatencyInjectingTransactionRunner : INeo4jTransactionRunner
+    {
+        private readonly INeo4jTransactionRunner _inner;
+        private readonly PerfDependencyLatency _dependencyLatency;
+
+        public LatencyInjectingTransactionRunner(
+            INeo4jTransactionRunner inner,
+            PerfDependencyLatency dependencyLatency)
+        {
+            _inner = inner;
+            _dependencyLatency = dependencyLatency;
+        }
+
+        public Task<T> ReadAsync<T>(
+            Func<IAsyncQueryRunner, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(
+                async runner =>
+                {
+                    await DelayAsync(cancellationToken).ConfigureAwait(false);
+                    return await work(runner).ConfigureAwait(false);
+                },
+                cancellationToken);
+
+        public Task ReadAsync(
+            Func<IAsyncQueryRunner, Task> work,
+            CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(
+                async runner =>
+                {
+                    await DelayAsync(cancellationToken).ConfigureAwait(false);
+                    await work(runner).ConfigureAwait(false);
+                },
+                cancellationToken);
+
+        public Task<T> WriteAsync<T>(
+            Func<IAsyncQueryRunner, Task<T>> work,
+            CancellationToken cancellationToken = default) =>
+            _inner.WriteAsync(
+                async runner =>
+                {
+                    await DelayAsync(cancellationToken).ConfigureAwait(false);
+                    return await work(runner).ConfigureAwait(false);
+                },
+                cancellationToken);
+
+        public Task WriteAsync(
+            Func<IAsyncQueryRunner, Task> work,
+            CancellationToken cancellationToken = default) =>
+            _inner.WriteAsync(
+                async runner =>
+                {
+                    await DelayAsync(cancellationToken).ConfigureAwait(false);
+                    await work(runner).ConfigureAwait(false);
+                },
+                cancellationToken);
+
+        private async Task DelayAsync(CancellationToken cancellationToken)
+        {
+            var delay = _dependencyLatency.Current?.DatabaseDelay ?? TimeSpan.Zero;
+            if (delay <= TimeSpan.Zero) return;
+
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            PerfCollector.Current?.Add("injected.database_delay.calls");
+            PerfCollector.Current?.Add(
+                "injected.database_delay.ms",
+                checked((long)delay.TotalMilliseconds));
+        }
     }
 }

--- a/tools/AgentMemory.Cli/Perf/PerfDependencyLatency.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfDependencyLatency.cs
@@ -1,0 +1,65 @@
+namespace AgentMemory.Cli.Perf;
+
+/// <summary>
+/// A named, deterministic dependency-delay shape applied by one performance scenario.
+/// This is separate from the run-wide zero/remote provider profile so a degraded control can coexist
+/// with ordinary scenarios without slowing or changing them.
+/// </summary>
+public sealed record PerfDependencyLatencyPreset(
+    string Name,
+    TimeSpan EmbeddingDelay,
+    TimeSpan DatabaseDelay)
+{
+    /// <summary>
+    /// PERF-R-07: a clearly degraded embedding provider plus a slower database transaction boundary.
+    /// Long enough to dominate normal hermetic noise while keeping the two-profile CI run below five minutes.
+    /// </summary>
+    public static PerfDependencyLatencyPreset Degraded { get; } = new(
+        "degraded",
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromMilliseconds(250));
+}
+
+/// <summary>
+/// Carries a scenario's dependency-delay override through async recall fan-out without changing any
+/// process-wide provider setting. Nested scopes restore the previous value on disposal.
+/// </summary>
+public sealed class PerfDependencyLatency
+{
+    private readonly AsyncLocal<PerfDependencyLatencyPreset?> _current = new();
+
+    public PerfDependencyLatencyPreset? Current => _current.Value;
+
+    public IDisposable Push(PerfDependencyLatencyPreset preset)
+    {
+        ArgumentNullException.ThrowIfNull(preset);
+        var previous = _current.Value;
+        _current.Value = preset;
+        return new RestoreScope(this, previous);
+    }
+
+    public TimeSpan ResolveEmbeddingDelay(TimeSpan runWideDelay) =>
+        Current?.EmbeddingDelay ?? runWideDelay;
+
+    private sealed class RestoreScope : IDisposable
+    {
+        private readonly PerfDependencyLatency _owner;
+        private readonly PerfDependencyLatencyPreset? _previous;
+        private bool _disposed;
+
+        public RestoreScope(
+            PerfDependencyLatency owner,
+            PerfDependencyLatencyPreset? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _owner._current.Value = _previous;
+        }
+    }
+}

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -18,7 +18,17 @@ public sealed record PerfScenario(
     string Id,
     string Description,
     Func<ScenarioContext, Task> RunAsync,
-    bool SupportsInterleavedAb = true);
+    bool SupportsInterleavedAb = true,
+    PerfDependencyLatencyPreset? DependencyLatency = null)
+{
+    public async Task ExecuteAsync(ScenarioContext context)
+    {
+        using var latencyScope = DependencyLatency is null
+            ? null
+            : context.Profile.DependencyLatency.Push(DependencyLatency);
+        await RunAsync(context).ConfigureAwait(false);
+    }
+}
 
 /// <summary>Everything a scenario body needs for one iteration.</summary>
 /// <param name="Phase">
@@ -49,6 +59,11 @@ public static class PerfScenarios
             "Greeting-only turn at the shipped default recall policy",
             GreetingRecallAsync),
         new("PERF-R-04", "Full multi-category recall at shipped defaults", RecallAsync),
+        new(
+            "PERF-R-07",
+            "Degraded dependency recall (embedding 2 s, database transaction 250 ms)",
+            DegradedRecallAsync,
+            DependencyLatency: PerfDependencyLatencyPreset.Degraded),
         new(
             "PERF-W-02",
             "Single response message, extraction enabled (shipped defaults)",
@@ -139,7 +154,54 @@ public static class PerfScenarios
     /// <summary>
     /// PERF-R-04 — the reference read turn: everything the MAF provider does before the model is called.
     /// </summary>
-    private static async Task RecallAsync(ScenarioContext ctx)
+    private static Task RecallAsync(ScenarioContext ctx) =>
+        RunDefaultRecallAsync(ctx, "PERF-R-04");
+
+    /// <summary>
+    /// PERF-R-07 — the same full recall under deterministic embedding/database degradation. Current
+    /// behavior has no deadline, so it must complete with the full item shape and record both waits.
+    /// </summary>
+    private static async Task DegradedRecallAsync(ScenarioContext ctx)
+    {
+        await RunDefaultRecallAsync(ctx, "PERF-R-07").ConfigureAwait(false);
+
+        var preset = PerfDependencyLatencyPreset.Degraded;
+        var embeddingCalls = ctx.Turn.Counter("injected.embedding_delay.calls");
+        var embeddingMs = ctx.Turn.Counter("injected.embedding_delay.ms");
+        var databaseCalls = ctx.Turn.Counter("injected.database_delay.calls");
+        var databaseMs = ctx.Turn.Counter("injected.database_delay.ms");
+        var accessTracked = ctx.Turn.Counter("access_tracking.items");
+        var queries = ctx.Turn.Counter("neo4j.queries");
+        var embeddingSpans = ctx.Turn.SpanCounts.TryGetValue(
+            "memory.recall.embedding", out var embeddingSpanCount)
+            ? embeddingSpanCount
+            : 0;
+        var transactionSpans = ctx.Turn.SpanCounts.TryGetValue(
+            "memory.db.tx", out var transactionSpanCount)
+            ? transactionSpanCount
+            : 0;
+
+        var expectedEmbeddingMs = checked((long)preset.EmbeddingDelay.TotalMilliseconds);
+        const long expectedDatabaseCalls = 7;
+        var expectedDatabaseMs = checked(
+            expectedDatabaseCalls * (long)preset.DatabaseDelay.TotalMilliseconds);
+        if (embeddingCalls != 1 || embeddingMs != expectedEmbeddingMs ||
+            databaseCalls != expectedDatabaseCalls || databaseMs != expectedDatabaseMs ||
+            embeddingSpans != 1 || transactionSpans != expectedDatabaseCalls ||
+            accessTracked != 25 || queries != 9)
+        {
+            throw new InvalidOperationException(
+                $"PERF-R-07 did not record its degraded dependency shape " +
+                $"(embedding delay calls/ms={embeddingCalls}/{embeddingMs}, expected " +
+                $"1/{expectedEmbeddingMs}; database delay calls/ms={databaseCalls}/{databaseMs}, " +
+                $"expected {expectedDatabaseCalls}/{expectedDatabaseMs}; embedding spans=" +
+                $"{embeddingSpans}/1; transaction spans={transactionSpans}/{expectedDatabaseCalls}; " +
+                $"access_tracking.items={accessTracked}/25; neo4j.queries={queries}/9). The scenario " +
+                "would not grade timeouts or graceful degradation reliably.");
+        }
+    }
+
+    private static async Task RunDefaultRecallAsync(ScenarioContext ctx, string scenarioId)
     {
         var identity = ctx.Variant is null
             ? PerfFixture.DefaultIdentity
@@ -165,7 +227,7 @@ public static class PerfScenarios
             var breakdown = string.Join(", ", expected.ByCategory
                 .Select(kv => $"{kv.Key}={ctx.Turn.Counter($"items.{kv.Key}")}/{kv.Value}"));
             throw new InvalidOperationException(
-                $"PERF-R-04 recalled {retrieved} items but expected {expected.Total} " +
+                $"{scenarioId} recalled {retrieved} items but expected {expected.Total} " +
                 $"({breakdown}). The fixture is not exercising the configured recall shape, so this " +
                 "measurement would be misleading. Check MinSimilarityScore and the seeded embeddings.");
         }


### PR DESCRIPTION
## M-15 — degraded-dependency recall scenario

Harness-only Phase C task. Adds stable scenario `PERF-R-07` with a deterministic degraded preset:
2,000 ms per embedding request and 250 ms inside each Neo4j transaction. It establishes the control
needed by optimization ranks 12 (timeouts/deadlines) and 13 (partial graceful degradation); it does
not implement either optimization.

## Pre-registered prediction

Recorded before implementation.

The current product has no recall deadline, so the degraded turn should complete rather than time out.
`PERF-R-07` uses the same query and shipped-default recall shape as `PERF-R-04`; only dependency
waiting changes. Six category reads run concurrently after one query embedding, followed by one
access-tracking write.

| Counter | Expected value |
|---|---:|
| `embed.requests` | 1 |
| `neo4j.tx.read` | 6 |
| `neo4j.tx.write` | 1 |
| `neo4j.queries` | 9 |
| `items.retrieved` | 43 |
| `access_tracking.items` | 25 |
| injected embedding-delay calls / configured ms | 1 / 2,000 |
| injected database-delay calls / configured ms total | 7 / 1,750 |

Expected item shape: 10 recent messages, 5 relevant messages, 10 entities, 10 facts, 5 preferences,
and 3 traces. The embedding span must record the 2-second degradation, and the seven transaction spans
must include the configured database wait. These checks prove the preset was active; their elapsed
milliseconds are scenario-input validation, not deployment performance.

Guards:

- all existing scenario counters remain at their committed baselines;
- retrieval Recall@K/MRR and extraction precision/recall remain 1.000, forbidden/false-positive counts
  remain zero;
- R-07 must return the same 43-item recall shape as R-04, proving that “completion” did not mean silent
  data loss;
- the expanded zero + remote PR gate remains below its five-minute timeout.

## Result

Prediction matched exactly in two fresh-container runs and the five-iteration combined baseline:

| Counter | Predicted | Measured |
|---|---:|---:|
| Embedding requests | 1 | 1 |
| Neo4j read / write transactions | 6 / 1 | 6 / 1 |
| Neo4j queries | 9 | 9 |
| Items retrieved | 43 | 43 |
| Access timestamps updated | 25 | 25 |
| Injected embedding wait | 1 × 2,000 ms | 1 × 2,000 ms |
| Injected database wait | 7 × 250 ms | 7 × 250 ms |

All retrieval and extraction quality metrics remained 1.000, with zero forbidden and false-positive
counts. Existing scenario counters remained exact and the committed baseline gate passed locally.

The first acceptance run correctly failed because the Microsoft Agent Framework provider performed
query embedding outside the existing `memory.recall.embedding` span. The implementation adds that
missing production trace boundary; the same self-asserting scenario then passed with one embedding
span and seven transaction spans. This was a real observability gap found by the new control.

Indicative hermetic controlled-stimulus medians: 2,566 ms turn elapsed, 2,009 ms embedding span, and
1,958 ms summed across seven database spans. These are not deployment-performance claims; the
portable results are the exact counters, complete result shape, and observable injected waits.

## Verification

- Red-first catalog tests: 2 expected failures before `PERF-R-07` existed; pass after implementation.
- First scenario acceptance run: expected failure before the missing embedding span was fixed.
- Fresh-container determinism: 2/2 exact.
- Combined five-iteration baseline: exact, quality 1.000, `perf gate` PASS.
- Unit: 3,423 passed.
- Release solution build: 0 warnings, 0 errors.
- Integration: 311 passed; the known 29 NAMS failures remain due to the deprovisioned workspace.
