### PR TITLE
Release 1.4.1 — remove the starvation ceiling shipped in 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-08-11
+
+### Fixed
+
+- **The 1.4.0 starvation fix had a ceiling, and a multi-tenant deployment would have hit it.** 1.4.0
+  gave owner-scoped entity, preference and reasoning-trace searches a retry at a wider top-K when the
+  first pass returned nothing. That retry is bounded: it multiplies the width by 8 and caps at 2,000
+  candidates. **Once more than ~2,000 rows belonging to other owners outrank yours, no amount of
+  widening reaches them**, and the search returns nothing again.
+
+  Measured on a 50-owner index, an owner holding 4 facts and asking for 10:
+
+  | competing rows | 1.4.0 | 1.4.1 |
+  |---|---|---|
+  | 500 | 4 of 4 | 4 of 4 |
+  | 3,000 | 4 of 4 | 4 of 4 |
+  | **4,000** | **0 of 4** | **4 of 4** |
+  | 8,000 | 0 of 4 | 4 of 4 |
+
+  Fixed by adding a final owner-scoped similarity scan, reached **only** when the indexed search and
+  its widened retry have both returned nothing. It scores your own rows with
+  `vector.similarity.cosine` — a scan, deliberately, but one **bounded by a single owner's data rather
+  than by the corpus**, in the case whose alternative is returning nothing at all. Raising the cap
+  instead would have moved the ceiling without removing it, and made every rescued query read more of
+  other tenants' data.
+
+  Applies to facts, entities, preferences and reasoning traces. The `as-of` variants are unchanged.
+  A reasoning-trace search carries its `successFilter` into the fallback, so a filtered search that
+  genuinely matches nothing still returns nothing rather than being rescued into a wrong answer.
+
 ## [1.4.0] - 2026-08-11
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
        and never leaks into non-published projects. Per-package Description/PackageTags live in each
        .csproj. NuGet package IDs default to the (already de-Neo4j-renamed) project names. -->
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('AgentMemory')) and !$(MSBuildProjectName.Contains('.Tests')) and !$(MSBuildProjectName.Contains('.Sample'))">
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <Authors>Jose Luis Latorre Millas</Authors>
     <Company>Jose Luis Latorre Millas</Company>
     <Product>AgentMemory for .NET</Product>


### PR DESCRIPTION
## What this is

The version bump and release notes for **1.4.1**. The code changes are already on `main` (`601b0b6`, `21c1367`); this PR is the release itself.

## Why 1.4.1 exists

**1.4.0 shipped a fix that had a ceiling, and a multi-tenant deployment would have hit it.**

1.4.0 gave owner-scoped entity, preference and reasoning-trace searches a retry at a wider top-K when the first pass returned nothing. That retry is **bounded** — it multiplies the width by 8 and caps at 2,000 candidates. Once more than ~2,000 rows belonging to *other* owners outrank yours, no amount of widening reaches them and the search returns nothing again.

The measured production corpus holds **36,489 facts**, so this is squarely in the failing regime.

## Measured

Owner holding 4 facts, asking for 10, on a 50-owner index:

| competing rows | 1.4.0 | 1.4.1 |
|---|---|---|
| 500 | 4 of 4 | 4 of 4 |
| 3,000 | 4 of 4 | 4 of 4 |
| **4,000** | **0 of 4** | **4 of 4** |
| 8,000 | 0 of 4 | 4 of 4 |

Verified live across all four vector paths:

```
ALL-PATHS[4000 foreign rows each]: fact=4 entity=4 preference=4 trace=4, of 4 each
```

## The fix, and why this shape

A final **owner-scoped similarity scan**, reached *only* when the indexed search **and** its widened retry have both returned nothing. It scores the owner's own rows with `vector.similarity.cosine`.

It is a scan, deliberately — but one **bounded by a single owner's data rather than by the corpus**, in the one case whose alternative is returning nothing at all.

**Raising the cap instead would have moved the ceiling without removing it**, and would have made every rescued query read more of other tenants' data.

## Scope

- Applies to facts, entities, preferences and reasoning traces
- `as-of` variants unchanged — they issue one query and keep the no-escalation invariant
- A reasoning-trace search carries its `successFilter` into the fallback, so a filtered search that genuinely matches nothing still returns nothing rather than being rescued into a wrong answer

## How this was found

By **sweeping** the 1.4.0 fix across growing competition rather than re-checking it at the scale that motivated it. The ceiling was invisible at the scale where the original bug was found.

## Verification

- 4,307 unit tests green (3,990 core + 260 LongMemEval + 54 SK + 3 perf)
- Integration green with **zero non-NAMS failures** — the 29 NAMS failures are a deprovisioned external workspace no code here touches
- Solution builds 0 warnings
- Query-count guards updated deliberately: three queries now (indexed → widened → scoped scan). The count is still the guard, bounded at three, so a retry cannot silently become a loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE

---

Perf counter change justification: an owner-scoped vector search that returns ZERO now issues two additional queries — a widened index retry, then a similarity scan bounded by that owner's own rows. Measured `neo4j.queries 7 -> 13` and `neo4j.tx.read 6 -> 12` on the hermetic zero profile, whose database is empty so every scoped search takes that path. The extra work occurs ONLY when a scoped search has already come back empty, which is either an owner that genuinely holds nothing (two cheap queries returning no rows) or an owner starved by other tenants' data (the case this release exists to fix — previously it returned nothing at all, measured 0 of 4 against 4,000 competitors). I deliberately did NOT drop the widened index retry to lower this count: it reads ~480 indexed rows where the scan reads all of a large owner's rows, so removing it would improve this gate's number while making production worse for exactly the tenants it is meant to protect.

Note on provenance: this increase is already present on `main` — the same failure appears on unrelated dependabot PRs (`7 -> 13`, `6 -> 12`). The escalation work reached `main` through direct commits rather than a pull request, so this gate never evaluated it. This PR is the first to surface it.
