### PR TITLE
perf(M-16): add GraphRAG recall scenario

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -111,6 +111,10 @@ dotnet run --project tools/AgentMemory.Cli -- perf --label mine --latency remote
 dotnet run --project tools/AgentMemory.Cli -- perf --label degraded \
   --scenarios PERF-R-07 --iterations 3
 
+# Measures full memory + deterministic GraphRAG orchestration
+dotnet run --project tools/AgentMemory.Cli -- perf --label graphrag \
+  --scenarios PERF-R-08 --iterations 3
+
 # Compare two in-process recall configurations, with quality in the same report
 dotnet run --project tools/AgentMemory.Cli -- perf ab \
   --control default \
@@ -159,10 +163,12 @@ The judged quality fixtures had zero observed variance across five complete runs
 tolerance is zero rather than a guessed allowance.
 
 All measured scenarios also **self-assert**. The full and degraded recall scenarios fail if they
-retrieve fewer items than the configured limits; the degraded scenario additionally verifies that its
-embedding and database waits occurred inside recorded stage spans. The greeting scenario locks its
-current default-policy item shape, while both ingestion scenarios verify message persistence and
-extraction outcomes. Those failures are otherwise silent and would produce a confident, wrong number.
+retrieve fewer items than the configured limits; the degraded scenario additionally verifies that
+its embedding and database waits occurred inside recorded stage spans. The GraphRAG scenario requires
+its source call, two known items, configured wait, stage span, and rendered marker text while preserving
+the complete memory result. The greeting scenario locks its current default-policy item shape, while
+both ingestion scenarios verify message persistence and extraction outcomes. Those failures are
+otherwise silent and would produce a confident, wrong number.
 
 ### Pull-request regression gate
 

--- a/docs/performance/baseline-1.3.0.md
+++ b/docs/performance/baseline-1.3.0.md
@@ -84,6 +84,32 @@ entire 43-item result is preserved and both degraded stages are now observable. 
 can use this control to prove bounded completion; graceful-degradation work must additionally report
 which categories were omitted rather than silently returning less.
 
+### GraphRAG orchestration control
+
+`PERF-R-08` adds a scenario-only deterministic GraphRAG source to the complete `PERF-R-04` memory
+shape. It returns two known context items after a configured 300 ms wait:
+
+| Counter | Full recall (`R-04`) | GraphRAG (`R-08`) |
+|---|---:|---:|
+| Memory items retrieved | 43 | **43** |
+| GraphRAG items | – | **2** |
+| Prompt messages | 14 | **15** |
+| Embedding requests | 1 | **1** |
+| Neo4j read / write transactions | 6 / 1 | **6 / 1** |
+| Neo4j queries | 9 | **9** |
+| Access timestamps updated | 25 | **25** |
+| Configured GraphRAG wait | – | **1 × 300 ms** |
+
+The portable result is that enabling this optional path adds its two known items without changing or
+dropping any of the 43 memory items. One `memory.recall.graphrag` span and the marker text in the final
+Agent Framework context prove the source was registered, enabled, invoked, and materialized.
+
+The remote-shaped hermetic run also validates rank 17's orchestration target. The provider embedding
+span had a 126 ms median and completed before the 312 ms GraphRAG span because the provider currently
+awaits embedding before entering the assembler; median turn elapsed was 468 ms. Rank 17 should overlap
+those controlled stages so their contribution tends toward the slower stage instead of their sum.
+These are deterministic stimulus figures for an A/B control—not deployment performance.
+
 ### Six-message tool-heavy ingestion control
 
 `PERF-W-03` holds the scripted extraction result constant while increasing response messages from one

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -70,6 +70,31 @@
         "recall.chars": 3823
       }
     },
+    "PERF-R-08": {
+      "counters": {
+        "access_tracking.items": 25,
+        "context.chars": 4072,
+        "context.messages": 15,
+        "embed.chars": 95,
+        "embed.items": 1,
+        "embed.requests": 1,
+        "graphrag.calls": 1,
+        "injected.graphrag_delay.calls": 1,
+        "injected.graphrag_delay.ms": 300,
+        "items.entities": 10,
+        "items.facts": 10,
+        "items.graphrag": 2,
+        "items.preferences": 5,
+        "items.recent": 10,
+        "items.relevant": 5,
+        "items.retrieved": 43,
+        "items.traces": 3,
+        "neo4j.queries": 9,
+        "neo4j.tx.read": 6,
+        "neo4j.tx.write": 1,
+        "recall.chars": 3934
+      }
+    },
     "PERF-W-02": {
       "counters": {
         "embed.chars": 201,

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -64,4 +64,24 @@ public sealed class PerfScenarioCatalogTests
         selected.Should().ContainSingle();
         selected[0].Id.Should().Be("PERF-R-07");
     }
+
+    [Fact]
+    public void Catalog_ContainsGraphRagRecallScenario_WithStableContract()
+    {
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-R-08");
+
+        scenario.Description.Should().ContainEquivalentOf("GraphRAG");
+        scenario.Description.Should().ContainEquivalentOf("recall");
+        scenario.SupportsInterleavedAb.Should().BeTrue(
+            "the GraphRAG source is deterministic and the recall fixture is isolated per A/B arm");
+    }
+
+    [Fact]
+    public void Select_GraphRagRecallScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-R-08");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-R-08");
+    }
 }

--- a/tools/AgentMemory.Cli/Commands/PerfCommand.cs
+++ b/tools/AgentMemory.Cli/Commands/PerfCommand.cs
@@ -351,6 +351,7 @@ public sealed class PerfCommand
         "context.chars" or "recall.chars" => "characters",
         "items.retrieved" => "memory items",
         _ when counter.StartsWith("items.", StringComparison.Ordinal) => "memory items",
+        "graphrag.calls" => "GraphRAG requests",
         _ when counter.EndsWith("_delay.calls", StringComparison.Ordinal) => "injected waits",
         _ when counter.EndsWith("_delay.ms", StringComparison.Ordinal) => "configured milliseconds",
         _ => "count",

--- a/tools/AgentMemory.Cli/Perf/DeterministicGraphRagContextSource.cs
+++ b/tools/AgentMemory.Cli/Perf/DeterministicGraphRagContextSource.cs
@@ -1,0 +1,60 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+
+namespace AgentMemory.Cli.Perf;
+
+/// <summary>
+/// Scenario-only GraphRAG source with a known result and delay. It lets the harness prove that the
+/// optional path ran without coupling a GraphRAG orchestration measurement to a second search/index
+/// implementation whose own behavior belongs in integration tests.
+/// </summary>
+internal sealed class DeterministicGraphRagContextSource : IGraphRagContextSource
+{
+    internal const long DelayMilliseconds = 300;
+    internal const string FirstMarker =
+        "Project Atlas depends on the Beacon identity service.";
+    internal const string SecondMarker =
+        "The platform team owns Beacon and its incident response.";
+
+    public async Task<GraphRagContextResult> GetContextAsync(
+        GraphRagContextRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        PerfCollector.Current?.Add("graphrag.calls");
+
+        await Task.Delay(
+                TimeSpan.FromMilliseconds(DelayMilliseconds),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        PerfCollector.Current?.Add("injected.graphrag_delay.calls");
+        PerfCollector.Current?.Add(
+            "injected.graphrag_delay.ms",
+            DelayMilliseconds);
+
+        IReadOnlyList<GraphRagContextItem> all =
+        [
+            new()
+            {
+                Text = FirstMarker,
+                Score = 1.0,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["source"] = "deterministic-perf-fixture",
+                },
+            },
+            new()
+            {
+                Text = SecondMarker,
+                Score = 0.9,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["source"] = "deterministic-perf-fixture",
+                },
+            },
+        ];
+        var items = all.Take(Math.Max(0, request.TopK)).ToList();
+        PerfCollector.Current?.Add("items.graphrag", items.Count);
+        return new GraphRagContextResult { Items = items };
+    }
+}

--- a/tools/AgentMemory.Cli/Perf/HermeticProfile.cs
+++ b/tools/AgentMemory.Cli/Perf/HermeticProfile.cs
@@ -95,6 +95,11 @@ public sealed class HermeticProfile : IAsyncDisposable
             // stay registered and a post-turn scenario would measure extraction that never happens.
             llm => { });
 
+        // Registered exactly as a host source would be, but the shared MemoryOptions keep GraphRAG
+        // disabled. PERF-R-08 builds an isolated production assembler with EnableGraphRag=true; every
+        // other scenario continues to exercise shipped defaults and cannot call this source.
+        services.AddSingleton<IGraphRagContextSource, DeterministicGraphRagContextSource>();
+
         DecorateTransactionRunner(services, DependencyLatency);
 
         // Counting wrappers sit outermost so they observe every call the product makes, including the

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -1,6 +1,8 @@
 using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.AgentFramework;
+using AgentMemory.Core.Services;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,6 +66,10 @@ public static class PerfScenarios
             "Degraded dependency recall (embedding 2 s, database transaction 250 ms)",
             DegradedRecallAsync,
             DependencyLatency: PerfDependencyLatencyPreset.Degraded),
+        new(
+            "PERF-R-08",
+            "GraphRAG-enabled full recall with deterministic context",
+            GraphRagRecallAsync),
         new(
             "PERF-W-02",
             "Single response message, extraction enabled (shipped defaults)",
@@ -201,14 +207,65 @@ public static class PerfScenarios
         }
     }
 
-    private static async Task RunDefaultRecallAsync(ScenarioContext ctx, string scenarioId)
+    /// <summary>
+    /// PERF-R-08 — the full memory recall plus a scenario-only deterministic GraphRAG source. The
+    /// Agent Framework provider currently finishes its query embedding before the assembler can start
+    /// GraphRAG; rank 17 uses this control to prove those two stages overlap after orchestration moves.
+    /// </summary>
+    private static async Task GraphRagRecallAsync(ScenarioContext ctx)
+    {
+        var provider = CreateProvider(ctx.Profile, ctx.RecallOptions, enableGraphRag: true);
+        var context = await RunDefaultRecallAsync(ctx, "PERF-R-08", provider).ConfigureAwait(false);
+
+        var graphRagSpans = ctx.Turn.SpanCounts.TryGetValue(
+            "memory.recall.graphrag", out var graphRagSpanCount)
+            ? graphRagSpanCount
+            : 0;
+        var graphRagCalls = ctx.Turn.Counter("graphrag.calls");
+        var graphRagItems = ctx.Turn.Counter("items.graphrag");
+        var graphRagDelayCalls = ctx.Turn.Counter("injected.graphrag_delay.calls");
+        var graphRagDelayMs = ctx.Turn.Counter("injected.graphrag_delay.ms");
+        var embeddings = ctx.Turn.Counter("embed.requests");
+        var reads = ctx.Turn.Counter("neo4j.tx.read");
+        var writes = ctx.Turn.Counter("neo4j.tx.write");
+        var queries = ctx.Turn.Counter("neo4j.queries");
+        var accessTracked = ctx.Turn.Counter("access_tracking.items");
+        var materialized = context.Messages?.Any(message =>
+            message.Text?.Contains(
+                DeterministicGraphRagContextSource.FirstMarker,
+                StringComparison.Ordinal) == true &&
+            message.Text.Contains(
+                DeterministicGraphRagContextSource.SecondMarker,
+                StringComparison.Ordinal)) == true;
+
+        if (graphRagSpans != 1 || graphRagCalls != 1 || graphRagItems != 2 ||
+            graphRagDelayCalls != 1 ||
+            graphRagDelayMs != DeterministicGraphRagContextSource.DelayMilliseconds ||
+            embeddings != 1 || reads != 6 || writes != 1 || queries != 9 ||
+            accessTracked != 25 || !materialized)
+        {
+            throw new InvalidOperationException(
+                $"PERF-R-08 did not exercise its GraphRAG contract " +
+                $"(spans={graphRagSpans}/1, calls={graphRagCalls}/1, items={graphRagItems}/2, " +
+                $"delay calls/ms={graphRagDelayCalls}/{graphRagDelayMs}, expected " +
+                $"1/{DeterministicGraphRagContextSource.DelayMilliseconds}; embed.requests=" +
+                $"{embeddings}/1; neo4j read/write/queries={reads}/{writes}/{queries}, expected " +
+                $"6/1/9; access_tracking.items={accessTracked}/25; materialized={materialized}/true). " +
+                "A disabled or unregistered GraphRAG source would make this measurement a no-op.");
+        }
+    }
+
+    private static async Task<AIContext> RunDefaultRecallAsync(
+        ScenarioContext ctx,
+        string scenarioId,
+        Neo4jMemoryContextProvider? provider = null)
     {
         var identity = ctx.Variant is null
             ? PerfFixture.DefaultIdentity
             : PerfFixture.ForVariant(ctx.Variant);
         var messages = new[] { new ChatMessage(ChatRole.User, PerfFixture.ProbeQueryFor(identity)) };
 
-        var context = await ctx.Provider.BuildContextAsync(
+        var context = await (provider ?? ctx.Provider).BuildContextAsync(
             messages,
             identity.SessionId,
             identity.ConversationId,
@@ -231,6 +288,8 @@ public static class PerfScenarios
                 $"({breakdown}). The fixture is not exercising the configured recall shape, so this " +
                 "measurement would be misleading. Check MinSimilarityScore and the seeded embeddings.");
         }
+
+        return context;
     }
 
     private static void RecordContext(TurnRecord turn, AIContext context)
@@ -351,19 +410,63 @@ public static class PerfScenarios
     /// </remarks>
     public static Neo4jMemoryContextProvider CreateProvider(
         HermeticProfile profile,
-        RecallOptions? recallOptions = null)
+        RecallOptions? recallOptions = null,
+        bool enableGraphRag = false)
     {
         var services = profile.Services;
         var configuredMemory = services.GetRequiredService<IOptions<MemoryOptions>>().Value;
         var selectedRecall = recallOptions ?? configuredMemory.Recall;
+        var selectedMemory = configuredMemory with
+        {
+            Recall = selectedRecall,
+            EnableGraphRag = enableGraphRag || configuredMemory.EnableGraphRag,
+        };
+        var memoryService = enableGraphRag
+            ? CreateGraphRagMemoryService(services, selectedMemory)
+            : services.GetRequiredService<IMemoryService>();
         return new Neo4jMemoryContextProvider(
-            services.GetRequiredService<IMemoryService>(),
+            memoryService,
             services.GetRequiredService<IEmbeddingOrchestrator>(),
             services.GetRequiredService<IClock>(),
             services.GetRequiredService<IIdGenerator>(),
-            Options.Create(configuredMemory with { Recall = selectedRecall }),
+            Options.Create(selectedMemory),
             Options.Create(new ContextFormatOptions()),
             Options.Create(new AgentFrameworkOptions()),
             services.GetRequiredService<ILogger<Neo4jMemoryContextProvider>>());
+    }
+
+    private static IMemoryService CreateGraphRagMemoryService(
+        IServiceProvider services,
+        MemoryOptions memoryOptions)
+    {
+        var options = Options.Create(memoryOptions);
+        var shortTerm = services.GetRequiredService<IShortTermMemoryService>();
+        var embedding = services.GetRequiredService<IEmbeddingOrchestrator>();
+        var assembler = new MemoryContextAssembler(
+            shortTerm,
+            services.GetRequiredService<ILongTermMemoryService>(),
+            services.GetRequiredService<IReasoningMemoryService>(),
+            services.GetRequiredService<IGraphRagContextSource>(),
+            embedding,
+            services.GetRequiredService<IClock>(),
+            options,
+            services.GetRequiredService<ILogger<MemoryContextAssembler>>(),
+            services.GetRequiredService<IMemoryIsolationPolicy>(),
+            services.GetService<IWritableMemoryRankingContext>());
+
+        return new MemoryService(
+            shortTerm,
+            assembler,
+            services.GetRequiredService<IMemoryExtractionPipeline>(),
+            services.GetRequiredService<IEntityRepository>(),
+            services.GetRequiredService<IFactRepository>(),
+            services.GetRequiredService<IPreferenceRepository>(),
+            embedding,
+            options,
+            services.GetRequiredService<IClock>(),
+            services.GetRequiredService<IIdGenerator>(),
+            services.GetRequiredService<ILogger<MemoryService>>(),
+            services.GetService<IMemoryDecayService>(),
+            services.GetService<IConversationRepository>());
     }
 }


### PR DESCRIPTION
## M-16 — GraphRAG-enabled recall scenario

Harness-only Phase C task. Adds stable scenario `PERF-R-08`: the same complete scale-S memory recall
as `PERF-R-04`, plus a registered deterministic GraphRAG source enabled only in this scenario. This
establishes the control needed by optimization rank 17 (overlap query embedding with GraphRAG); it does
not implement that optimization.

## Pre-registered prediction

Recorded before implementation.

The Agent Framework provider currently generates the query embedding before it calls the memory
assembler. Although the assembler starts GraphRAG before its own memory fan-out, GraphRAG therefore
cannot overlap the provider-owned query embedding. The scenario injects a 300 ms GraphRAG source delay
and returns two known context items.

| Counter | Expected value |
|---|---:|
| `embed.requests` | 1 |
| `neo4j.tx.read` | 6 |
| `neo4j.tx.write` | 1 |
| `neo4j.queries` | 9 |
| memory `items.retrieved` | 43 |
| `access_tracking.items` | 25 |
| `graphrag.calls` | 1 |
| `items.graphrag` | 2 |
| injected GraphRAG-delay calls / configured ms | 1 / 300 |
| `memory.recall.graphrag` spans | 1 |

Expected memory shape remains 10 recent messages, 5 relevant messages, 10 entities, 10 facts,
5 preferences, and 3 traces. The two GraphRAG items are additional context and must both be
materialized in the Agent Framework result.

Guards:

- retrieval Recall@K/MRR and extraction precision/recall remain 1.000; forbidden/false-positive counts
  remain zero;
- the complete 43-item memory shape and all access tracking remain unchanged;
- every existing scenario remains at its committed counter baseline;
- the GraphRAG marker text and span must be present, preventing an unregistered/disabled source from
  producing a healthy-looking no-op;
- the expanded zero + remote PR gate remains below five minutes.

## Result

Prediction matched exactly in two final-code fresh-container runs, including the complete combined
baseline:

| Counter | Predicted | Measured |
|---|---:|---:|
| Embedding requests | 1 | 1 |
| Neo4j read / write transactions | 6 / 1 | 6 / 1 |
| Neo4j queries | 9 | 9 |
| Memory items retrieved | 43 | 43 |
| Access timestamps updated | 25 | 25 |
| GraphRAG calls / items | 1 / 2 | 1 / 2 |
| Injected GraphRAG wait | 1 × 300 ms | 1 × 300 ms |
| GraphRAG spans | 1 | 1 |

Both known GraphRAG markers were materialized in the final context, which expanded from 14 to 15
prompt messages and from 3,906 to 4,072 context characters. All five pre-existing scenarios remained
at their exact committed counters. Retrieval and extraction quality remained 1.000 with zero
forbidden/false-positive counts; the regenerated baseline adds only the new `PERF-R-08` block.

The remote-shaped controlled run measured median provider embedding 126 ms, GraphRAG span 312 ms, and
turn elapsed 468 ms. The provider currently awaits embedding before entering the assembler, so these
stages are serialized; rank 17 can use this scenario to prove they overlap. These hermetic figures
validate stimulus/orchestration only and are not deployment-performance claims.

Self-review tightened plan compliance: the first implementation passed the scenario but injected the
source directly. The final implementation registers the source in the hermetic service graph, keeps
GraphRAG disabled in the shared profile, and enables it only in `PERF-R-08`'s isolated production
assembler. The final combined baseline proves no cross-scenario contamination.

## Verification

- Red-first catalog tests: 2 expected failures before `PERF-R-08` existed; pass after implementation.
- Final-code fresh-container determinism: 2/2 exact.
- Combined six-scenario five-iteration baseline: exact, quality 1.000, `perf gate` PASS.
- Unit: 3,425 passed.
- Release solution build: 0 warnings, 0 errors.
- Integration: 311 passed; the known 29 NAMS failures remain due to the deprovisioned workspace.
