### PR TITLE
perf(M-17): measure whole-session extraction

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -115,6 +115,10 @@ dotnet run --project tools/AgentMemory.Cli -- perf --label degraded \
 dotnet run --project tools/AgentMemory.Cli -- perf --label graphrag \
   --scenarios PERF-R-08 --iterations 3
 
+# Measures one whole-session extraction over 50 pre-seeded messages
+dotnet run --project tools/AgentMemory.Cli -- perf --label session-extraction \
+  --scenarios PERF-W-05 --iterations 3
+
 # Compare two in-process recall configurations, with quality in the same report
 dotnet run --project tools/AgentMemory.Cli -- perf ab \
   --control default \
@@ -149,8 +153,8 @@ as independent. `--iterations` must therefore be a multiple of six and at least 
 The initial configuration grammar accepts `default` plus `Recall.Max*` and
 `Recall.MinSimilarityScore` assignments. `PERF-R-04` measures a full default recall, while
 `PERF-R-01` is a greeting-only control that locks the work performed by the shipped default recall
-policy. State-mutating scenarios such as `PERF-W-02` and `PERF-W-03` are rejected because shared write
-state would invalidate paired-sample independence.
+policy. State-mutating scenarios `PERF-W-02`, `PERF-W-03`, and `PERF-W-05` are rejected because their
+writes would invalidate paired-sample independence.
 
 The rendered markdown reports exact counter ranges, retrieval and extraction quality, and the
 candidate/control bootstrap interval together. Only `iteration total` is the pre-registered timing
@@ -167,8 +171,11 @@ retrieve fewer items than the configured limits; the degraded scenario additiona
 its embedding and database waits occurred inside recorded stage spans. The GraphRAG scenario requires
 its source call, two known items, configured wait, stage span, and rendered marker text while preserving
 the complete memory result. The greeting scenario locks its current default-policy item shape, while
-both ingestion scenarios verify message persistence and extraction outcomes. Those failures are
-otherwise silent and would produce a confident, wrong number.
+the per-turn ingestion scenarios verify message persistence and extraction outcomes. Whole-session
+extraction additionally requires exactly 50 source messages and reads the graph back after the measured
+turn to prove that two entities, two facts, one preference, and 250 provenance relationships were
+actually stored. Fixture setup and graph verification are outside the measured scope. Those failures
+are otherwise silent and would produce a confident, wrong number.
 
 ### Pull-request regression gate
 

--- a/docs/performance/baseline-1.3.0.md
+++ b/docs/performance/baseline-1.3.0.md
@@ -133,6 +133,39 @@ growth similarly consists of four message-persistence queries per additional mes
 provenance queries: **(5 × 4) + 25 = 45**. This control makes true batch response-message persistence
 measurable while also exposing the separate provenance fan-out it will not remove.
 
+### Whole-session extraction control
+
+`PERF-W-05` bulk-seeds 50 messages outside the measured scope, then measures the production
+`ExtractFromSessionAsync` path once. A post-turn raw-driver check, also outside the measured scope,
+proves that the graph contains every input and learned item:
+
+| Counter | Whole-session extraction (`W-05`) |
+|---|---:|
+| Source messages read | **50** |
+| Model completions | **4** |
+| Model input / output tokens | **7,774 / 668** |
+| Embedding requests | **7** |
+| Neo4j read / write transactions | **5 / 257** |
+| Neo4j queries | **278** |
+| Persisted entities / facts / preferences | **2 / 2 / 1** |
+| Provenance relationships found by graph read-back | **250** |
+
+Two fresh-container runs produced the same exact counters; both judged quality fixtures remained at
+1.000 with zero forbidden retrievals and zero false positives.
+
+The four model calls are one per extractor category regardless of transcript length. They lock the
+session-end side of matrix rank 8's comparison: extracting every one of 20 turns separately costs
+80 completions today, while one final session extraction costs four, a predicted **95% reduction**.
+That reduction is the target of the later optimization, not a product improvement shipped by this
+measurement scenario; extracted-item count and judged quality remain mandatory guards.
+
+The 257 writes expose a separate current cost. The five learned memories each link to all 50 source
+messages, producing 250 per-message provenance transactions in addition to seven entity-resolution
+and memory-upsert writes. Repository upserts also issue their own bulk provenance queries, so the
+resulting graph has 250 unique `EXTRACTED_FROM` relationships while the measured path executes 278
+Cypher queries. This fan-out is now visible for a later batching optimization; it is not hidden from
+the baseline.
+
 ### How these scale
 
 Worth knowing before you tune anything:

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -101,6 +101,7 @@
         "embed.items": 4,
         "embed.requests": 4,
         "extract.candidate_entities": 2,
+        "extract.source_messages": 2,
         "llm.calls": 4,
         "llm.tokens_in": 947,
         "llm.tokens_out": 668,
@@ -120,6 +121,7 @@
         "embed.items": 9,
         "embed.requests": 9,
         "extract.candidate_entities": 2,
+        "extract.source_messages": 7,
         "llm.calls": 4,
         "llm.tokens_in": 1170,
         "llm.tokens_out": 668,
@@ -131,6 +133,25 @@
         "persist.preferences": 1,
         "persist.relationships": 0,
         "store.messages": 6
+      }
+    },
+    "PERF-W-05": {
+      "counters": {
+        "embed.chars": 159,
+        "embed.items": 7,
+        "embed.requests": 7,
+        "extract.candidate_entities": 2,
+        "extract.source_messages": 50,
+        "llm.calls": 4,
+        "llm.tokens_in": 7774,
+        "llm.tokens_out": 668,
+        "neo4j.queries": 278,
+        "neo4j.tx.read": 5,
+        "neo4j.tx.write": 257,
+        "persist.entities": 2,
+        "persist.facts": 2,
+        "persist.preferences": 1,
+        "persist.relationships": 0
       }
     }
   },

--- a/src/AgentMemory.Core/Extraction/ExtractionStage.cs
+++ b/src/AgentMemory.Core/Extraction/ExtractionStage.cs
@@ -111,6 +111,7 @@ internal sealed class ExtractionStage : IExtractionStage
         // concurrent extractor categories above its cost grows linearly with entity count.
         using var resolutionActivity = AgentMemoryDiagnostics.Source.StartActivity("memory.extract.resolution");
         resolutionActivity?.SetTag("memory.extract.candidate_entities", rawEntities.Count);
+        resolutionActivity?.SetTag("memory.extract.source_messages", sourceMessageIds.Count);
 
         var resolvedEntityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase);
         foreach (var extracted in rawEntities)

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -84,4 +84,26 @@ public sealed class PerfScenarioCatalogTests
         selected.Should().ContainSingle();
         selected[0].Id.Should().Be("PERF-R-08");
     }
+
+    [Fact]
+    public void Catalog_ContainsWholeSessionExtractionScenario_WithStableContract()
+    {
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-W-05");
+
+        scenario.Description.Should().ContainEquivalentOf("session");
+        scenario.Description.Should().Contain("50");
+        scenario.SupportsInterleavedAb.Should().BeFalse(
+            "the scenario persists extracted memories and cannot share mutable state between A/B arms");
+        scenario.SetupAsync.Should().NotBeNull(
+            "the 50 source messages must be seeded outside the measured turn");
+    }
+
+    [Fact]
+    public void Select_WholeSessionExtractionScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-W-05");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-W-05");
+    }
 }

--- a/tools/AgentMemory.Cli/Commands/PerfAbCommand.cs
+++ b/tools/AgentMemory.Cli/Commands/PerfAbCommand.cs
@@ -291,17 +291,32 @@ public sealed class PerfAbCommand
         ICollection<AbSample> samples,
         CancellationToken cancellationToken)
     {
-        using var turn = collector.BeginTurn($"{scenario.Id}/{variant}", iteration, phase);
-        await scenario.ExecuteAsync(new ScenarioContext(
+        var datasetVariant = DatasetVariantFor(variant, iteration);
+        await scenario.PrepareAsync(new ScenarioSetupContext(
             profile,
-            provider,
-            turn.Record,
             iteration,
             phase,
-            DatasetVariantFor(variant, iteration),
-            configuration.Recall,
+            datasetVariant,
             cancellationToken)).ConfigureAwait(false);
-        samples.Add(new AbSample(scenario.Id, variant, turn.Record));
+
+        TurnRecord record;
+        using (var turn = collector.BeginTurn($"{scenario.Id}/{variant}", iteration, phase))
+        {
+            record = turn.Record;
+            await scenario.ExecuteAsync(new ScenarioContext(
+                profile,
+                provider,
+                record,
+                iteration,
+                phase,
+                datasetVariant,
+                configuration.Recall,
+                cancellationToken)).ConfigureAwait(false);
+        }
+
+        await scenario.ValidateAsync(new ScenarioVerificationContext(
+            profile, record, iteration, phase, datasetVariant, cancellationToken)).ConfigureAwait(false);
+        samples.Add(new AbSample(scenario.Id, variant, record));
     }
 
     internal static string DatasetVariantFor(string configurationVariant, int iteration) =>

--- a/tools/AgentMemory.Cli/Commands/PerfCommand.cs
+++ b/tools/AgentMemory.Cli/Commands/PerfCommand.cs
@@ -175,19 +175,43 @@ public sealed class PerfCommand
         // percentile is one of the standard ways a benchmark misleads.
         for (var i = 0; i < warmup; i++)
         {
-            using var turn = collector.BeginTurn(scenario.Id, i, "warmup");
-            await scenario.ExecuteAsync(new ScenarioContext(
-                profile, provider, turn.Record, i, "warmup", null,
-                AgentMemory.Abstractions.Options.RecallOptions.Default, cancellationToken)).ConfigureAwait(false);
+            await RunIterationAsync(
+                scenario, profile, provider, collector, i, "warmup", cancellationToken).ConfigureAwait(false);
         }
 
         for (var i = 0; i < iterations; i++)
         {
-            using var turn = collector.BeginTurn(scenario.Id, i, "measure");
+            await RunIterationAsync(
+                scenario, profile, provider, collector, i, "measure", cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RunIterationAsync(
+        PerfScenario scenario,
+        HermeticProfile profile,
+        AgentMemory.AgentFramework.Neo4jMemoryContextProvider provider,
+        PerfCollector collector,
+        int iteration,
+        string phase,
+        CancellationToken cancellationToken)
+    {
+        await scenario.PrepareAsync(new ScenarioSetupContext(
+            profile, iteration, phase, null, cancellationToken)).ConfigureAwait(false);
+
+        TurnRecord record;
+        using (var turn = collector.BeginTurn(scenario.Id, iteration, phase))
+        {
+            record = turn.Record;
             await scenario.ExecuteAsync(new ScenarioContext(
-                profile, provider, turn.Record, i, "measure", null,
+                profile, provider, record, iteration, phase, null,
                 AgentMemory.Abstractions.Options.RecallOptions.Default, cancellationToken)).ConfigureAwait(false);
         }
+
+        // Verification is deliberately outside the measured turn. Scenarios may read their writes back
+        // to prove learning occurred; charging that harness-only query to the product path would corrupt
+        // both elapsed time and database counters.
+        await scenario.ValidateAsync(new ScenarioVerificationContext(
+            profile, record, iteration, phase, null, cancellationToken)).ConfigureAwait(false);
     }
 
     private static object BuildManifest(

--- a/tools/AgentMemory.Cli/Perf/PerfCollector.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfCollector.cs
@@ -121,6 +121,8 @@ public sealed class PerfCollector : IDisposable
             case "memory.extract.resolution":
                 if (activity.GetTagItem("memory.extract.candidate_entities") is int candidates)
                     turn.Add("extract.candidate_entities", candidates);
+                if (activity.GetTagItem("memory.extract.source_messages") is int sourceMessages)
+                    turn.Add("extract.source_messages", sourceMessages);
                 break;
 
             case "memory.persist.total":

--- a/tools/AgentMemory.Cli/Perf/PerfFixture.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfFixture.cs
@@ -2,6 +2,7 @@ using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Neo4j.Driver;
 
 namespace AgentMemory.Cli.Perf;
 
@@ -212,6 +213,104 @@ public static class PerfFixture
         log.WriteLine(
             $"perf: seeded {identity.IdPrefix}: {EntityCount} entities, {FactCount} facts, " +
             $"{preferenceTexts.Length} preferences, {MessageCount} messages, {TraceCount} traces.");
+    }
+
+    /// <summary>
+    /// Seeds an iteration-isolated whole-session extraction fixture in one raw-driver transaction.
+    /// This runs before the measured turn: setup latency and setup database work are fixture cost, not
+    /// product extraction cost. The production session-read and extraction paths remain fully measured.
+    /// </summary>
+    public static async Task SeedSessionExtractionAsync(
+        HermeticProfile profile,
+        string sessionId,
+        string conversationId,
+        int messageCount,
+        CancellationToken cancellationToken)
+    {
+        var startedAt = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var messages = Enumerable.Range(0, messageCount)
+            .Select(index => new Dictionary<string, object?>
+            {
+                ["id"] = $"{sessionId}-msg-{index:D2}",
+                ["session_id"] = sessionId,
+                ["conversation_id"] = conversationId,
+                ["role"] = index % 2 == 0 ? "user" : "assistant",
+                ["content"] = index == 0
+                    ? PerfScenarios.StoreProbeUserMessage
+                    : $"Session extraction fixture message {index:D2}: Alice Martin works on the " +
+                      "Acme Corporation platform team and prefers concise written updates.",
+                ["timestamp"] = startedAt.AddSeconds(index).ToString("O"),
+                ["tool_call_ids"] = Array.Empty<string>(),
+                ["metadata"] = "{}",
+            })
+            .ToList();
+
+        const string cypher = """
+            UNWIND $messages AS item
+            MERGE (m:Message {id: item.id})
+            SET m.session_id = item.session_id,
+                m.conversation_id = item.conversation_id,
+                m.role = item.role,
+                m.content = item.content,
+                m.timestamp = item.timestamp,
+                m.tool_call_ids = item.tool_call_ids,
+                m.metadata = item.metadata
+            RETURN count(m) AS seeded
+            """;
+
+        await using var session = profile.Driver.AsyncSession();
+        var seeded = await session.ExecuteWriteAsync(async transaction =>
+        {
+            var cursor = await transaction.RunAsync(cypher, new { messages }).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
+            return record["seeded"].As<long>();
+        }).ConfigureAwait(false);
+
+        if (seeded != messageCount)
+        {
+            throw new InvalidOperationException(
+                $"Session extraction setup seeded {seeded} messages but expected {messageCount}.");
+        }
+    }
+
+    public sealed record SessionExtractionShape(
+        long Messages,
+        long Entities,
+        long Facts,
+        long Preferences,
+        long ProvenanceRelationships);
+
+    /// <summary>
+    /// Reads the graph after the measured turn to prove extraction actually learned the expected items.
+    /// Raw-driver verification is intentional: it runs outside the turn and must not inflate product cost.
+    /// </summary>
+    public static async Task<SessionExtractionShape> InspectSessionExtractionAsync(
+        HermeticProfile profile,
+        string sessionId,
+        string ownerId)
+    {
+        const string cypher = """
+            CALL { MATCH (m:Message {session_id: $sessionId}) RETURN count(m) AS messages }
+            CALL { MATCH (e:Entity {owner_id: $ownerId}) RETURN count(e) AS entities }
+            CALL { MATCH (f:Fact {owner_id: $ownerId}) RETURN count(f) AS facts }
+            CALL { MATCH (p:Preference {owner_id: $ownerId}) RETURN count(p) AS preferences }
+            CALL {
+                MATCH (memory)-[:EXTRACTED_FROM]->(m:Message {session_id: $sessionId})
+                WHERE memory.owner_id = $ownerId
+                RETURN count(*) AS provenance
+            }
+            RETURN messages, entities, facts, preferences, provenance
+            """;
+
+        await using var session = profile.Driver.AsyncSession();
+        var cursor = await session.RunAsync(cypher, new { sessionId, ownerId }).ConfigureAwait(false);
+        var record = await cursor.SingleAsync().ConfigureAwait(false);
+        return new SessionExtractionShape(
+            record["messages"].As<long>(),
+            record["entities"].As<long>(),
+            record["facts"].As<long>(),
+            record["preferences"].As<long>(),
+            record["provenance"].As<long>());
     }
 
     public sealed record ExpectedRecallShape(IReadOnlyDictionary<string, int> ByCategory, int Total);

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -21,7 +21,9 @@ public sealed record PerfScenario(
     string Description,
     Func<ScenarioContext, Task> RunAsync,
     bool SupportsInterleavedAb = true,
-    PerfDependencyLatencyPreset? DependencyLatency = null)
+    PerfDependencyLatencyPreset? DependencyLatency = null,
+    Func<ScenarioSetupContext, Task>? SetupAsync = null,
+    Func<ScenarioVerificationContext, Task>? VerifyAsync = null)
 {
     public async Task ExecuteAsync(ScenarioContext context)
     {
@@ -30,7 +32,20 @@ public sealed record PerfScenario(
             : context.Profile.DependencyLatency.Push(DependencyLatency);
         await RunAsync(context).ConfigureAwait(false);
     }
+
+    public Task PrepareAsync(ScenarioSetupContext context) =>
+        SetupAsync?.Invoke(context) ?? Task.CompletedTask;
+
+    public Task ValidateAsync(ScenarioVerificationContext context) =>
+        VerifyAsync?.Invoke(context) ?? Task.CompletedTask;
 }
+
+public sealed record ScenarioSetupContext(
+    HermeticProfile Profile,
+    int Iteration,
+    string Phase,
+    string? Variant,
+    CancellationToken CancellationToken);
 
 /// <summary>Everything a scenario body needs for one iteration.</summary>
 /// <param name="Phase">
@@ -45,6 +60,14 @@ public sealed record ScenarioContext(
     string Phase,
     string? Variant,
     RecallOptions RecallOptions,
+    CancellationToken CancellationToken);
+
+public sealed record ScenarioVerificationContext(
+    HermeticProfile Profile,
+    TurnRecord Turn,
+    int Iteration,
+    string Phase,
+    string? Variant,
     CancellationToken CancellationToken);
 
 /// <summary>
@@ -80,10 +103,19 @@ public static class PerfScenarios
             "Six-message tool-heavy response turn, extraction enabled",
             StoreToolHeavyAndExtractAsync,
             SupportsInterleavedAb: false),
+        new(
+            "PERF-W-05",
+            "Whole-session extraction over 50 pre-seeded messages",
+            ExtractWholeSessionAsync,
+            SupportsInterleavedAb: false,
+            SetupAsync: PrepareWholeSessionAsync,
+            VerifyAsync: VerifyWholeSessionAsync),
     ];
 
-    private const string StoreProbeUserMessage =
+    internal const string StoreProbeUserMessage =
         "Alice Martin just moved to the Acme Corporation platform team and prefers concise updates.";
+
+    private const int SessionExtractionMessageCount = 50;
 
     /// <summary>
     /// Input-keyed model responses required by cost scenarios. Kept separate from judged fixture rules:
@@ -379,6 +411,75 @@ public static class PerfScenarios
 
         AssertScriptedExtraction(ctx, "PERF-W-03");
     }
+
+    /// <summary>
+    /// PERF-W-05 — reads one complete 50-message session and extracts once. Together with the existing
+    /// per-turn control, this is the baseline rank 8 needs to grade deferred/windowed extraction.
+    /// </summary>
+    private static async Task ExtractWholeSessionAsync(ScenarioContext ctx)
+    {
+        var sessionId = SessionExtractionSessionId(ctx.Phase, ctx.Iteration);
+        var ownerId = SessionExtractionOwnerId(ctx.Phase, ctx.Iteration);
+        var memory = ctx.Profile.Services.GetRequiredService<IMemoryService>();
+
+        await memory.ExtractFromSessionAsync(sessionId, ownerId, ctx.CancellationToken).ConfigureAwait(false);
+
+        var sourceMessages = ctx.Turn.Counter("extract.source_messages");
+        var modelCalls = ctx.Turn.Counter("llm.calls");
+        var entities = ctx.Turn.Counter("persist.entities");
+        var facts = ctx.Turn.Counter("persist.facts");
+        var preferences = ctx.Turn.Counter("persist.preferences");
+        if (sourceMessages != SessionExtractionMessageCount || modelCalls != 4 ||
+            entities != 2 || facts != 2 || preferences != 1)
+        {
+            throw new InvalidOperationException(
+                $"PERF-W-05 did not exercise whole-session extraction " +
+                $"(extract.source_messages={sourceMessages}/{SessionExtractionMessageCount}, " +
+                $"llm.calls={modelCalls}/4, persist entities/facts/preferences=" +
+                $"{entities}/{facts}/{preferences}, expected 2/2/1). A capped or empty session, " +
+                "missing extractor, or empty scripted response would make rank 8's baseline invalid.");
+        }
+    }
+
+    private static Task PrepareWholeSessionAsync(ScenarioSetupContext ctx)
+    {
+        var sessionId = SessionExtractionSessionId(ctx.Phase, ctx.Iteration);
+        return PerfFixture.SeedSessionExtractionAsync(
+            ctx.Profile,
+            sessionId,
+            $"{sessionId}-conv",
+            SessionExtractionMessageCount,
+            ctx.CancellationToken);
+    }
+
+    private static async Task VerifyWholeSessionAsync(ScenarioVerificationContext ctx)
+    {
+        var sessionId = SessionExtractionSessionId(ctx.Phase, ctx.Iteration);
+        var shape = await PerfFixture.InspectSessionExtractionAsync(
+            ctx.Profile,
+            sessionId,
+            SessionExtractionOwnerId(ctx.Phase, ctx.Iteration)).ConfigureAwait(false);
+
+        const int expectedMemories = 5;
+        var expectedProvenance = expectedMemories * SessionExtractionMessageCount;
+        if (shape.Messages != SessionExtractionMessageCount ||
+            shape.Entities != 2 || shape.Facts != 2 || shape.Preferences != 1 ||
+            shape.ProvenanceRelationships != expectedProvenance)
+        {
+            throw new InvalidOperationException(
+                $"PERF-W-05 graph read-back failed (messages={shape.Messages}/" +
+                $"{SessionExtractionMessageCount}, entities/facts/preferences=" +
+                $"{shape.Entities}/{shape.Facts}/{shape.Preferences}, expected 2/2/1; " +
+                $"provenance={shape.ProvenanceRelationships}/{expectedProvenance}). Counters alone " +
+                "cannot prove that the extracted memories were actually learned.");
+        }
+    }
+
+    private static string SessionExtractionSessionId(string phase, int iteration) =>
+        $"perf-w05-{phase}-{iteration}";
+
+    private static string SessionExtractionOwnerId(string phase, int iteration) =>
+        $"{SessionExtractionSessionId(phase, iteration)}-owner";
 
     private static void AssertScriptedExtraction(ScenarioContext ctx, string scenarioId)
     {


### PR DESCRIPTION
## Scope

Add the final Phase C measurement scenario, `PERF-W-05`, for whole-session extraction over exactly 50 pre-seeded messages. Fixture setup and graph verification run outside the measured turn. This is harness work only; it does not change product extraction behavior.

## Preregistered prediction (written before implementation)

Primary metric:

- `llm.calls`: exactly **4** for one whole-session extraction, one call for each currently registered extractor category.
- Matrix rank 8 uses this control beside the existing per-turn ingestion control: 20 separately extracted turns cost 80 calls today; one session-end extraction costs 4, a predicted **95% reduction**, before considering quality.

Guard metrics:

- `extract.source_messages`: exactly **50**, proving the uncapped session path saw the complete fixture.
- `persist.entities / facts / preferences`: exactly **2 / 2 / 1**, proving extraction and persistence did not become a no-op.
- retrieval and extraction quality: unchanged at the committed **1.000** metrics and zero false positives.

Predicted structural diagnostics for an owner- and iteration-isolated session:

- `neo4j.tx.read`: **5**
- `neo4j.tx.write`: **257**
- `neo4j.queries`: **278**
- `embed.requests`: **7**

The large write count is expected current behavior, not a regression to hide: five extracted memories each receive provenance for all 50 source messages, and the repositories currently write both bulk and per-message provenance. M-17 is intended to expose that fan-out for later optimization.

## Verified result

The preregistered M-17 values matched exactly in two fresh-container zero-latency runs and one remote-shaped run:

- 50 source messages; 4 model calls; 2 entities / 2 facts / 1 preference.
- 5 Neo4j reads; 257 writes; 278 queries; 7 embedding requests.
- Graph read-back found all five learned memories and exactly 250 unique provenance relationships.
- Retrieval Recall@K / MRR and all extraction precision/recall metrics remained 1.000; forbidden retrievals and false positives remained zero.

Review also corrected the newly added W-02/W-03 source-message baseline entries to 2/7 (request plus 1/6 responses) before commit. No existing transaction, query, embedding, model, item, or quality counter changed.

## Local verification

- New catalog tests failed against the unfixed type (`PerfScenario.SetupAsync` absent), then passed after implementation.
- Unit: 3,427 passed.
- Release solution build: 0 warnings, 0 errors.
- Integration: 311 passed; the same known 29 NAMS tests failed because the workspace is deprovisioned.
- Combined seven-scenario zero profile: quality PASS and `perf gate: PASS`.
- Remote-shaped M-17 profile: exact structural counters and quality PASS.

Perf counter change justification: M-17 intentionally adds a new independently gated scenario whose higher counters measure whole-session extraction; existing scenario baselines remain unchanged.
