### PR TITLE
Post-1.4.1: recall cost, query deadlines, retrieval diagnostics, and telemetry privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Recall misses are now observable.** `memory.recall.section.empty` and
+  `memory.recall.section.short`, tagged by category. A `:MemoryReadAudit` row is created *inside*
+  `MATCH (n {id: $id})`, so a row existed only for a **hit** — there was no record anywhere that an
+  owner asked and memory had nothing. `…section.short` exposes the owner-starvation shape, which the
+  escalation path cannot see because it fires only on a *total* zero.
+
+  Counters rather than stored nodes: a node per miss grows without bound on exactly the workload that
+  produces the most misses. Requires `RecallOptions.IncludeDiagnostics`; without it nothing is emitted
+  rather than a guess, because "empty" and "never searched" are different questions.
+
 - **A tenant identifier no longer reaches telemetry by default.** `InstrumentedMemoryService` emitted
   `memory.user_id` unconditionally — while every owner-scoped vector search in the codebase already
   tags a **boolean** (`memory.vector.owner_scoped`) rather than the value. A trace backend is usually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`memory_start_trace` now accepts a `userId` and scopes the trace to it.** It passed no owner at
+  all, so an MCP-started trace was written to the shared/global bucket — while trace *recall* goes
+  through the ambient owner context. A trace written by one tenant could therefore be invisible to
+  that same tenant and visible to every other one. Additive parameter; omitting it behaves as before.
+
 - **A reasoning trace with no recorded outcome is no longer shown to the model as a failure.**
   `ReasoningTrace.Success` is `bool?` and null means *unrecorded* — and null was the common case,
   because `AgentTraceRecorder` had no success parameter at all until recently. `find_similar_tasks`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A reasoning trace with no recorded outcome is no longer shown to the model as a failure.**
+  `ReasoningTrace.Success` is `bool?` and null means *unrecorded* — and null was the common case,
+  because `AgentTraceRecorder` had no success parameter at all until recently. `find_similar_tasks`
+  rendered `Success == true ? "✓" : "✗"`, so every MAF-recorded trace appeared as a **failed**
+  precedent. Now renders three states. A wrong precedent is acted on; an absent one is investigated.
+
 - **The query embedding is no longer generated when nothing will read it.** Every vector search is
   gated on its own `MaxX > 0`; the embedding was not, so a policy that narrowed a turn still paid for a
   provider round trip whose result nothing consumed. Remote-shaped that is the single largest stage of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -31,6 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```csharp
   services.AddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
   ```
+
+- **An empty recall section can now say why it is empty.** `MemoryContextSection<T>.Diagnostics`
+  (null unless `RecallOptions.IncludeDiagnostics` is set) records whether the section was actually
+  searched, the limit it asked for, how many items came back, the top and lowest scores, and the
+  similarity floor in force.
+
+  Three causes needed opposite responses and looked identical from outside: the section was never
+  searched, the store genuinely holds nothing, or candidates existed and were filtered away — by the
+  floor, or by an owner post-filter applied after the vector index picked a global top-K. `Searched`
+  separates the first; `SearchedAndShort` exposes the third, which is otherwise invisible because the
+  starvation escalation fires only on a *total* zero.
+
+  An unscoreable section reports `null` scores rather than zero — zero is a real score.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A tenant identifier no longer reaches telemetry by default.** `InstrumentedMemoryService` emitted
+  `memory.user_id` unconditionally — while every owner-scoped vector search in the codebase already
+  tags a **boolean** (`memory.vector.owner_scoped`) rather than the value. A trace backend is usually
+  less access-controlled than the database the value came from, retained differently, and often
+  exported to a third party.
+
+  Spans now carry `memory.owner_scoped` (bool), so the operational question — *was this scoped?* — is
+  still answerable. Hosts that correlate traces by user opt back in:
+
+  ```csharp
+  services.AddAgentMemoryObservability(o => o.IncludeOwnerIdInTelemetry = true);
+  ```
+
+  The recall span also gains the owner dimension, which it never had.
+
 - **`memory_start_trace` now accepts a `userId` and scopes the trace to it.** It passed no owner at
   all, so an MCP-started trace was written to the shared/global bucket — while trace *recall* goes
   through the ambient owner context. A trace written by one tenant could therefore be invisible to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **A greeting no longer costs a full recall.** Measured on the hermetic `PERF-R-01` scenario — a
+  greeting-only turn at shipped defaults — recall issued **13 Cypher queries and 12 read transactions,
+  plus an embedding round trip, to retrieve 11 items**. Ten of those were recent messages, which need
+  no vector at all. The 1.4.0/1.4.1 owner-starvation rescue made it worse rather than better: with no
+  entities, facts or traces to find, each of those three searches returns empty, escalates to a widened
+  index query, then falls back to an owner-bounded scan — **three queries each, all guaranteed to find
+  nothing, because there is nothing to find.**
+
+  The default `IAutomaticRecallPolicy` is now `TrivialTurnRecallPolicy`. On a turn that is nothing but
+  a greeting or acknowledgement it recalls **recent messages only**; on every other turn it is
+  byte-identical to the previous default.
+
+  It **narrows rather than skips** deliberately: dropping recall entirely would also drop recent
+  messages, and *"ok, go ahead"* is exactly the turn where an agent most needs the conversation so far
+  to know what it is agreeing to.
+
+  **What changes for you:** on a greeting-only turn you previously received whatever
+  entities/facts/preferences/traces matched; you now receive recent messages only. To restore the
+  previous behaviour, register the old policy explicitly:
+
+  ```csharp
+  services.AddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
+  ```
+
+### Fixed
+
+- **The query embedding is no longer generated when nothing will read it.** Every vector search is
+  gated on its own `MaxX > 0`; the embedding was not, so a policy that narrowed a turn still paid for a
+  provider round trip whose result nothing consumed. Remote-shaped that is the single largest stage of a
+  recall (~120 ms), which meant category narrowing **relocated** the cost rather than removing it.
+  Gated in `MemoryContextAssembler` (live *and* point-in-time paths, so the Semantic Kernel adapter, the
+  CLI and the facade all benefit) and in `Neo4jMemoryContextProvider`, which embeds before handing the
+  request over. **Byte-identical at every shipped default**, since no default excludes all five vector
+  categories.
+
 ## [1.4.1] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Live recall can now honour a fact's valid-time window** — `RecallOptions.ValidTime`
+  (`Ignore` by default, so nothing changes unless you ask).
+
+  `valid_from`/`valid_until` persist, are writable through the public API, and the point-in-time path
+  already filtered on them. **Live recall did not.** A fact valid from six months hence was returned
+  *today*, and a fact whose `valid_until` had passed was returned **forever**. The gap was harmless
+  until 1.4.0 shipped `TemporalValidityMode.Extract` — the writer it had been waiting for.
+
+  Gated on **both** live fact paths: the indexed vector query and 1.4.1's owner-scoped fallback.
+  Gating only the first would have left valid time bypassed for exactly the starved multi-tenant
+  owners that fallback exists to rescue.
+
+  Honouring it also delivers the first two mechanisms of prospective memory — *expression* and
+  *gating* — i.e. due-on-next-interaction semantics. Acting at a time with no query is a scheduler,
+  a different risk class, and deliberately not in scope.
+
 - **Recall misses are now observable.** `memory.recall.section.empty` and
   `memory.recall.section.short`, tagged by category. A `:MemoryReadAudit` row is created *inside*
   `MATCH (n {id: $id})`, so a row existed only for a **hit** — there was no record anywhere that an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Overview — Agent Memory for .NET
+﻿# Architecture Overview — Agent Memory for .NET
 
 **Last Updated:** 2026-07-17 (#92 Phase 8 + stabilization pass)
 **Author:** Jose Luis Latorre Millas
@@ -142,7 +142,7 @@ graph TD
 | **Purpose** | Domain contracts — all models, interfaces, and configuration types shared across the system |
 | **Dependencies** | **Microsoft.Extensions.AI.Abstractions** 10.8.0 (approved, D-AR2-1) — .NET BCL otherwise (multi-targets net8.0/net9.0/net10.0) |
 | **MUST NOT reference** | Neo4j.Driver, Microsoft.Agents.*, any GraphRAG SDK, any MCP SDK, any NuGet package **except** Microsoft.Extensions.AI.Abstractions |
-| **Key types** | 51 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, IngestionItemOutcome, MemoryContextRankedItem, UnifiedExtractionResult, etc.), 41 service interfaces (incl. `IMemoryIsolationPolicy`, `IUnifiedMemoryExtractor`, and `IMultiSessionUnifiedMemoryExtractor`), 11 repository interfaces, 16 configuration types (incl. `MemoryRankingOptions`, `MemoryIsolationOptions`), 26 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`, `MemoryNodeKind`, `MemoryOperationAccess`, `MemoryIsolationMode`, `IngestionStatus`, `IngestionStage`, `IngestionItemStatus`, `MemoryItemKind`, `IngestionFailureMode`, `MemoryTrustLevel`, `AssistantContentMode`, `TemporalValidityMode`) |
+| **Key types** | 52 domain records (Conversation, Message, Entity, Fact, Preference, Relationship, MemoryHistoryQuery, MemoryHistoryRecord, ReasoningTrace, ReasoningStep, ToolCall, ToolCallStats, IngestionItemOutcome, MemoryContextRankedItem, MemoryContextSectionDiagnostics, UnifiedExtractionResult, etc.), 41 service interfaces (incl. `IMemoryIsolationPolicy`, `IUnifiedMemoryExtractor`, and `IMultiSessionUnifiedMemoryExtractor`), 11 repository interfaces, 16 configuration types (incl. `MemoryRankingOptions`, `MemoryIsolationOptions`), 26 enums (incl. `MemoryProfile`, `RankingIntent`, `DuplicateStatus`, `EntityMatchType`, `MemoryNodeKind`, `MemoryOperationAccess`, `MemoryIsolationMode`, `IngestionStatus`, `IngestionStage`, `IngestionItemStatus`, `MemoryItemKind`, `IngestionFailureMode`, `MemoryTrustLevel`, `AssistantContentMode`, `TemporalValidityMode`) |
 
 **Namespace structure:**
 ```

--- a/eng/perf/baselines/hermetic-S.json
+++ b/eng/perf/baselines/hermetic-S.json
@@ -19,11 +19,30 @@
         "items.retrieved": 11,
         "items.traces": 0,
         "neo4j.bytes_est": 37476,
-        "neo4j.queries": 7,
+        "neo4j.queries": 13,
         "neo4j.records": 11,
-        "neo4j.tx.read": 6,
+        "neo4j.tx.read": 12,
         "neo4j.tx.write": 1,
         "recall.chars": 1261
+      }
+    },
+    "PERF-R-09": {
+      "counters": {
+        "access_tracking.items": 0,
+        "context.chars": 1627,
+        "context.messages": 11,
+        "items.entities": 0,
+        "items.facts": 0,
+        "items.preferences": 0,
+        "items.recent": 10,
+        "items.relevant": 0,
+        "items.retrieved": 10,
+        "items.traces": 0,
+        "neo4j.bytes_est": 34130,
+        "neo4j.queries": 1,
+        "neo4j.records": 10,
+        "neo4j.tx.read": 1,
+        "recall.chars": 1180
       }
     },
     "PERF-R-04": {

--- a/src/AgentMemory.Abstractions/Domain/Context/MemoryContextSection.cs
+++ b/src/AgentMemory.Abstractions/Domain/Context/MemoryContextSection.cs
@@ -1,4 +1,4 @@
-namespace AgentMemory.Abstractions.Domain;
+﻿namespace AgentMemory.Abstractions.Domain;
 
 /// <summary>
 /// Represents a section of memory context with items of a specific type.
@@ -17,6 +17,20 @@ public sealed record MemoryContextSection<T>
     /// </summary>
     public IReadOnlyList<MemoryContextRankedItem> RankedItems { get; init; } =
         Array.Empty<MemoryContextRankedItem>();
+
+    /// <summary>
+    /// Why this section holds what it holds. <see langword="null"/> unless the recall requested
+    /// diagnostics.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Items"/> being empty has at least three causes that need opposite responses, and
+    /// nothing recorded which one applied: the section was never searched, the owner genuinely holds
+    /// nothing, or candidates existed and every one fell below <c>MinSimilarityScore</c> — or, on an
+    /// owner-scoped vector search, survived the index's global top-K only to be filtered away. A
+    /// measured example: one benchmark question retrieved <b>2 facts from a 710-fact graph</b> with the
+    /// answer demonstrably present, and no artifact could say which of those it was.
+    /// </remarks>
+    public MemoryContextSectionDiagnostics? Diagnostics { get; init; }
 
     /// <summary>
     /// Section-level metadata (e.g., retrieval method, scores).
@@ -42,3 +56,45 @@ public sealed record MemoryContextRankedItem(
     double Score,
     int RetrievalRank,
     int ContextRank);
+
+/// <summary>
+/// Why a recall section holds what it holds.
+/// </summary>
+/// <param name="Searched">
+/// Whether a retrieval actually ran for this section. <see langword="false"/> means the section was
+/// excluded — by a task-aware recall policy, a zero limit, or a missing query embedding — and its
+/// emptiness says nothing about the store.
+/// </param>
+/// <param name="RequestedLimit">The limit the retrieval asked for, so a short result is visible as short.</param>
+/// <param name="Returned">How many items the retrieval returned, before context budgeting.</param>
+/// <param name="TopScore">
+/// Highest provider score among the returned items, or <see langword="null"/> when nothing was
+/// returned or the provider cannot supply scores. Never a placeholder: a section that cannot be
+/// scored reports null rather than zero, because zero is a real score.
+/// </param>
+/// <param name="LowestScore">Lowest returned score, or <see langword="null"/> under the same rules.</param>
+/// <param name="MinimumScore">The similarity floor in force, so "all below threshold" is checkable.</param>
+public sealed record MemoryContextSectionDiagnostics(
+    bool Searched,
+    int RequestedLimit,
+    int Returned,
+    double? TopScore,
+    double? LowestScore,
+    double MinimumScore)
+{
+    /// <summary>
+    /// The retrieval ran and came back with nothing — as opposed to never having run.
+    /// </summary>
+    public bool SearchedAndEmpty => Searched && Returned == 0;
+
+    /// <summary>
+    /// The retrieval ran and returned fewer items than it asked for.
+    /// </summary>
+    /// <remarks>
+    /// On an owner-scoped vector search this is the shape that matters most: the index picks a global
+    /// top-K and the owner filter is applied afterwards, so a short result can mean an owner was
+    /// crowded out by other tenants rather than that it holds little. The escalation path fires only
+    /// on a <i>total</i> zero, so this case is otherwise invisible.
+    /// </remarks>
+    public bool SearchedAndShort => Searched && Returned < RequestedLimit;
+}

--- a/src/AgentMemory.Abstractions/Options/RecallOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/RecallOptions.cs
@@ -1,4 +1,4 @@
-namespace AgentMemory.Abstractions.Options;
+﻿namespace AgentMemory.Abstractions.Options;
 
 /// <summary>
 /// Configuration for memory recall operations.
@@ -52,6 +52,16 @@ public sealed record RecallOptions
     /// and allocation profile.
     /// </summary>
     public bool IncludeDiagnostics { get; init; }
+
+    /// <summary>
+    /// Whether live recall honours a fact's valid-time window. Defaults to
+    /// <see cref="ValidTimeMode.Ignore"/> — today's behaviour.
+    /// </summary>
+    /// <remarks>
+    /// <c>MemoryProfile.Parity</c> must resolve to <see cref="ValidTimeMode.Ignore"/>: parity means
+    /// "ranks exactly like upstream Python", and upstream has no valid-time gate on its live path.
+    /// </remarks>
+    public ValidTimeMode ValidTime { get; init; } = ValidTimeMode.Ignore;
 
     /// <summary>Default singleton instance.</summary>
     public static RecallOptions Default { get; } = new();

--- a/src/AgentMemory.Abstractions/Options/ValidTimeMode.cs
+++ b/src/AgentMemory.Abstractions/Options/ValidTimeMode.cs
@@ -1,0 +1,40 @@
+﻿namespace AgentMemory.Abstractions.Options;
+
+/// <summary>
+/// Whether ordinary recall honours a fact's valid-time window (<c>valid_from</c>/<c>valid_until</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A fact's <c>ValidFrom</c>/<c>ValidUntil</c> persist, are writable through the public
+/// API, and the point-in-time recall path already filters on them. <b>Live recall does not</b>: it
+/// filters on similarity, <c>invalidated_at</c> and owner, and nothing else. So a fact valid from six
+/// months hence is returned by ordinary recall <i>today</i>, and a fact whose <c>valid_until</c> has
+/// passed is returned <b>forever</b>.
+/// </para>
+/// <para>
+/// <b>This stopped being harmless in 1.4.0.</b> The gap used to be inert because no extractor wrote
+/// validity bounds, so the clauses would have matched nothing. 1.4.0 shipped
+/// <c>TemporalValidityMode.Extract</c> — the writer the gap had been waiting for — which makes the
+/// defect reachable from configuration.
+/// </para>
+/// <para>
+/// Honouring it also happens to deliver prospective memory's first two mechanisms: <b>expression</b>
+/// (a schema that can say "this holds from T") and <b>gating</b> (a read path that respects it).
+/// <i>Firing</i> — acting at T with no query — is a scheduler, a different risk class, and explicitly
+/// not in scope here.
+/// </para>
+/// </remarks>
+public enum ValidTimeMode
+{
+    /// <summary>
+    /// Ignore valid time on live recall. Today's behaviour, and the default so no existing deployment
+    /// silently starts recalling less than it did.
+    /// </summary>
+    Ignore = 0,
+
+    /// <summary>
+    /// Return only facts whose valid-time window contains the present: <c>valid_from</c> is null or in
+    /// the past, and <c>valid_until</c> is null or in the future.
+    /// </summary>
+    Current = 1,
+}

--- a/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
@@ -1,4 +1,4 @@
-using AgentMemory.Abstractions.Domain;
+﻿using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 
 namespace AgentMemory.Abstractions.Repositories;
@@ -44,6 +44,26 @@ public interface IFactRepository
         double minScore = 0.0,
         MemoryScope? scope = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Searches facts by vector similarity, optionally restricted to facts valid <i>now</i>.
+    /// </summary>
+    /// <remarks>
+    /// A <b>default interface method</b> rather than a new parameter on the method above: the public
+    /// surface is locked under SemVer and this is the sanctioned way to extend it without breaking a
+    /// third-party implementer. The default body ignores <paramref name="validTime"/> and calls the
+    /// existing overload, which is exactly the behaviour every implementation has today — so a provider
+    /// that does not support valid time keeps working and simply does not filter, rather than silently
+    /// appearing to.
+    /// </remarks>
+    Task<IReadOnlyList<(Fact Fact, double Score)>> SearchByVectorAsync(
+        float[] queryEmbedding,
+        ValidTimeMode validTime,
+        int limit = 10,
+        double minScore = 0.0,
+        MemoryScope? scope = null,
+        CancellationToken cancellationToken = default) =>
+        SearchByVectorAsync(queryEmbedding, limit, minScore, scope, cancellationToken);
 
     /// <summary>
     /// Adds or updates a batch of facts atomically. Facts are merged by their {subject, predicate, object}

--- a/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
+++ b/src/AgentMemory.Abstractions/Services/ILongTermMemoryService.cs
@@ -1,4 +1,4 @@
-using AgentMemory.Abstractions.Domain;
+﻿using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 
 namespace AgentMemory.Abstractions.Services;
@@ -250,4 +250,23 @@ public interface ILongTermMemoryService
         SearchFactsAsync(
             queryEmbedding, limit, minScore, scope, expandByPredicate, expansionLimit,
             cancellationToken);
+
+
+    /// <summary>
+    /// Fact recall restricted to facts whose valid-time window contains the present.
+    /// </summary>
+    /// <remarks>
+    /// A third default interface method, for the same reason as the two above: the interface is locked
+    /// under SemVer and optional parameters would break every implementor. The default ignores
+    /// <paramref name="validTime"/>, which is what every implementation does today — a store that
+    /// cannot filter on valid time keeps working and simply does not filter, rather than appearing to.
+    /// </remarks>
+    Task<IReadOnlyList<Fact>> SearchFactsAsync(
+        float[] queryEmbedding,
+        ValidTimeMode validTime,
+        int limit,
+        double minScore,
+        MemoryScope? scope,
+        CancellationToken cancellationToken) =>
+        SearchFactsAsync(queryEmbedding, limit, minScore, scope, cancellationToken);
 }

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -61,7 +61,11 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
         _storeContext = storeContext;
         _ownerContext = ownerContext;
         _toolFactory = toolFactory;
-        _recallPolicy = recallPolicy ?? new ConfiguredAutomaticRecallPolicy();
+        // Must stay the same type AddAgentMemoryFramework registers. A constructor default that differs
+        // from the DI default gives one component two behaviours depending on how it was built, and the
+        // direct-construction path (tools, tests, hosts wiring by hand) is exactly where that divergence
+        // goes unnoticed -- it did here, until a perf run showed the counters had not moved.
+        _recallPolicy = recallPolicy ?? new TrivialTurnRecallPolicy();
         _admissionPolicy = admissionPolicy ?? new DefaultMemoryContextAdmissionPolicy();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }

--- a/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
+++ b/src/AgentMemory.AgentFramework/Neo4jMemoryContextProvider.cs
@@ -135,21 +135,33 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
 
             var effectiveOptions = ResolveEffectiveOptions(decision);
 
+            // Only embed if a retrieval that consumes the vector survived the policy's narrowing.
+            // A policy that excludes every vector category (e.g. "recent messages only" on a trivial
+            // turn) would otherwise still pay the largest single stage of a remote-shaped recall for a
+            // vector nothing reads. The assembler applies the same gate for its other callers; this one
+            // is needed because the provider embeds BEFORE handing the request over, so narrowing alone
+            // would relocate the call rather than remove it.
+            //
+            // Null is already the established "no embedding" value here — the catch below hands the
+            // assembler a null on failure and it degrades to recent messages — so this adds no new state.
             float[]? queryEmbedding = null;
-            try
+            if (RecallNeedsQueryEmbedding(effectiveOptions))
             {
-                using var embeddingSpan = AgentMemoryDiagnostics.Source.StartActivity("memory.recall.embedding");
-                queryEmbedding = await _embeddingOrchestrator
-                    .EmbedQueryAsync(queryText, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to generate query embedding; proceeding without semantic search.");
+                try
+                {
+                    using var embeddingSpan = AgentMemoryDiagnostics.Source.StartActivity("memory.recall.embedding");
+                    queryEmbedding = await _embeddingOrchestrator
+                        .EmbedQueryAsync(queryText, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to generate query embedding; proceeding without semantic search.");
+                }
             }
 
             var recallRequest = new RecallRequest
@@ -219,6 +231,23 @@ public sealed class Neo4jMemoryContextProvider : AIContextProvider
     /// cleared afterwards: scope must always be resolved from this invocation's authenticated userId (via
     /// #100's isolation policy), never from a statically configured or policy-supplied value.
     /// </summary>
+    /// <summary>
+    /// Whether any retrieval selected by <paramref name="options"/> consumes a query vector.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>MemoryContextAssembler</c>'s own gate on exactly the five categories whose searches
+    /// require an embedding. Recent messages are session-scoped and time-ordered; GraphRAG builds its
+    /// own retriever. Kept as a separate copy rather than shared because the two live in different
+    /// packages, and <c>MemoryContextAssembler</c>'s is <c>private</c> — the shared thing is the rule,
+    /// which is stated in both places and covered by tests on both sides.
+    /// </remarks>
+    private static bool RecallNeedsQueryEmbedding(RecallOptions options) =>
+        options.MaxRelevantMessages > 0
+        || options.MaxEntities > 0
+        || options.MaxPreferences > 0
+        || options.MaxFacts > 0
+        || options.MaxTraces > 0;
+
     private RecallOptions ResolveEffectiveOptions(AutomaticRecallDecision decision)
     {
         var effective = decision.RecallOptions ?? _recallOptions with

--- a/src/AgentMemory.AgentFramework/Recall/HeuristicAutomaticRecallPolicy.cs
+++ b/src/AgentMemory.AgentFramework/Recall/HeuristicAutomaticRecallPolicy.cs
@@ -28,14 +28,6 @@ public sealed class HeuristicAutomaticRecallPolicy : IAutomaticRecallPolicy
     private const AutomaticRecallCategories BaselineCategories =
         AutomaticRecallCategories.Default | AutomaticRecallCategories.GraphRag;
 
-    private static readonly HashSet<string> GreetingPhrases = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "hi", "hello", "hey", "thanks", "thank you", "ok", "okay", "sure", "got it",
-        "yes", "no", "yep", "nope", "sounds good", "great", "cool", "noted", "understood"
-    };
-
-    private static readonly char[] WordSeparators = { ' ', '\t', '\r', '\n', '.', ',', '!', '?' };
-
     private static readonly Regex RecencyOriented = new(
         @"\b(latest|current|most recent|right now|these days|nowadays)\b",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -67,7 +59,7 @@ public sealed class HeuristicAutomaticRecallPolicy : IAutomaticRecallPolicy
     {
         var query = string.Join(" ", context.Messages.Select(m => m.Text ?? string.Empty)).Trim();
 
-        if (string.IsNullOrWhiteSpace(query) || IsGreetingOrAcknowledgementOnly(query))
+        if (TrivialTurnDetector.IsGreetingOrAcknowledgementOnly(query))
             return ValueTask.FromResult(AutomaticRecallDecision.Skip);
 
         var categories = BaselineCategories;
@@ -97,34 +89,4 @@ public sealed class HeuristicAutomaticRecallPolicy : IAutomaticRecallPolicy
         });
     }
 
-    /// <summary>
-    /// Whether every word/short-phrase in <paramref name="text"/> is a greeting or acknowledgement, e.g.
-    /// "hi", "ok, got it.", "sounds good". Deliberately NOT regex-based: an earlier version used a single
-    /// repeating-group pattern (<c>^(\s*(hi|...)\s*)+$</c>) that exhibited catastrophic backtracking --
-    /// verified experimentally, a string of ~30 repeated short fragments blocked the calling thread for
-    /// multiple seconds. Plain tokenization is linear time and has no such failure mode.
-    /// </summary>
-    private static bool IsGreetingOrAcknowledgementOnly(string text)
-    {
-        var words = text.ToLowerInvariant().Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries);
-        if (words.Length == 0)
-            return true;
-
-        var i = 0;
-        while (i < words.Length)
-        {
-            if (i + 1 < words.Length && GreetingPhrases.Contains($"{words[i]} {words[i + 1]}"))
-            {
-                i += 2;
-                continue;
-            }
-
-            if (!GreetingPhrases.Contains(words[i]))
-                return false;
-
-            i++;
-        }
-
-        return true;
-    }
 }

--- a/src/AgentMemory.AgentFramework/Recall/TrivialTurnDetector.cs
+++ b/src/AgentMemory.AgentFramework/Recall/TrivialTurnDetector.cs
@@ -1,0 +1,59 @@
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// Whether a turn's user text is nothing but greetings and acknowledgements.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted so <see cref="HeuristicAutomaticRecallPolicy"/> and <see cref="TrivialTurnRecallPolicy"/>
+/// share one definition. Two policies disagreeing about what "trivial" means would be a silent
+/// behaviour difference between an opt-in policy and the default one.
+/// </para>
+/// <para>
+/// <b>Deliberately not regex-based.</b> An earlier version used a single repeating-group pattern
+/// (<c>^(\s*(hi|...)\s*)+$</c>) that exhibited catastrophic backtracking — verified experimentally, a
+/// string of ~30 repeated short fragments blocked the calling thread for multiple seconds. Plain
+/// tokenization is linear and has no such failure mode.
+/// </para>
+/// </remarks>
+internal static class TrivialTurnDetector
+{
+    private static readonly HashSet<string> GreetingPhrases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "hi", "hello", "hey", "thanks", "thank you", "ok", "okay", "sure", "got it",
+        "yes", "no", "yep", "nope", "sounds good", "great", "cool", "noted", "understood"
+    };
+
+    private static readonly char[] WordSeparators = { ' ', '\t', '\r', '\n', '.', ',', '!', '?' };
+
+    /// <summary>
+    /// True when <paramref name="text"/> is empty, whitespace, or composed entirely of greeting and
+    /// acknowledgement words/phrases — e.g. "hi", "ok, got it.", "sounds good".
+    /// </summary>
+    internal static bool IsGreetingOrAcknowledgementOnly(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return true;
+
+        var words = text.ToLowerInvariant().Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+            return true;
+
+        var i = 0;
+        while (i < words.Length)
+        {
+            if (i + 1 < words.Length && GreetingPhrases.Contains($"{words[i]} {words[i + 1]}"))
+            {
+                i += 2;
+                continue;
+            }
+
+            if (!GreetingPhrases.Contains(words[i]))
+                return false;
+
+            i++;
+        }
+
+        return true;
+    }
+}

--- a/src/AgentMemory.AgentFramework/Recall/TrivialTurnRecallPolicy.cs
+++ b/src/AgentMemory.AgentFramework/Recall/TrivialTurnRecallPolicy.cs
@@ -1,0 +1,60 @@
+namespace AgentMemory.AgentFramework.Recall;
+
+/// <summary>
+/// The default <see cref="IAutomaticRecallPolicy"/>: full configured recall on every real turn, and
+/// recent messages only on a turn that is nothing but a greeting or acknowledgement.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is the default.</b> Measured on the hermetic <c>PERF-R-01</c> scenario — a greeting-only
+/// turn at shipped defaults — recall issued <b>13 Cypher queries and 12 read transactions, plus an
+/// embedding round trip, to retrieve 11 items</b>. Ten of those items were recent messages, which need
+/// no vector at all; the eleventh was a single preference. The owner-starvation rescue added in 1.4.0
+/// and 1.4.1 makes it worse, not better: with no entities, facts or traces to find, each of those three
+/// searches returns empty, escalates to a widened index query, and then falls back to an owner-bounded
+/// scan — three queries each, all guaranteed to find nothing, because there is nothing to find.
+/// </para>
+/// <para>
+/// <b>Why it narrows rather than skips.</b> The obvious design — skip recall entirely on a trivial turn
+/// — also drops <c>RecentMessages</c>, and "ok, go ahead" is exactly the turn where the agent most needs
+/// the conversation so far to know what it is agreeing to. Narrowing keeps that context and still elides
+/// the embedding and every vector search, because <c>MemoryContextAssembler</c> and
+/// <c>Neo4jMemoryContextProvider</c> both gate the embedding on whether a category consuming it survived.
+/// <see cref="HeuristicAutomaticRecallPolicy"/> remains available for hosts that do want the full skip.
+/// </para>
+/// <para>
+/// <b>Behaviour change, stated plainly.</b> On a greeting-only turn a host previously received whatever
+/// entities/facts/preferences/traces matched; it now receives recent messages only. That is a deliberate
+/// trade — those items were retrieved for a turn carrying no question — and it is the only difference.
+/// Every other turn is byte-identical to <see cref="ConfiguredAutomaticRecallPolicy"/>. A host that wants
+/// the previous behaviour registers it explicitly after <c>AddAgentMemoryFramework</c>, which is the
+/// documented replacement seam:
+/// <c>services.AddScoped&lt;IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy&gt;()</c>.
+/// </para>
+/// <para>
+/// Deterministic and free: no model call, no regex backtracking, one linear pass over the turn's words.
+/// </para>
+/// </remarks>
+public sealed class TrivialTurnRecallPolicy : IAutomaticRecallPolicy
+{
+    /// <inheritdoc/>
+    public ValueTask<AutomaticRecallDecision> DecideAsync(
+        AutomaticRecallContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var query = string.Join(" ", context.Messages.Select(m => m.Text ?? string.Empty)).Trim();
+
+        if (!TrivialTurnDetector.IsGreetingOrAcknowledgementOnly(query))
+            return ValueTask.FromResult(AutomaticRecallDecision.Recall);
+
+        return ValueTask.FromResult(new AutomaticRecallDecision
+        {
+            // Recall still runs -- this is a narrowing, not a skip. RecentMessages is session-scoped and
+            // time-ordered, so it needs no query vector, and the embedding gate downstream elides the
+            // provider round trip precisely because no vector category survives here.
+            ShouldRecall = true,
+            Categories = AutomaticRecallCategories.RecentMessages,
+        });
+    }
+}

--- a/src/AgentMemory.AgentFramework/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.AgentFramework/ServiceCollectionExtensions.cs
@@ -58,7 +58,14 @@ public static class ServiceCollectionExtensions
 
         // Task-aware automatic recall policy (#88). TryAdd: a host registering its own
         // IAutomaticRecallPolicy either before or after this call always wins over this default.
-        services.TryAddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
+        //
+        // Default changed to TrivialTurnRecallPolicy: identical to ConfiguredAutomaticRecallPolicy on
+        // every real turn, and recent-messages-only on a greeting/acknowledgement-only one. Measured on
+        // PERF-R-01, a greeting turn previously cost 13 Cypher queries, 12 read transactions and an
+        // embedding round trip to retrieve 11 items, 10 of which need no vector at all.
+        // A host wanting the previous behaviour registers it explicitly:
+        //   services.AddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
+        services.TryAddScoped<IAutomaticRecallPolicy, TrivialTurnRecallPolicy>();
 
         // Memory-context admission policy (#92 Phase 2). TryAdd: same override semantics as above.
         services.TryAddScoped<IMemoryContextAdmissionPolicy, DefaultMemoryContextAdmissionPolicy>();

--- a/src/AgentMemory.Core/Services/LongTermMemoryService.cs
+++ b/src/AgentMemory.Core/Services/LongTermMemoryService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Core.Memory;
@@ -414,6 +414,18 @@ internal sealed class LongTermMemoryService : ILongTermMemoryService, IScoredLon
         return new ScoredFactSearchResult(facts, scoreSink);
     }
 
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<Fact>> SearchFactsAsync(
+        float[] queryEmbedding,
+        ValidTimeMode validTime,
+        int limit,
+        double minScore,
+        MemoryScope? scope,
+        CancellationToken cancellationToken) =>
+        SearchFactsCoreAsync(
+            queryEmbedding, limit, minScore, scope, expandByPredicate: false, expansionLimit: 0,
+            questionRelations: Array.Empty<string>(), scoreSink: null, cancellationToken, validTime);
+
     /// <summary>
     /// The single fact-recall implementation. <paramref name="scoreSink"/> is a sink rather than a second
     /// return value so the ordinary (diagnostics-off) call keeps exactly its previous allocations: null
@@ -428,11 +440,22 @@ internal sealed class LongTermMemoryService : ILongTermMemoryService, IScoredLon
         int expansionLimit,
         IReadOnlyList<string> questionRelations,
         List<(Fact Fact, double Score)>? scoreSink,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        ValidTimeMode validTime = ValidTimeMode.Ignore)
     {
         ArgumentNullException.ThrowIfNull(questionRelations);
         var resolved = Resolve(scope, nameof(SearchFactsAsync));
-        var scored = await _factRepo.SearchByVectorAsync(queryEmbedding, limit, minScore, resolved, cancellationToken).ConfigureAwait(false);
+        // Take the pre-existing overload unless the gate is actually on, so an ungated recall emits the
+        // exact repository call it always did -- byte-identical rather than merely equivalent. It also
+        // means a third-party IFactRepository that never implements the valid-time overload is only
+        // reached through it when a caller explicitly asked for gating.
+        var scored = validTime == ValidTimeMode.Ignore
+            ? await _factRepo
+                .SearchByVectorAsync(queryEmbedding, limit, minScore, resolved, cancellationToken)
+                .ConfigureAwait(false)
+            : await _factRepo
+                .SearchByVectorAsync(queryEmbedding, validTime, limit, minScore, resolved, cancellationToken)
+                .ConfigureAwait(false);
         // Only the similarity search scores anything. Expansion below appends facts fetched by predicate,
         // which carry no comparable score and are deliberately left out of the sink rather than given a
         // stand-in one.

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -100,6 +100,28 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         return map;
     }
 
+    /// <summary>
+    /// Whether any retrieval selected by <paramref name="recallOpts"/> actually consumes a query vector.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exactly the five categories whose searches are gated on <c>hasEmbedding</c>. Recent messages are
+    /// session-scoped and time-ordered, so they need no vector; GraphRAG builds its own retriever and
+    /// starts before this point, so it needs nothing from here either.
+    /// </para>
+    /// <para>
+    /// <b>One definition, deliberately.</b> The live and as-of paths repeat their per-category gates
+    /// independently and have already drifted apart once on a single option, so the decision that spans
+    /// both lives in one place where a new category cannot be added to one and forgotten in the other.
+    /// </para>
+    /// </remarks>
+    private static bool NeedsQueryEmbedding(RecallOptions recallOpts) =>
+        recallOpts.MaxRelevantMessages > 0
+        || recallOpts.MaxEntities > 0
+        || recallOpts.MaxPreferences > 0
+        || recallOpts.MaxFacts > 0
+        || recallOpts.MaxTraces > 0;
+
     /// <inheritdoc/>
     public async Task<MemoryContext> AssembleContextAsync(
         RecallRequest request,
@@ -183,12 +205,22 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
 
         if (includeMemory)
         {
-            // Generate embedding if not provided (only needed for memory-layer semantic search).
+            // Generate embedding if not provided, and ONLY if some retrieval will actually consume it.
+            // Every vector search below is gated on its own MaxX > 0 (#88); the embedding was not, so a
+            // task-aware policy that narrowed a turn to recent messages alone still paid for a provider
+            // round trip whose result nothing read. Remote-shaped that is the single largest recall
+            // stage (~120 ms), which made category narrowing *relocate* the cost rather than remove it.
+            // Gating it here rather than in the MAF provider also covers the SK adapter, the CLI and the
+            // facade, which all reach this method.
+            bool needsEmbedding = NeedsQueryEmbedding(recallOpts);
+
             var queryEmbedding = request.QueryEmbedding
-                ?? await TimedAsync(
-                        "memory.recall.embedding",
-                        () => _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken))
-                    .ConfigureAwait(false);
+                ?? (needsEmbedding
+                    ? await TimedAsync(
+                            "memory.recall.embedding",
+                            () => _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken))
+                        .ConfigureAwait(false)
+                    : Array.Empty<float>());
 
             // Vector searches require a non-empty embedding. A blank query (e.g. a history-only
             // recall via the chat-history provider) yields an empty embedding — skip the semantic
@@ -509,8 +541,13 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         var scope = _isolationPolicy.ResolveReadScope(
             recallOpts.Scope, request.UserId, nameof(AssembleContextAsOfAsync), MemoryOperationAccess.Tenant);
 
+        // Same elision as the live path, asserted separately rather than assumed: these two paths have
+        // already diverged once on a single option (SuccessfulTracesOnly is passed live and hardcoded
+        // null here), so "it mirrors the live path" is not a safe thing to take on trust.
         var queryEmbedding = request.QueryEmbedding
-            ?? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken).ConfigureAwait(false);
+            ?? (NeedsQueryEmbedding(recallOpts)
+                ? await _embeddingOrchestrator.EmbedQueryAsync(request.Query, cancellationToken).ConfigureAwait(false)
+                : Array.Empty<float>());
 
         // Vector searches require a non-empty embedding. A blank query, or a transient embedding-generation
         // failure (degrades to an empty vector), would otherwise issue a zero-dimension vector query which

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Diagnostics;
 using AgentMemory.Abstractions.Domain;
@@ -98,6 +98,34 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
                 map[strategy.Strategy] = strategy;
 
         return map;
+    }
+
+    /// <summary>
+    /// Builds a section's diagnostics from what the retrieval actually did.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="searched"/> is passed in rather than inferred from the item count, because the
+    /// whole point is to separate "searched and found nothing" from "never searched" — and those look
+    /// identical from the results alone.
+    /// </remarks>
+    private static MemoryContextSectionDiagnostics Diagnose<T>(
+        bool searched,
+        int requestedLimit,
+        IReadOnlyList<T> items,
+        IReadOnlyList<MemoryContextRankedItem> ranked,
+        double minimumScore)
+    {
+        // Scores come from the ranked items, which exist only when the provider could supply them.
+        // An unscoreable section reports null rather than a placeholder: zero is a real score.
+        double? top = null, low = null;
+        if (ranked.Count > 0)
+        {
+            top = ranked.Max(item => item.Score);
+            low = ranked.Min(item => item.Score);
+        }
+
+        return new MemoryContextSectionDiagnostics(
+            searched, requestedLimit, items.Count, top, low, minimumScore);
     }
 
     /// <summary>
@@ -203,6 +231,11 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
             ? MemoryRelationLexicon.Default.ResolveQuestion(request.Query)
             : Array.Empty<string>();
 
+        // Whether the vector searches were reachable at all this recall, hoisted so the diagnostics built
+        // after budgeting can distinguish "searched and found nothing" from "never searched". False when
+        // memory was excluded by blend mode, or when no embedding was available to search with.
+        bool vectorSearchRan = false;
+
         if (includeMemory)
         {
             // Generate embedding if not provided, and ONLY if some retrieval will actually consume it.
@@ -226,6 +259,7 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
             // recall via the chat-history provider) yields an empty embedding — skip the semantic
             // searches rather than issue zero-dimension vector queries (which the index rejects).
             bool hasEmbedding = queryEmbedding is { Length: > 0 };
+            vectorSearchRan = hasEmbedding;
             static Task<IReadOnlyList<T>> Empty<T>() => Task.FromResult<IReadOnlyList<T>>(Array.Empty<T>());
 
             // Every long-term/reasoning search below is ranked by the vector index and the service layer
@@ -473,31 +507,59 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         {
             SessionId = request.SessionId,
             AssembledAtUtc = _clock.UtcNow,
-            RecentMessages = new MemoryContextSection<Message> { Items = recentMessages },
+            RecentMessages = new MemoryContextSection<Message>
+            {
+                Items = recentMessages,
+                // No vector involved: session-scoped and time-ordered, so the limit alone decides.
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(recallOpts.MaxRecentMessages > 0, recallOpts.MaxRecentMessages,
+                        recentMessages, Array.Empty<MemoryContextRankedItem>(), minScore)
+                    : null
+            },
             RelevantMessages = new MemoryContextSection<Message>
             {
                 Items = relevantMessages,
-                RankedItems = relevantRanked
+                RankedItems = relevantRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(vectorSearchRan && recallOpts.MaxRelevantMessages > 0,
+                        recallOpts.MaxRelevantMessages, relevantMessages, relevantRanked, minScore)
+                    : null
             },
             RelevantEntities = new MemoryContextSection<Entity>
             {
                 Items = entities,
-                RankedItems = entityRanked
+                RankedItems = entityRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(vectorSearchRan && recallOpts.MaxEntities > 0,
+                        recallOpts.MaxEntities, entities, entityRanked, minScore)
+                    : null
             },
             RelevantPreferences = new MemoryContextSection<Preference>
             {
                 Items = preferences,
-                RankedItems = preferenceRanked
+                RankedItems = preferenceRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(vectorSearchRan && recallOpts.MaxPreferences > 0,
+                        recallOpts.MaxPreferences, preferences, preferenceRanked, minScore)
+                    : null
             },
             RelevantFacts = new MemoryContextSection<Fact>
             {
                 Items = facts,
-                RankedItems = factRanked
+                RankedItems = factRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(vectorSearchRan && recallOpts.MaxFacts > 0,
+                        recallOpts.MaxFacts, facts, factRanked, minScore)
+                    : null
             },
             SimilarTraces = new MemoryContextSection<ReasoningTrace>
             {
                 Items = traces,
-                RankedItems = traceRanked
+                RankedItems = traceRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(vectorSearchRan && recallOpts.MaxTraces > 0,
+                        recallOpts.MaxTraces, traces, traceRanked, minScore)
+                    : null
             },
             GraphRagContext = graphRagContext,
             GraphRagItems = graphRagItems,
@@ -713,29 +775,52 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
         {
             SessionId = request.SessionId,
             AssembledAtUtc = _clock.UtcNow,
-            RecentMessages = new MemoryContextSection<Message> { Items = recentMessages },
+            RecentMessages = new MemoryContextSection<Message>
+            {
+                Items = recentMessages,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(recallOpts.MaxRecentMessages > 0, recallOpts.MaxRecentMessages,
+                        recentMessages, Array.Empty<MemoryContextRankedItem>(), minScore)
+                    : null
+            },
             // Empty, not unscored: the temporal snapshot runs no semantic message search at all, so there
             // is no retrieval here to report a rank for.
             RelevantMessages = MemoryContextSection<Message>.Empty,
             RelevantEntities = new MemoryContextSection<Entity>
             {
                 Items = entities,
-                RankedItems = entityRanked
+                RankedItems = entityRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(hasEmbedding && recallOpts.MaxEntities > 0,
+                        recallOpts.MaxEntities, entities, entityRanked, minScore)
+                    : null
             },
             RelevantPreferences = new MemoryContextSection<Preference>
             {
                 Items = preferences,
-                RankedItems = preferenceRanked
+                RankedItems = preferenceRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(hasEmbedding && recallOpts.MaxPreferences > 0,
+                        recallOpts.MaxPreferences, preferences, preferenceRanked, minScore)
+                    : null
             },
             RelevantFacts = new MemoryContextSection<Fact>
             {
                 Items = facts,
-                RankedItems = factRanked
+                RankedItems = factRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(hasEmbedding && recallOpts.MaxFacts > 0,
+                        recallOpts.MaxFacts, facts, factRanked, minScore)
+                    : null
             },
             SimilarTraces = new MemoryContextSection<ReasoningTrace>
             {
                 Items = traces,
-                RankedItems = traceRanked
+                RankedItems = traceRanked,
+                Diagnostics = recallOpts.IncludeDiagnostics
+                    ? Diagnose(hasEmbedding && recallOpts.MaxTraces > 0,
+                        recallOpts.MaxTraces, traces, traceRanked, minScore)
+                    : null
             },
             Truncated = truncated,
             // "asOf" retained as the valid-time alias for backward compatibility; both clocks recorded.

--- a/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
+++ b/src/AgentMemory.Core/Services/MemoryContextAssembler.cs
@@ -362,8 +362,18 @@ internal sealed class MemoryContextAssembler : IMemoryContextAssembler
                             // previous call exactly.
                             resolvedQueryRelations,
                             cancellationToken)
-                        : _longTerm.SearchFactsAsync(
-                            queryEmbedding, recallOpts.MaxFacts, minScore, scope, cancellationToken))
+                        // Valid time is applied on the non-expansion path only. Expansion fetches by
+                        // predicate rather than by vector and would need its own clause; gating one and
+                        // silently not the other would be worse than gating neither, so expansion keeps
+                        // today's behaviour until it is done deliberately.
+                        // Same rule as the service below it: take the pre-existing overload unless the
+                        // gate is on, so an ungated recall is byte-identical to what it always was.
+                        : recallOpts.ValidTime == ValidTimeMode.Ignore
+                            ? _longTerm.SearchFactsAsync(
+                                queryEmbedding, recallOpts.MaxFacts, minScore, scope, cancellationToken)
+                            : _longTerm.SearchFactsAsync(
+                                queryEmbedding, recallOpts.ValidTime, recallOpts.MaxFacts, minScore,
+                                scope, cancellationToken))
                 : Empty<Fact>();
 
             var tracesTask = searchTraces && scoredReasoning is null

--- a/src/AgentMemory.Core/Services/MemoryQueryFacade.cs
+++ b/src/AgentMemory.Core/Services/MemoryQueryFacade.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Microsoft.Extensions.Logging;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
@@ -199,7 +199,16 @@ internal sealed class MemoryQueryFacade : IMemoryQueryFacade
             var traces = await _reasoning.SearchSimilarTracesAsync(embedding, scope: ResolveScope("find_similar_tasks"), cancellationToken: cancellationToken).ConfigureAwait(false);
             if (traces.Count == 0) return "No similar tasks found.";
             var sb = new StringBuilder();
-            foreach (var t in traces) sb.AppendLine($"[{(t.Success == true ? "✓" : "✗")}] {t.Task}: {t.Outcome}");
+            // Three states, not two. Success is bool? and null means UNRECORDED, not failed -- and
+            // null is the common case: AgentTraceRecorder had no success parameter at all until
+            // recently, so every trace it wrote carries null. Collapsing that into "✗" presented the
+            // model with a precedent library in which everything had failed, which is worse than
+            // showing nothing: a wrong precedent is acted on, an absent one is investigated.
+            foreach (var t in traces)
+            {
+                var mark = t.Success switch { true => "✓", false => "✗", null => "?" };
+                sb.AppendLine($"[{mark}] {t.Task}: {t.Outcome}");
+            }
             return sb.ToString().Trim();
         }).ConfigureAwait(false);
     }

--- a/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
+++ b/src/AgentMemory.McpServer/Tools/ReasoningTools.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 using AgentMemory.Abstractions.Services;
@@ -17,10 +17,18 @@ internal sealed class ReasoningTools
         IOptions<AgentMemoryMcpOptions> options,
         [Description("Description of the task being solved")] string task,
         [Description("Session identifier (optional, uses default if omitted)")] string? sessionId = null,
+        [Description("User identifier (optional)")] string? userId = null,
         CancellationToken cancellationToken = default)
     {
         var sid = sessionId ?? options.Value.DefaultSessionId;
-        var trace = await reasoningMemory.StartTraceAsync(sid, task, cancellationToken: cancellationToken).ConfigureAwait(false);
+        // Owner scoping, matching every other tenant-facing MCP tool. Without it this tool passed no
+        // owner at all, so an MCP-started trace was written to the shared/global bucket while
+        // MemoryQueryFacade READS traces through the ambient owner context -- an isolation asymmetry in
+        // which a trace could be written by one tenant and be invisible to that same tenant on recall,
+        // while visible to every other one.
+        var trace = await reasoningMemory
+            .StartTraceAsync(sid, task, ownerId: userId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         return ToolJsonContext.Serialize(new
         {
             trace.TraceId,

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jOptions.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jOptions.cs
@@ -1,4 +1,4 @@
-namespace AgentMemory.Neo4j.Infrastructure;
+﻿namespace AgentMemory.Neo4j.Infrastructure;
 
 public class Neo4jOptions
 {
@@ -9,6 +9,30 @@ public class Neo4jOptions
     public int MaxConnectionPoolSize { get; set; } = 100;
     public TimeSpan ConnectionAcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(60);
     public bool EncryptionEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Server-side deadline for every managed read/write transaction. <see langword="null"/> (default)
+    /// means no deadline, which is today's behaviour.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Nothing bounds a query today. The driver's <c>ExecuteReadAsync</c>/<c>ExecuteWriteAsync</c> take
+    /// no <see cref="CancellationToken"/>, so an in-flight query cannot be interrupted from this side —
+    /// cooperative cancellation only checks <em>before</em> work starts. A transaction timeout is the
+    /// only mechanism that actually bounds one, because the <b>server</b> enforces it.
+    /// </para>
+    /// <para>
+    /// This matters more since the owner-starvation rescue: a scoped search that returns nothing falls
+    /// back to a scan bounded by one owner's data, and "one owner's data" is unbounded in principle.
+    /// </para>
+    /// <para>
+    /// <b>Default is null on purpose.</b> A timeout that is too low converts a slow query into a failed
+    /// one, and the right value depends on deployment shape, so this is a deliberate operator decision
+    /// rather than a number chosen here. Values must be strictly positive; zero or negative is rejected
+    /// at startup rather than silently meaning "no timeout".
+    /// </para>
+    /// </remarks>
+    public TimeSpan? TransactionTimeout { get; set; }
 
     /// <summary>
     /// Dimensionality of embedding vectors. Must match the model used to generate embeddings.

--- a/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/Neo4jTransactionRunner.cs
@@ -1,5 +1,6 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Diagnostics;
 using AgentMemory.Neo4j.Queries;
 using Neo4j.Driver;
@@ -33,10 +34,28 @@ internal sealed class Neo4jTransactionRunner : INeo4jTransactionRunner, INeo4jAt
     private readonly ILogger<Neo4jTransactionRunner> _logger;
 
     private readonly AsyncLocal<IAsyncQueryRunner?> _ambientWriteTransaction = new();
-    public Neo4jTransactionRunner(INeo4jSessionFactory sessionFactory, ILogger<Neo4jTransactionRunner> logger)
+
+    /// <summary>
+    /// Applies the configured server-side deadline, or null when none is configured.
+    /// </summary>
+    /// <remarks>
+    /// Built once. Null is passed straight through to the driver's overload that takes no transaction
+    /// config, so an unconfigured deployment emits byte-identical driver calls to before this existed.
+    /// </remarks>
+    private readonly Action<TransactionConfigBuilder>? _transactionConfig;
+
+    public Neo4jTransactionRunner(
+        INeo4jSessionFactory sessionFactory,
+        ILogger<Neo4jTransactionRunner> logger,
+        IOptions<Neo4jOptions>? options = null)
     {
         _sessionFactory = sessionFactory;
         _logger = logger;
+
+        var timeout = options?.Value.TransactionTimeout;
+        _transactionConfig = timeout is { } value && value > TimeSpan.Zero
+            ? builder => builder.WithTimeout(value)
+            : null;
     }
 
     public async Task<T> ReadAsync<T>(Func<IAsyncQueryRunner, Task<T>> work, CancellationToken cancellationToken = default)
@@ -54,8 +73,11 @@ internal sealed class Neo4jTransactionRunner : INeo4jTransactionRunner, INeo4jAt
         await using var _ = session.ConfigureAwait(false); // ConfigureAwait the disposal without rebinding session's type
         try
         {
+            // Always the config-taking overload: the driver's single-argument form forwards to this one
+            // with a null config, so passing null here is byte-identical to the call this used to make.
             return await session.ExecuteReadAsync(
-                Instrument(work, "read", activity, payload, transactionEntryStartedAt)).ConfigureAwait(false);
+                Instrument(work, "read", activity, payload, transactionEntryStartedAt),
+                _transactionConfig).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -94,7 +116,8 @@ internal sealed class Neo4jTransactionRunner : INeo4jTransactionRunner, INeo4jAt
         try
         {
             return await session.ExecuteWriteAsync(
-                Instrument(work, "write", activity, payload, transactionEntryStartedAt)).ConfigureAwait(false);
+                Instrument(work, "write", activity, payload, transactionEntryStartedAt),
+                _transactionConfig).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -132,7 +155,11 @@ internal sealed class Neo4jTransactionRunner : INeo4jTransactionRunner, INeo4jAt
         {
             // Explicit rather than managed transaction: the callback mutates in-memory outcome state
             // and must execute exactly once. The caller owns any whole-operation retry after rollback.
-            transaction = await session.BeginTransactionAsync().ConfigureAwait(false);
+            // The same deadline as the managed paths. Covering two of the three transaction entry
+            // points would be worse than covering none: the uncovered one is the FUSED PERSISTENCE
+            // path, which is the longest-running write in the system, and an operator who configured
+            // a timeout would reasonably believe it applied everywhere.
+            transaction = await session.BeginTransactionAsync(_transactionConfig).ConfigureAwait(false);
             activity?.SetTag(
                 "db.transaction_entry_ms_est",
                 Stopwatch.GetElapsedTime(transactionEntryStartedAt).TotalMilliseconds);

--- a/src/AgentMemory.Neo4j/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Neo4j/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Neo4j.Driver;
 using AgentMemory.Abstractions.Repositories;
@@ -26,6 +26,11 @@ public static class ServiceCollectionExtensions
             .Validate(o => !string.IsNullOrWhiteSpace(o.Username), "Neo4j Username must be provided.")
             .Validate(o => !string.IsNullOrWhiteSpace(o.Database), "Neo4j Database must be provided.")
             .Validate(o => o.MaxConnectionPoolSize > 0, "Neo4j MaxConnectionPoolSize must be positive.")
+            .Validate(
+                o => o.TransactionTimeout is null || o.TransactionTimeout > TimeSpan.Zero,
+                "Neo4j TransactionTimeout must be positive when set; use null for no deadline. "
+                + "Zero or negative is rejected rather than silently treated as 'no timeout', because "
+                + "an operator who configured a bound would then be running without one.")
             .Validate(o => o.EmbeddingDimensions > 0, "Neo4j EmbeddingDimensions must be positive.")
             .Validate(o => o.ConnectionAcquisitionTimeout > TimeSpan.Zero, "Neo4j ConnectionAcquisitionTimeout must be positive.")
             .ValidateOnStart();

--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -1,4 +1,4 @@
-using AgentMemory.Neo4j.Infrastructure;
+﻿using AgentMemory.Neo4j.Infrastructure;
 
 namespace AgentMemory.Neo4j.Queries;
 
@@ -212,12 +212,20 @@ internal static class FactQueries
     /// <paramref name="recencyRerank"/> is set (D1) the clamped ACT-R retention score is blended into the
     /// order key (<c>$tmpWeight</c>); when unset the query is byte-for-byte today's semantic-only ranking.
     /// </summary>
-    public static string SearchByVector(bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false) =>
+    public static string SearchByVector(
+        bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false, bool currentValidTime = false) =>
         VectorRerank.Finish(
             new CypherBuilder()
                 .WithVectorSearch("fact_embedding_idx", "$embedding", "node", topK)
                 .Where("score >= $minScore")
                 .And("node.invalidated_at IS NULL")
+                // Valid time, copied VERBATIM from TemporalQueries so the two clocks cannot drift: the
+                // as-of path has filtered on exactly this for as long as it has existed, while live
+                // recall filtered on similarity, invalidated_at and owner and nothing else. A fact valid
+                // from six months hence was returned TODAY, and one whose valid_until had passed was
+                // returned FOREVER. Off unless asked for, so no deployment silently recalls less.
+                .And("(node.valid_from IS NULL OR node.valid_from <= datetime($now))", when: currentValidTime)
+                .And("(node.valid_until IS NULL OR node.valid_until > datetime($now))", when: currentValidTime)
                 .And(includeShared ? "(node.owner_id = $ownerId OR node.owner_id IS NULL)" : "node.owner_id = $ownerId", when: hasOwnerFilter),
             recencyRerank);
 
@@ -240,16 +248,24 @@ internal static class FactQueries
     /// makes it O(this owner's facts) in the rare case, versus returning nothing at all.
     /// </para>
     /// </remarks>
-    public static string SearchByVectorOwnerScopedFallback(bool includeShared)
+    public static string SearchByVectorOwnerScopedFallback(bool includeShared, bool currentValidTime = false)
     {
         var owner = includeShared
             ? "(f.owner_id = $ownerId OR f.owner_id IS NULL)"
             : "f.owner_id = $ownerId";
+        // The SECOND live fact path, and the one every prior analysis of this gap predates -- it did not
+        // exist before 1.4.1. Gating only the indexed query above would leave valid time silently
+        // bypassed for exactly the starved multi-tenant owners this fallback was added to rescue.
+        var validTime = currentValidTime
+            ? @"
+              AND (f.valid_from  IS NULL OR f.valid_from  <= datetime($now))
+              AND (f.valid_until IS NULL OR f.valid_until >  datetime($now))"
+            : string.Empty;
         return $@"
             MATCH (f:Fact)
             WHERE {owner}
               AND f.embedding IS NOT NULL
-              AND f.invalidated_at IS NULL
+              AND f.invalidated_at IS NULL{validTime}
             WITH f, vector.similarity.cosine(f.embedding, $embedding) AS score
             WHERE score >= $minScore
             RETURN f AS node, score

--- a/src/AgentMemory.Neo4j/Queries/SchemaQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/SchemaQueries.cs
@@ -1,4 +1,4 @@
-namespace AgentMemory.Neo4j.Queries;
+﻿namespace AgentMemory.Neo4j.Queries;
 
 /// <summary>
 /// Centralized Cypher statements for schema bootstrapping (constraints, indexes)
@@ -374,6 +374,21 @@ internal static class SchemaQueries
         $"CREATE VECTOR INDEX entity_embedding_idx IF NOT EXISTS FOR (n:Entity) ON (n.embedding) OPTIONS {{indexConfig: {{`vector.dimensions`: {dimensions}, `vector.similarity_function`: 'cosine'}}}}",
         $"CREATE VECTOR INDEX preference_embedding_idx IF NOT EXISTS FOR (n:Preference) ON (n.embedding) OPTIONS {{indexConfig: {{`vector.dimensions`: {dimensions}, `vector.similarity_function`: 'cosine'}}}}",
         $"CREATE VECTOR INDEX fact_embedding_idx IF NOT EXISTS FOR (n:Fact) ON (n.embedding) OPTIONS {{indexConfig: {{`vector.dimensions`: {dimensions}, `vector.similarity_function`: 'cosine'}}}}",
+        // RESERVED, and deliberately kept. Decision recorded 2026-08-12 after auditing it.
+        //
+        // State, precisely: the WRITE path is complete and caller-supplied -- AddStepAsync takes an
+        // optional embedding and Neo4jReasoningStepRepository persists it -- but no first-party caller
+        // supplies one (AgentTraceRecorder, the MCP tool and the evaluation CLI all omit it), and
+        // NOTHING reads this index. It is the only vector index here with no reader.
+        //
+        // Kept rather than dropped because its real cost today is ~zero: a vector index over a property
+        // that is always NULL indexes no nodes. Removing it would cost a migration, an ExpectedQueryCount
+        // bump and a snapshot regeneration for no measurable gain, and reintroducing it later would cost
+        // the same migration again. The honest position is to say what it is rather than to churn schema.
+        //
+        // The reader belongs with its consumer: step-level retrieval is what procedural memory would want
+        // (find the steps that solved a similar sub-problem), so it should arrive in the same change that
+        // uses it -- not as speculative machinery whose absence of a caller nobody notices.
         $"CREATE VECTOR INDEX reasoning_step_embedding_idx IF NOT EXISTS FOR (n:ReasoningStep) ON (n.embedding) OPTIONS {{indexConfig: {{`vector.dimensions`: {dimensions}, `vector.similarity_function`: 'cosine'}}}}",
         $"CREATE VECTOR INDEX task_embedding_idx IF NOT EXISTS FOR (n:ReasoningTrace) ON (n.task_embedding) OPTIONS {{indexConfig: {{`vector.dimensions`: {dimensions}, `vector.similarity_function`: 'cosine'}}}}"
         ]

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Diagnostics;
 using AgentMemory.Abstractions.Domain;
@@ -262,8 +262,17 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public Task<IReadOnlyList<(Fact Fact, double Score)>> SearchByVectorAsync(
+        float[] queryEmbedding,
+        int limit = 10,
+        double minScore = 0.0,
+        MemoryScope? scope = null,
+        CancellationToken cancellationToken = default) =>
+        SearchByVectorAsync(queryEmbedding, ValidTimeMode.Ignore, limit, minScore, scope, cancellationToken);
+
     public async Task<IReadOnlyList<(Fact Fact, double Score)>> SearchByVectorAsync(
         float[] queryEmbedding,
+        ValidTimeMode validTime,
         int limit = 10,
         double minScore = 0.0,
         MemoryScope? scope = null,
@@ -291,12 +300,17 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
             ["limit"] = limit,
             ["minScore"] = minScore,
         };
+        bool currentValidTime = validTime == ValidTimeMode.Current;
+        // Both gated queries read $now; supplied only when the gate is on, so an ungated query's
+        // parameter set stays byte-identical to what it has always sent.
+        if (currentValidTime) parameters["now"] = DateTimeOffset.UtcNow.ToString("O");
         if (hasOwner) parameters["ownerId"] = scope!.OwnerId;
         if (recencyRerank) RerankParameters.Add(parameters, ranking, _decay);
 
         async Task<List<(Fact, double)>> QueryAsync(int width, CancellationToken ct)
         {
-            var cypher = FactQueries.SearchByVector(hasOwner, includeShared, width, recencyRerank);
+            var cypher = FactQueries.SearchByVector(
+                hasOwner, includeShared, width, recencyRerank, currentValidTime);
             return await _tx.ReadAsync(async runner =>
             {
                 var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
@@ -345,7 +359,7 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
                 results = await _tx.ReadAsync(async runner =>
                 {
                     var cursor = await runner.RunAsync(
-                        FactQueries.SearchByVectorOwnerScopedFallback(includeShared),
+                        FactQueries.SearchByVectorOwnerScopedFallback(includeShared, currentValidTime),
                         new Dictionary<string, object?>
                         {
                             ["embedding"] = queryEmbedding.ToList(),

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Exceptions;
@@ -15,13 +15,37 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     private readonly IMemoryService _inner;
     private readonly MemoryMetrics _metrics;
     private readonly IngestionFailureMode _failureMode;
+    private readonly bool _includeOwnerId;
 
     public InstrumentedMemoryService(
-        IMemoryService inner, MemoryMetrics metrics, IOptions<ExtractionOptions>? extractionOptions = null)
+        IMemoryService inner,
+        MemoryMetrics metrics,
+        IOptions<ExtractionOptions>? extractionOptions = null,
+        IOptions<ObservabilityOptions>? observabilityOptions = null)
     {
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _failureMode = extractionOptions?.Value.FailureMode ?? IngestionFailureMode.BestEffort;
+        _includeOwnerId = observabilityOptions?.Value.IncludeOwnerIdInTelemetry ?? false;
+    }
+
+    /// <summary>
+    /// Tags the owner dimension without exporting tenant data unless the host asked for it.
+    /// </summary>
+    /// <remarks>
+    /// A tenant identifier in a trace is tenant data in a system usually less access-controlled than
+    /// the database it came from. The boolean answers the operational question -- was this operation
+    /// scoped? -- without carrying the value, which is the same choice every owner-scoped vector
+    /// search here already makes with <c>memory.vector.owner_scoped</c>.
+    /// </remarks>
+    private void TagOwner(System.Diagnostics.Activity? activity, string? userId)
+    {
+        if (activity is null) return;
+
+        if (_includeOwnerId && userId is not null)
+            activity.SetTag("memory.user_id", userId);
+        else
+            activity.SetTag("memory.owner_scoped", userId is not null);
     }
 
     public async Task<RecallResult> RecallAsync(
@@ -30,6 +54,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     {
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.recall");
         activity?.SetTag("memory.session_id", request.SessionId);
+        TagOwner(activity, request.UserId);
 
         var sw = Stopwatch.StartNew();
         try
@@ -267,7 +292,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     {
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.extract_from_session");
         activity?.SetTag("memory.session_id", sessionId);
-        if (userId is not null) activity?.SetTag("memory.user_id", userId);
+        TagOwner(activity, userId);
 
         var sw = Stopwatch.StartNew();
         try
@@ -293,7 +318,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     {
         using var activity = MemoryActivitySource.Instance.StartActivity("memory.extract_from_conversation");
         activity?.SetTag("memory.conversation_id", conversationId);
-        if (userId is not null) activity?.SetTag("memory.user_id", userId);
+        TagOwner(activity, userId);
 
         var sw = Stopwatch.StartNew();
         try

--- a/src/AgentMemory.Observability/InstrumentedMemoryService.cs
+++ b/src/AgentMemory.Observability/InstrumentedMemoryService.cs
@@ -30,6 +30,46 @@ internal sealed class InstrumentedMemoryService : IMemoryService
     }
 
     /// <summary>
+    /// Emits which recall sections came back empty or short.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The misses are the roadmap, and nothing recorded them.</b> A <c>:MemoryReadAudit</c> row is
+    /// created inside <c>MATCH (n:{label} {id: $id})</c>, so a row exists only for a <b>hit</b> — there
+    /// was no record anywhere that an owner asked for something and memory had nothing.
+    /// </para>
+    /// <para>
+    /// A counter rather than a stored node, deliberately: a node per miss grows without bound on the
+    /// exact workload that produces the most misses, and would need its own retention policy to stop
+    /// being a liability. A counter answers the operational question — how often, for which category —
+    /// without storing anything.
+    /// </para>
+    /// <para>
+    /// <b>Requires <c>RecallOptions.IncludeDiagnostics</c>.</b> Without it the sections carry no
+    /// diagnostics and nothing is emitted, rather than emitting a guess: "empty" and "never searched"
+    /// are different, and only the diagnostics can tell them apart.
+    /// </para>
+    /// </remarks>
+    private void RecordSectionOutcomes(MemoryContext context)
+    {
+        Record("recent", context.RecentMessages.Diagnostics);
+        Record("relevant_messages", context.RelevantMessages.Diagnostics);
+        Record("entities", context.RelevantEntities.Diagnostics);
+        Record("preferences", context.RelevantPreferences.Diagnostics);
+        Record("facts", context.RelevantFacts.Diagnostics);
+        Record("traces", context.SimilarTraces.Diagnostics);
+
+        void Record(string category, MemoryContextSectionDiagnostics? diagnostics)
+        {
+            if (diagnostics is null) return;
+
+            var tag = new KeyValuePair<string, object?>("memory.category", category);
+            if (diagnostics.SearchedAndEmpty) _metrics.RecallSectionEmpty.Add(1, tag);
+            else if (diagnostics.SearchedAndShort) _metrics.RecallSectionShort.Add(1, tag);
+        }
+    }
+
+    /// <summary>
     /// Tags the owner dimension without exporting tenant data unless the host asked for it.
     /// </summary>
     /// <remarks>
@@ -63,6 +103,7 @@ internal sealed class InstrumentedMemoryService : IMemoryService
             _metrics.RecallRequests.Add(1);
             activity?.SetTag("memory.recall.entity_count", result.Context.RelevantEntities.Items.Count);
             activity?.SetTag("memory.recall.total_items", result.TotalItemsRetrieved);
+            RecordSectionOutcomes(result.Context);
             return result;
         }
         catch (Exception ex)

--- a/src/AgentMemory.Observability/MemoryMetrics.cs
+++ b/src/AgentMemory.Observability/MemoryMetrics.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.Metrics;
+﻿using System.Diagnostics.Metrics;
 
 namespace AgentMemory.Observability;
 
@@ -40,6 +40,21 @@ public sealed class MemoryMetrics : IDisposable
         RecallRequests = _meter.CreateCounter<long>(
             "memory.recall.requests",
             description: "Number of recall operations performed");
+
+        RecallSectionEmpty = _meter.CreateCounter<long>(
+            "memory.recall.section.empty",
+            description:
+                "Recall sections that were searched and returned nothing, tagged by category. "
+                + "The misses are the roadmap: an audit row is created inside MATCH, so it exists only "
+                + "for a HIT, and nothing recorded that an owner asked and memory had nothing.");
+
+        RecallSectionShort = _meter.CreateCounter<long>(
+            "memory.recall.section.short",
+            description:
+                "Recall sections that returned fewer items than requested, tagged by category. On an "
+                + "owner-scoped vector search this is the starvation shape: the index picks a global "
+                + "top-K and the owner filter runs afterwards, and the escalation path fires only on a "
+                + "TOTAL zero -- so short-but-non-empty is otherwise invisible.");
 
         ExtractionErrors = _meter.CreateCounter<long>(
             "memory.extraction.errors",
@@ -147,6 +162,12 @@ public sealed class MemoryMetrics : IDisposable
 
     /// <summary>Number of recall operations performed.</summary>
     internal Counter<long> RecallRequests { get; }
+
+    /// <summary>Searched sections that came back empty, tagged by category.</summary>
+    internal Counter<long> RecallSectionEmpty { get; }
+
+    /// <summary>Searched sections that came back short of their limit, tagged by category.</summary>
+    internal Counter<long> RecallSectionShort { get; }
 
     /// <summary>Number of extraction operations that failed.</summary>
     internal Counter<long> ExtractionErrors { get; }

--- a/src/AgentMemory.Observability/ObservabilityOptions.cs
+++ b/src/AgentMemory.Observability/ObservabilityOptions.cs
@@ -1,0 +1,31 @@
+namespace AgentMemory.Observability;
+
+/// <summary>
+/// Options for the observability decorators.
+/// </summary>
+public sealed class ObservabilityOptions
+{
+    /// <summary>
+    /// Whether to emit the raw owner/user identifier as a span tag. <see langword="false"/> by default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A tenant identifier in a trace is tenant data in a system that is usually less
+    /// access-controlled than the database it came from, retained on a different schedule, and often
+    /// exported to a third party. The rest of this codebase already takes that position: every
+    /// owner-scoped vector search tags <c>memory.vector.owner_scoped</c> as a <b>boolean</b> rather
+    /// than the identifier, which answers the operational question ("was this scoped?") without
+    /// carrying the value.
+    /// </para>
+    /// <para>
+    /// When <see langword="false"/>, a <c>memory.owner_scoped</c> boolean is emitted instead, so a
+    /// reader can still tell a scoped operation from an unscoped one.
+    /// </para>
+    /// <para>
+    /// <b>Off is a change from previous behaviour</b>, which always emitted the identifier. Hosts that
+    /// correlate traces by user — and have decided their identifier is safe to export — turn it back on
+    /// deliberately here, which is the point: it should be a decision rather than a default.
+    /// </para>
+    /// </remarks>
+    public bool IncludeOwnerIdInTelemetry { get; set; }
+}

--- a/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
+++ b/src/AgentMemory.Observability/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using AgentMemory.Abstractions.Services;
 
@@ -19,8 +19,22 @@ public static class ServiceCollectionExtensions
     /// Call this after registering the core memory services.
     /// </remarks>
     public static IServiceCollection AddAgentMemoryObservability(this IServiceCollection services)
+        => services.AddAgentMemoryObservability(configure: null);
+
+    /// <inheritdoc cref="AddAgentMemoryObservability(IServiceCollection)"/>
+    /// <param name="configure">
+    /// Optional observability configuration, e.g. to opt back into emitting the raw owner identifier
+    /// as a span tag (off by default -- a tenant id in a trace is tenant data).
+    /// </param>
+    public static IServiceCollection AddAgentMemoryObservability(
+        this IServiceCollection services,
+        Action<ObservabilityOptions>? configure)
     {
         services.TryAddSingleton<MemoryMetrics>();
+
+        var optionsBuilder = services.AddOptions<ObservabilityOptions>();
+        if (configure is not null)
+            optionsBuilder.Configure(configure);
 
         DecorateMemoryService(services);
         DecorateGraphRagContextSource(services);

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/AnswerPresenceDerivedAnswerTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/AnswerPresenceDerivedAnswerTests.cs
@@ -1,0 +1,62 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// A gold answer that is purely a number is <b>uncheckable</b> by token overlap, not absent.
+/// </summary>
+/// <remarks>
+/// Found by reconciling two questions where this gate and the judge disagreed: <c>eeda8a6d</c>
+/// ("17 fish total") and <c>1f2b8d4f</c> ("$750"). Both were judged CORRECT while the gate reported
+/// the answer absent from memory. Neither was wrong — the number is <i>derived</i> from stored
+/// evidence and was never itself written down, so overlap cannot find it. Reporting that as absent
+/// blames extraction for an answer the model computed correctly.
+/// </remarks>
+public sealed class AnswerPresenceDerivedAnswerTests
+{
+    private static readonly string[] Memory =
+    [
+        "user owns 5 golden honey gouramis",
+        "user owns 1 small pleco catfish",
+        "user owns 10 neon tetras",
+    ];
+
+    [Theory]
+    [InlineData("17")]
+    [InlineData("750")]
+    [InlineData("$750")]
+    [InlineData("17.")]
+    public void APurelyNumericGoldAnswerIsUncheckableRatherThanAbsent(string goldAnswer)
+    {
+        var result = LongMemEvalAnswerPresence.Evaluate(goldAnswer, Memory);
+
+        result.Checkable.Should().BeFalse(
+            "the number is derived from stored evidence and was never itself stored");
+        result.Present.Should().BeFalse(
+            "an unmeasurable question must never count as passing either");
+    }
+
+    [Fact]
+    public void AnAnswerWithLexicalContentIsStillChecked()
+    {
+        // The guard must stay narrow: a number ALONGSIDE distinctive words is still checkable, because
+        // the words carry evidence even when the numeral does not.
+        var result = LongMemEvalAnswerPresence.Evaluate("10 neon tetras", Memory);
+
+        result.Checkable.Should().BeTrue();
+        result.Present.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AGenuinelyAbsentTextAnswerIsStillReportedAbsent()
+    {
+        // The floor still has to fire. Widening "uncheckable" until nothing is ever absent would make
+        // this gate unable to fail, which is the exact defect shape it exists to prevent.
+        var result = LongMemEvalAnswerPresence.Evaluate("a saltwater reef tank", Memory);
+
+        result.Checkable.Should().BeTrue();
+        result.Present.Should().BeFalse();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/JudgeProtocolOptionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/JudgeProtocolOptionsTests.cs
@@ -1,0 +1,89 @@
+using AgentEval.Memory.External.Models;
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The judge options adopted from AgentEval 0.19, and the one that must stay opt-in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why <see cref="JudgeVerdictProtocol.StructuredJson"/> is not the default.</b> It is strictly
+/// better at recovering a verdict — AgentEval's own documentation names the free-text failure mode as
+/// vetoing a leading "yes" when the word "no" appears later in the response, which is exactly the
+/// systematic failure this project saw on question <c>7405e8b1</c>. But the same documentation states
+/// that enabling it "changes verdicts on the questions the free-text parser mis-scored" and therefore
+/// "makes results non-comparable with a base recorded under the free-text protocol".
+/// </para>
+/// <para>
+/// Every sealed base here was recorded under free text. A default flip would silently invalidate all
+/// of them, so the protocol is a stated per-run decision.
+/// </para>
+/// </remarks>
+public sealed class JudgeProtocolOptionsTests
+{
+    private static ExternalBenchmarkOptions Create(
+        JudgeVerdictProtocol? protocol = null) =>
+        protocol is null
+            ? LongMemEvalBenchmarkProtocol.CreateOptions(
+                "dataset.json", questions: 10, seed: 42, judgeRetryAttempts: 2,
+                LongMemEvalEvidenceDetail.Identifiers, maxRelevantMessages: 5)
+            : LongMemEvalBenchmarkProtocol.CreateOptions(
+                "dataset.json", questions: 10, seed: 42, judgeRetryAttempts: 2,
+                LongMemEvalEvidenceDetail.Identifiers, maxRelevantMessages: 5, protocol.Value);
+
+    [Fact]
+    public void TheDefaultProtocolIsFreeText_SoSealedBasesStayComparable()
+    {
+        Create().JudgeVerdictProtocol.Should().Be(JudgeVerdictProtocol.FreeText);
+    }
+
+    [Fact]
+    public void StructuredJsonIsReachableWhenAskedForExplicitly()
+    {
+        // It must be available -- it fixes a real, systematic mis-scoring -- but only on request.
+        Create(JudgeVerdictProtocol.StructuredJson)
+            .JudgeVerdictProtocol.Should().Be(JudgeVerdictProtocol.StructuredJson);
+    }
+
+    [Fact]
+    public void TheRawJudgeResponseIsRetainedIndependentlyOfEvidenceMode()
+    {
+        // Retention and rendering are different questions. Coupling them is how a later move to a
+        // shorter evidence mode would silently remove the only signal that separates a WRONG judge
+        // from an UNPARSEABLE one.
+        var options = Create();
+
+        options.RetainRawJudgeResponse.Should().BeTrue();
+        options.JudgeEvidenceMode.Should().Be(JudgeEvidenceMode.Raw);
+    }
+
+    [Fact]
+    public void EverythingElseAboutTheProtocolIsUnchanged()
+    {
+        // The 0.19 adoption must move exactly the two fields above and nothing else, or a sealed base
+        // becomes incomparable for a reason nobody wrote down.
+        var options = Create();
+
+        options.StratifiedSampling.Should().BeTrue();
+        options.RandomSeed.Should().Be(42);
+        options.MaxQuestions.Should().Be(10);
+        options.DatasetMode.Should().Be("S");
+        options.PreserveSessionBoundaries.Should().BeTrue();
+        options.IncludeTimestamps.Should().BeTrue();
+        options.JudgeFailurePolicy.Should().Be(JudgeFailurePolicy.RetryThenInconclusive);
+        options.JudgeTemperature.Should().BeNull();
+        options.JudgeMaxOutputTokens.Should().Be(256);
+        options.HistoryInjectionMode.Should().Be(HistoryInjectionMode.StructuredChatHistory);
+    }
+
+    [Fact]
+    public void DecompositionStaysOffByDefault()
+    {
+        // Per-predicate judging multiplies judge calls per question. It is worth having, but its cost
+        // must be a decision rather than something inherited from a package upgrade.
+        Create().JudgeDecompositionMode.Should().Be(JudgeDecompositionMode.None);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/LongMemEvalRunValidatorTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/LongMemEvalRunValidatorTests.cs
@@ -1,4 +1,4 @@
-using AgentEval.Memory.External.Models;
+﻿using AgentEval.Memory.External.Models;
 using AgentMemory.LongMemEval;
 using FluentAssertions;
 using Xunit;
@@ -77,8 +77,13 @@ public sealed class LongMemEvalRunValidatorTests
             questionResults: [result]);
 
         validation.Accepted.Should().BeFalse();
-        validation.Issues.Should().ContainSingle()
-            .Which.Should().Contain("q-empty-judge");
+        validation.Issues.Should().Contain(issue => issue.Contains("q-empty-judge", StringComparison.Ordinal));
+
+        // This run also has a failure and no answer-presence measurement, so it correctly reports that
+        // its failures are unattributed. Named explicitly rather than relaxing the assertion to "at
+        // least one issue": the count staying pinned is what stops a future check appearing unnoticed.
+        validation.Issues.Should().HaveCount(2);
+        validation.Issues.Should().Contain(issue => issue.Contains("unattributed", StringComparison.Ordinal));
     }
     [Fact]
     public void Validate_RejectsObservedPurposeAndExtractionCallMismatches()
@@ -212,4 +217,21 @@ public sealed class LongMemEvalRunValidatorTests
             JudgeExplanation = judgeExplanation,
             Duration = TimeSpan.FromSeconds(1)
         };
+
+    [Fact]
+    public void Validate_CleanRunWithoutPresenceData_IsNotFlagged()
+    {
+        // Gated on there being failures to ATTRIBUTE. A run that answered everything has nothing to
+        // explain, and flagging it would train readers to ignore the message -- which is how a warning
+        // stops working. A Raw-mode arm, which has no extracted memory to probe, would trip it forever.
+        var validation = LongMemEvalRunValidator.Validate(
+            questionCount: 1,
+            llmCalls: 2,
+            telemetry: [new LongMemEvalQuestionTelemetry(1, 20, 10, false)],
+            questionResults: [Result("q-1")]);
+
+        validation.Accepted.Should().BeTrue();
+        validation.Issues.Should().BeEmpty();
+    }
+
 }

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/MemoryTypeMapTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/MemoryTypeMapTests.cs
@@ -1,0 +1,75 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The task-label → memory-type mapping that every per-type figure inherits.
+/// </summary>
+public sealed class MemoryTypeMapTests
+{
+    private static readonly LongMemEvalMemoryTypeMap Map = LongMemEvalMemoryTypeMap.Default;
+
+    [Theory]
+    [InlineData("single-session-user", "semantic")]
+    [InlineData("single-session-preference", "semantic")]
+    [InlineData("multi-session", "semantic")]
+    [InlineData("single-session-assistant", "episodic")]
+    [InlineData("temporal-reasoning", "temporal")]
+    [InlineData("knowledge-update", "temporal")]
+    public void EveryDatasetTaskTypeIsMapped(string taskType, string expected)
+    {
+        // All six of LongMemEval's labels, pinned. An unmapped label silently becoming "unmapped" in a
+        // published table is the failure this covers.
+        Map.ForQuestion(taskType, isAbstention: false).Should().ContainSingle().Which.Should().Be(expected);
+    }
+
+    [Fact]
+    public void AbstentionOverridesTheTaskLabel()
+    {
+        // An _abs question is answerable only by knowing memory does NOT hold the answer, whatever its
+        // task label says it is about -- so the label must not win here.
+        Map.ForQuestion("single-session-user", isAbstention: true)
+            .Should().ContainSingle().Which.Should().Be(LongMemEvalMemoryTypeMap.MetaMemory);
+    }
+
+    [Fact]
+    public void AnUnknownLabelIsReportedRatherThanDropped()
+    {
+        // A shrinking denominator is how a metric stops adding up: an unrecognised label must appear in
+        // the output as unmapped, not vanish from the totals.
+        Map.ForQuestion("some-future-task-type", isAbstention: false)
+            .Should().ContainSingle().Which.Should().Be(LongMemEvalMemoryTypeMap.Unmapped);
+
+        Map.ForQuestion(null, isAbstention: false)
+            .Should().ContainSingle().Which.Should().Be(LongMemEvalMemoryTypeMap.Unmapped);
+    }
+
+    [Fact]
+    public void TheRevisionTravelsWithTheMapping()
+    {
+        // The mapping is an opinion and will change. A per-type number that cannot name which opinion
+        // produced it is not reproducible.
+        Map.Revision.Should().NotBeNullOrWhiteSpace();
+        Map.Revision.Should().NotBe("unknown");
+    }
+
+    [Fact]
+    public void ProceduralIsReachableFromNoTaskType()
+    {
+        // The load-bearing negative. LongMemEval-S contains no tool trajectories, so procedural memory
+        // is unreachable here AT ANY SAMPLE SIZE -- and publishing a LongMemEval number as evidence for
+        // a procedural tier is exactly the metric substitution this mapping exists to prevent.
+        var allTypes = new[]
+        {
+            "single-session-user", "single-session-preference", "multi-session",
+            "single-session-assistant", "temporal-reasoning", "knowledge-update",
+        };
+
+        allTypes.SelectMany(t => Map.ForQuestion(t, isAbstention: false))
+            .Should().NotContain("procedural");
+        Map.ForQuestion("single-session-user", isAbstention: true)
+            .Should().NotContain("procedural");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TokenCounterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TokenCounterTests.cs
@@ -1,0 +1,77 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// Exact token counting for figures that leave the repository, and an honest label when it cannot.
+/// </summary>
+public sealed class TokenCounterTests
+{
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-4o-mini")]
+    [InlineData("gpt-4")]
+    [InlineData("gpt-35-turbo")]
+    [InlineData("my-gpt-4o-deployment")]
+    public void AKnownModelCountsExactly(string modelId)
+    {
+        var counter = new LongMemEvalTokenCounter(modelId);
+
+        counter.Method.Should().Be(TokenCountMethod.Exact);
+        counter.Count("The quick brown fox jumps over the lazy dog.").Should().BeGreaterThan(0);
+    }
+
+    [Theory]
+    [InlineData("llama-3")]
+    [InlineData("some-unlabelled-deployment")]
+    [InlineData(null)]
+    public void AnUnknownModelFallsBackToTheHeuristicAndSaysSo(string? modelId)
+    {
+        // Failing soft matters: a missing vocabulary must not fail a benchmark run. Reporting the
+        // method matters more: a heuristic silently labelled exact is worse than no number at all.
+        var counter = new LongMemEvalTokenCounter(modelId);
+
+        counter.Method.Should().Be(TokenCountMethod.CharacterHeuristic);
+        counter.Encoding.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnUnknownModelNeverCountsWithTheWrongVocabulary()
+    {
+        // The failure mode this guards: quietly picking a default encoding for an unrecognised model
+        // produces a confident, wrong number -- which is the shape of error that survives review.
+        var unknown = new LongMemEvalTokenCounter("definitely-not-a-real-model");
+        var text = "The quick brown fox jumps over the lazy dog.";
+
+        unknown.Count(text).Should().Be(LongMemEvalContextSize.Estimate(text));
+    }
+
+    [Fact]
+    public void TheHeuristicAndTheExactCountActuallyDisagree()
+    {
+        // The load-bearing test for why this exists at all. If 4-chars-per-token matched a real
+        // tokenizer, none of this would be worth the dependency -- so assert they differ on ordinary
+        // English prose, which is what a published figure would be computed over.
+        const string prose =
+            "Memory systems are often evaluated end to end, which conflates retrieval quality with "
+            + "the answer model's competence. A token count is one of the few figures that cannot be "
+            + "inflated by a better model, and is therefore worth measuring precisely.";
+
+        var exact = new LongMemEvalTokenCounter("gpt-4o").Count(prose);
+        var heuristic = LongMemEvalContextSize.Estimate(prose);
+
+        exact.Should().NotBe(heuristic,
+            "if the heuristic were accurate this whole type would be unnecessary");
+        exact.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void EmptyContentIsZeroByEitherMethod()
+    {
+        new LongMemEvalTokenCounter("gpt-4o").Count("").Should().Be(0);
+        new LongMemEvalTokenCounter("gpt-4o").Count(null).Should().Be(0);
+        new LongMemEvalTokenCounter("unknown").Count("").Should().Be(0);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedBreakdownTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedBreakdownTests.cs
@@ -1,0 +1,117 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// Grouping a run by memory type rather than by task label, and attributing its failures.
+/// </summary>
+public sealed class TypedBreakdownTests
+{
+    private static LongMemEvalQuestionTelemetry Q(
+        int number, string id, string taskType, bool? present, bool checkable = true) =>
+        new(number, 20, 10, false)
+        {
+            QuestionId = id,
+            QuestionType = taskType,
+            AnswerPresence = present is null
+                ? null
+                : new LongMemEvalAnswerPresenceResult(checkable, present.Value, [], present.Value ? 1 : 0),
+        };
+
+    [Fact]
+    public void QuestionsAreGroupedByMemoryTypeNotTaskLabel()
+    {
+        // Three different task labels, one memory type. This is the whole point: the aggregate hides
+        // that episodic is a handful of questions carrying its own, very different, score.
+        var telemetry = new[]
+        {
+            Q(1, "a", "single-session-user", present: true),
+            Q(2, "b", "multi-session", present: true),
+            Q(3, "c", "single-session-preference", present: true),
+            Q(4, "d", "single-session-assistant", present: true),
+        };
+        var correct = new Dictionary<string, bool> { ["a"] = true, ["b"] = true, ["c"] = false, ["d"] = false };
+
+        var rows = LongMemEvalTypedBreakdown.Summarise(telemetry, correct);
+
+        rows.Should().Contain(r => r.MemoryType == "semantic" && r.Questions == 3 && r.Correct == 2);
+        rows.Should().Contain(r => r.MemoryType == "episodic" && r.Questions == 1 && r.Correct == 0);
+    }
+
+    [Fact]
+    public void FailuresAreSplitIntoExtractionAndRetrieval()
+    {
+        // The split that redirected this whole track: a failure whose answer was never STORED needs a
+        // different fix from one whose answer was stored and not surfaced.
+        var telemetry = new[]
+        {
+            Q(1, "stored-but-missed", "single-session-user", present: true),
+            Q(2, "never-stored", "single-session-user", present: false),
+        };
+        var correct = new Dictionary<string, bool> { ["stored-but-missed"] = false, ["never-stored"] = false };
+
+        var row = LongMemEvalTypedBreakdown.Summarise(telemetry, correct)
+            .Single(r => r.MemoryType == "semantic");
+
+        row.RetrievalFailures.Should().Be(1);
+        row.ExtractionFailures.Should().Be(1);
+    }
+
+    [Fact]
+    public void AnUncheckableAnswerIsCountedApartFromAnAbsentOne()
+    {
+        // A derived answer -- "17 fish", "$750" -- is computed from stored evidence and was never itself
+        // stored, so overlap cannot find it. Folding that into "extraction failure" would blame
+        // extraction for an answer the model got right, which is exactly what it did before.
+        var telemetry = new[] { Q(1, "derived", "multi-session", present: false, checkable: false) };
+        var correct = new Dictionary<string, bool> { ["derived"] = false };
+
+        var row = LongMemEvalTypedBreakdown.Summarise(telemetry, correct).Single();
+
+        row.Unattributable.Should().Be(1);
+        row.ExtractionFailures.Should().Be(0);
+    }
+
+    [Fact]
+    public void AbstentionQuestionsLandUnderMetaMemory()
+    {
+        var telemetry = new[] { Q(1, "q_abs", "single-session-user", present: false) };
+        var correct = new Dictionary<string, bool> { ["q_abs"] = true };
+        var abstention = new Dictionary<string, bool> { ["q_abs"] = true };
+
+        var rows = LongMemEvalTypedBreakdown.Summarise(telemetry, correct, abstention);
+
+        rows.Should().ContainSingle()
+            .Which.MemoryType.Should().Be(LongMemEvalMemoryTypeMap.MetaMemory);
+    }
+
+    [Fact]
+    public void EveryRowCarriesWhatOneQuestionIsWorth()
+    {
+        // A per-type subset is small, and a bare percentage over six questions invites exactly the
+        // comparison it cannot support. Six questions is 16.7 points each, and the row says so.
+        var telemetry = Enumerable.Range(1, 6)
+            .Select(i => Q(i, $"q{i}", "single-session-assistant", present: true)).ToArray();
+        var correct = telemetry.ToDictionary(t => t.QuestionId!, _ => true);
+
+        var row = LongMemEvalTypedBreakdown.Summarise(telemetry, correct).Single();
+
+        row.PointsPerQuestion.Should().BeApproximately(16.67, 0.01);
+        row.Accuracy.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void AQuestionWithNoJudgementIsExcludedRatherThanCountedWrong()
+    {
+        // An unjudged question is not a failure. Counting it as one would understate every arm.
+        var telemetry = new[] { Q(1, "judged", "single-session-user", present: true), Q(2, "unjudged", "single-session-user", present: true) };
+        var correct = new Dictionary<string, bool> { ["judged"] = true };
+
+        var row = LongMemEvalTypedBreakdown.Summarise(telemetry, correct).Single();
+
+        row.Questions.Should().Be(1);
+        row.Correct.Should().Be(1);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedSamplingOptionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedSamplingOptionsTests.cs
@@ -1,0 +1,90 @@
+using AgentEval.Memory.External.Models;
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The AgentEval 0.20 sampling surface, which is what makes a per-memory-type claim possible.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sampling was stratified across all six question types with only a count and a seed, so a
+/// 50-question subset yielded roughly <b>six</b> <c>single-session-assistant</c> questions — and six
+/// cannot carry a per-type claim. Type-filtered sampling is the difference between "30 episodic
+/// questions" and "50 questions of which 6 are".
+/// </para>
+/// <para>
+/// Abstention matters for the same reason in reverse: <c>_abs</c> questions are the dataset's only
+/// meta-memory signal, and across 52 recorded runs of ours <b>not one ever ran</b>.
+/// </para>
+/// </remarks>
+public sealed class TypedSamplingOptionsTests
+{
+    private static ExternalBenchmarkOptions Create(
+        IReadOnlyList<string>? types = null,
+        AbstentionSamplingPolicy abstention = AbstentionSamplingPolicy.AsSampled,
+        double? proportion = null,
+        bool suppressBoundaries = false) =>
+        LongMemEvalBenchmarkProtocol.CreateOptions(
+            "dataset.json", questions: 30, seed: 42, judgeRetryAttempts: 2,
+            LongMemEvalEvidenceDetail.Identifiers, maxRelevantMessages: 5,
+            JudgeVerdictProtocol.FreeText, types, abstention, proportion, suppressBoundaries);
+
+    [Fact]
+    public void NoTypeFilterReproducesTheStratifiedDefault()
+    {
+        // Null, not an empty list: the loader treats null as "no composition filter", and an empty list
+        // must not accidentally mean "select nothing".
+        Create().IncludeQuestionTypes.Should().BeNull();
+        Create(types: Array.Empty<string>()).IncludeQuestionTypes.Should().BeNull();
+    }
+
+    [Fact]
+    public void ARequestedTypeReachesTheSampler()
+    {
+        var options = Create(types: new[] { "single-session-assistant" });
+
+        options.IncludeQuestionTypes.Should().ContainSingle()
+            .Which.Should().Be("single-session-assistant");
+    }
+
+    [Fact]
+    public void AbstentionDefaultsToTheHistoricalBehaviour()
+    {
+        // AsSampled is what every recorded run did. Changing this default would silently alter what a
+        // sealed base contains, which is exactly the comparability break to avoid.
+        Create().AbstentionPolicy.Should().Be(AbstentionSamplingPolicy.AsSampled);
+        Create().AbstentionTargetProportion.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(AbstentionSamplingPolicy.Exclude)]
+    [InlineData(AbstentionSamplingPolicy.Only)]
+    [InlineData(AbstentionSamplingPolicy.TargetProportion)]
+    public void EveryAbstentionPolicyIsReachable(AbstentionSamplingPolicy policy)
+    {
+        Create(abstention: policy, proportion: 0.25).AbstentionPolicy.Should().Be(policy);
+    }
+
+    [Fact]
+    public void ProvenanceIsCapturedInFull()
+    {
+        // Dataset SHA-256, judge-prompt fingerprint, AgentEval version and a fingerprint of the selected
+        // question ids. Sealed-base comparability used to be checked by hand-diffing AgentEval's source
+        // between releases; this makes it mechanical.
+        Create().RunProvenanceMode.Should().Be(RunProvenanceMode.Full);
+    }
+
+    [Fact]
+    public void SyntheticBoundariesAreKeptByDefaultAndSuppressibleOnRequest()
+    {
+        // Keeping them by default is what preserves comparability with every sealed base. Being able to
+        // omit them matters because for two failing questions, 30 of 30 retrieved messages were this
+        // boilerplate -- and it read as a defect in OUR retrieval for weeks.
+        Create().SyntheticTurnMarker.Should().BeNull("null means AgentEval's historical default text");
+        Create(suppressBoundaries: true).SyntheticTurnMarker.Should().BeEmpty(
+            "an empty marker omits the synthetic turn entirely");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Neo4jMemoryContextProviderTests.cs
@@ -106,11 +106,15 @@ public sealed class Neo4jMemoryContextProviderTests
     public async Task BuildContextAsync_NoConfiguredRecallOptions_UsesDefaults()
     {
         // Existing default behavior must remain unchanged when the host does not customize recall options.
+        // The turn text carries a real question deliberately: this test is about OPTION pass-through, and
+        // it previously used "hi", which the shipped default policy now narrows to recent messages only.
+        // Asserting full defaults on a greeting would have been asserting the wrong thing about the wrong
+        // turn -- the trivial-turn path has its own coverage in ProviderEmbeddingElisionTests.
         _embeddingOrchestrator.EmbedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new float[] { 0.1f });
         _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>()).Returns(EmptyRecall("s1"));
 
         await _sut.BuildContextAsync(
-            new List<ChatMessage> { new(ChatRole.User, "hi") },
+            new List<ChatMessage> { new(ChatRole.User, "what did we decide about pricing?") },
             "s1", "c1", CancellationToken.None);
 
         await _memoryService.Received(1).RecallAsync(

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/ProviderEmbeddingElisionTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/ProviderEmbeddingElisionTests.cs
@@ -1,0 +1,116 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using AgentMemory.AgentFramework.Recall;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.AgentFramework;
+
+/// <summary>
+/// The MAF provider must not embed a query no surviving retrieval will consume.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider generates the embedding itself and hands it to the assembler, so the assembler's own
+/// gate cannot help here: narrowing categories in a policy would <b>relocate</b> the provider's call
+/// rather than remove it. This is the trap that made "task-aware recall saves the embedding" false as
+/// originally designed, and it needs its own test on this side of the boundary.
+/// </para>
+/// <para>
+/// Recent messages are session-scoped and time-ordered, so a policy narrowing a trivial turn down to
+/// them alone is the case that matters: it must cost <b>no</b> provider round trip.
+/// </para>
+/// </remarks>
+public sealed class ProviderEmbeddingElisionTests
+{
+    private readonly IMemoryService _memoryService = Substitute.For<IMemoryService>();
+    private readonly IEmbeddingOrchestrator _embeddings = Substitute.For<IEmbeddingOrchestrator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IIdGenerator _idGenerator = Substitute.For<IIdGenerator>();
+
+    public ProviderEmbeddingElisionTests()
+    {
+        _clock.UtcNow.Returns(DateTimeOffset.UtcNow);
+        _idGenerator.GenerateId().Returns(_ => Guid.NewGuid().ToString("N"));
+        _embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0.1f }));
+        _memoryService.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RecallResult
+            {
+                Context = new MemoryContext { SessionId = "s1", AssembledAtUtc = DateTimeOffset.UtcNow }
+            });
+    }
+
+    /// <summary>A policy that narrows a turn to recent messages only — no vector category survives.</summary>
+    private sealed class RecentMessagesOnlyPolicy : IAutomaticRecallPolicy
+    {
+        public ValueTask<AutomaticRecallDecision> DecideAsync(
+            AutomaticRecallContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new AutomaticRecallDecision
+            {
+                ShouldRecall = true,
+                Categories = AutomaticRecallCategories.RecentMessages,
+            });
+    }
+
+    private Neo4jMemoryContextProvider CreateSut(IAutomaticRecallPolicy? policy = null) =>
+        new(_memoryService,
+            _embeddings,
+            _clock,
+            _idGenerator,
+            Options.Create(new MemoryOptions()),
+            Options.Create(new ContextFormatOptions()),
+            Options.Create(new AgentFrameworkOptions()),
+            NullLogger<Neo4jMemoryContextProvider>.Instance,
+            recallPolicy: policy);
+
+    [Fact]
+    public async Task NarrowingToRecentMessagesOnlyCostsNoEmbeddingCall()
+    {
+        var sut = CreateSut(new RecentMessagesOnlyPolicy());
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "ok") }, "s1", "c1", CancellationToken.None);
+
+        await _embeddings.DidNotReceive()
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecallStillHappensWhenTheEmbeddingIsElided()
+    {
+        // The saving must be the embedding, NOT the recall: recent messages are still wanted, and a
+        // provider that quietly stopped recalling would look identical on the embedding assertion above.
+        var sut = CreateSut(new RecentMessagesOnlyPolicy());
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "ok") }, "s1", "c1", CancellationToken.None);
+
+        await _memoryService.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r =>
+                r.QueryEmbedding == null &&
+                r.Options!.MaxRecentMessages > 0),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TheDefaultPolicyStillEmbedsExactlyOnce()
+    {
+        // The byte-identical guarantee: ConfiguredAutomaticRecallPolicy uses Categories.All, so every
+        // vector category survives and the call happens exactly as it did before.
+        var sut = CreateSut();
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "what did we decide about pricing?") },
+            "s1", "c1", CancellationToken.None);
+
+        await _embeddings.Received(1)
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/TrivialTurnRecallPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/TrivialTurnRecallPolicyTests.cs
@@ -1,6 +1,13 @@
 using AgentMemory.AgentFramework.Recall;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.AgentFramework;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 
 namespace AgentMemory.Tests.Unit.AgentFramework.Recall;
@@ -88,5 +95,58 @@ public sealed class TrivialTurnRecallPolicyTests
         var previousDefault = await new ConfiguredAutomaticRecallPolicy().DecideAsync(ctx);
 
         mine.Should().BeEquivalentTo(previousDefault);
+    }
+}
+
+/// <summary>
+/// The DI default and the constructor default must be the same policy.
+/// </summary>
+/// <remarks>
+/// They diverged once: <c>AddAgentMemoryFramework</c> was changed to register
+/// <see cref="TrivialTurnRecallPolicy"/> while <c>Neo4jMemoryContextProvider</c>'s own constructor still
+/// fell back to <see cref="ConfiguredAutomaticRecallPolicy"/>. Everything resolved through DI got the new
+/// behaviour and everything constructed by hand — tools, tests, hosts wiring manually — silently kept the
+/// old one. It was caught by a perf run whose counters had not moved, not by any test, which is why this
+/// one exists.
+/// </remarks>
+public sealed class RecallPolicyDefaultConsistencyTests
+{
+    [Fact]
+    public async Task AHandBuiltProviderNarrowsATrivialTurnJustLikeADiBuiltOne()
+    {
+        // Asserted through BEHAVIOUR, not by comparing two type literals: the bug was that the
+        // constructor fell back to a different policy than DI registered, and only an instance built
+        // the way the perf harness builds one can prove the fallback itself changed.
+        var memory = Substitute.For<IMemoryService>();
+        var embeddings = Substitute.For<IEmbeddingOrchestrator>();
+        var clock = Substitute.For<IClock>();
+        var ids = Substitute.For<IIdGenerator>();
+
+        clock.UtcNow.Returns(DateTimeOffset.UtcNow);
+        ids.GenerateId().Returns(_ => Guid.NewGuid().ToString("N"));
+        embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0.1f }));
+        memory.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RecallResult
+            {
+                Context = new MemoryContext { SessionId = "s1", AssembledAtUtc = DateTimeOffset.UtcNow }
+            });
+
+        // No recallPolicy argument -- exactly how tools, tests and hand-wired hosts build it.
+        var sut = new Neo4jMemoryContextProvider(
+            memory, embeddings, clock, ids,
+            Options.Create(new MemoryOptions()),
+            Options.Create(new ContextFormatOptions()),
+            Options.Create(new AgentFrameworkOptions()),
+            NullLogger<Neo4jMemoryContextProvider>.Instance);
+
+        await sut.BuildContextAsync(
+            new List<ChatMessage> { new(ChatRole.User, "thanks") }, "s1", "c1", CancellationToken.None);
+
+        await memory.Received(1).RecallAsync(
+            Arg.Is<RecallRequest>(r => r.Options!.MaxFacts == 0 && r.Options.MaxRecentMessages > 0),
+            Arg.Any<CancellationToken>());
+        await embeddings.DidNotReceive()
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/TrivialTurnRecallPolicyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/Recall/TrivialTurnRecallPolicyTests.cs
@@ -1,0 +1,92 @@
+using AgentMemory.AgentFramework.Recall;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.AgentFramework.Recall;
+
+/// <summary>
+/// The shipped default policy: full recall on a real turn, recent messages only on a trivial one.
+/// </summary>
+public sealed class TrivialTurnRecallPolicyTests
+{
+    private readonly TrivialTurnRecallPolicy _sut = new();
+
+    private static AutomaticRecallContext Context(string text) => new()
+    {
+        Messages = new[] { new ChatMessage(ChatRole.User, text) },
+        SessionId = "s1",
+        ConversationId = "c1",
+    };
+
+    [Theory]
+    [InlineData("hi")]
+    [InlineData("ok, got it.")]
+    [InlineData("thanks!")]
+    [InlineData("sounds good")]
+    [InlineData("")]
+    public async Task ATrivialTurnNarrowsToRecentMessagesOnly(string text)
+    {
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.Categories.Should().Be(AutomaticRecallCategories.RecentMessages);
+    }
+
+    [Theory]
+    [InlineData("hi")]
+    [InlineData("ok, go ahead")]
+    public async Task ATrivialTurnStillRecalls_SoTheConversationIsNotLost(string text)
+    {
+        // The load-bearing distinction from a full skip. "ok, go ahead" is exactly the turn where the
+        // agent most needs the conversation so far to know what it is agreeing to, and a skip would
+        // drop RecentMessages along with everything else.
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Categories.Should().HaveFlag(AutomaticRecallCategories.RecentMessages);
+    }
+
+    [Fact]
+    public async Task ATrivialTurnExcludesEveryVectorCategory_SoTheEmbeddingIsElided()
+    {
+        // The saving depends entirely on no embedding-consuming category surviving; the assembler and
+        // the provider both gate the embedding on exactly these five.
+        var decision = await _sut.DecideAsync(Context("ok"));
+
+        decision.Categories.Should().NotHaveFlag(AutomaticRecallCategories.RelevantMessages);
+        decision.Categories.Should().NotHaveFlag(AutomaticRecallCategories.Entities);
+        decision.Categories.Should().NotHaveFlag(AutomaticRecallCategories.Facts);
+        decision.Categories.Should().NotHaveFlag(AutomaticRecallCategories.Preferences);
+        decision.Categories.Should().NotHaveFlag(AutomaticRecallCategories.ReasoningTraces);
+    }
+
+    [Theory]
+    [InlineData("what did we decide about pricing?")]
+    [InlineData("ok, so what was the deployment step again?")]
+    [InlineData("thanks — can you remind me who owns billing?")]
+    public async Task ARealTurnIsByteIdenticalToTheOldDefault(string text)
+    {
+        // Anything carrying a question must be untouched: same ShouldRecall, same Categories.All, same
+        // null intent as ConfiguredAutomaticRecallPolicy. A greeting PREFIX must not trivialise a turn.
+        var decision = await _sut.DecideAsync(Context(text));
+
+        decision.ShouldRecall.Should().BeTrue();
+        decision.Categories.Should().Be(AutomaticRecallCategories.All);
+        decision.Intent.Should().BeNull();
+        decision.RecallOptions.Should().BeNull();
+        decision.RequiresRelationCompleteness.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ARealTurnMatchesConfiguredAutomaticRecallPolicyExactly()
+    {
+        // Stated as an equivalence rather than a list of fields, so a future property added to
+        // AutomaticRecallDecision cannot drift between the old default and the new one unnoticed.
+        var ctx = Context("what did we decide about pricing?");
+
+        var mine = await _sut.DecideAsync(ctx);
+        var previousDefault = await new ConfiguredAutomaticRecallPolicy().DecideAsync(ctx);
+
+        mine.Should().BeEquivalentTo(previousDefault);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/AgentFramework/ServiceCollectionExtensionsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/AgentFramework/ServiceCollectionExtensionsTests.cs
@@ -165,15 +165,34 @@ public sealed class ServiceCollectionExtensionsTests
     // ── #88: task-aware automatic recall policy ────────────────────────────────
 
     [Fact]
-    public void AddAgentMemoryFramework_RegistersConfiguredAutomaticRecallPolicy_AsScoped_ByDefault()
+    public void AddAgentMemoryFramework_RegistersTrivialTurnRecallPolicy_AsScoped_ByDefault()
     {
+        // Default changed from ConfiguredAutomaticRecallPolicy: identical on every real turn, and
+        // recent-messages-only on a greeting/acknowledgement-only one, where recall previously cost 13
+        // Cypher queries and an embedding round trip to retrieve 10 items that need no vector.
+        // ConfiguredAutomaticRecallPolicy remains public and registerable for hosts wanting the old
+        // behaviour -- see AddAgentMemoryFramework_HostCanRestoreTheAlwaysRecallDefault below.
         var services = BuildBaseServices();
         services.AddAgentMemoryFramework();
 
         services.Should().ContainSingle(d =>
             d.ServiceType == typeof(IAutomaticRecallPolicy) &&
-            d.ImplementationType == typeof(ConfiguredAutomaticRecallPolicy) &&
+            d.ImplementationType == typeof(TrivialTurnRecallPolicy) &&
             d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddAgentMemoryFramework_HostCanRestoreTheAlwaysRecallDefault()
+    {
+        // The documented escape hatch for the default change. Registering before the call wins via
+        // TryAdd, so a host pinned to pre-existing behaviour has a one-line, supported route back.
+        var services = BuildBaseServices();
+        services.AddScoped<IAutomaticRecallPolicy, ConfiguredAutomaticRecallPolicy>();
+        services.AddAgentMemoryFramework();
+
+        using var scope = services.BuildServiceProvider().CreateScope();
+        scope.ServiceProvider.GetRequiredService<IAutomaticRecallPolicy>()
+            .Should().BeOfType<ConfiguredAutomaticRecallPolicy>();
     }
 
     [Fact]
@@ -186,7 +205,7 @@ public sealed class ServiceCollectionExtensionsTests
         using var scope = provider.CreateScope();
         var sut = scope.ServiceProvider.GetRequiredService<IAutomaticRecallPolicy>();
 
-        sut.Should().BeOfType<ConfiguredAutomaticRecallPolicy>();
+        sut.Should().BeOfType<TrivialTurnRecallPolicy>();
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Cli/PerfScenarioCatalogTests.cs
@@ -1,4 +1,4 @@
-using AgentMemory.Cli.Perf;
+﻿using AgentMemory.Cli.Perf;
 using FluentAssertions;
 
 namespace AgentMemory.Tests.Unit.Cli;
@@ -310,4 +310,29 @@ public sealed class PerfScenarioCatalogTests
     }
 
 
+
+    [Fact]
+    public void Catalog_ContainsTrivialTurnScenario_AsTheMeasurementForTaskAwareRecall()
+    {
+        // PERF-R-01 is the full-recall CONTROL; this is the narrowed path it is contrasted against.
+        // Both must exist: without R-09 task-aware recall ships with no counter behind it, and without
+        // R-01 there is nothing to contrast it with.
+        var scenario = PerfScenarios.All.Single(item => item.Id == "PERF-R-09");
+
+        scenario.Description.Should().ContainEquivalentOf("trivial");
+        scenario.Description.Should().ContainEquivalentOf("recent messages");
+        scenario.SupportsInterleavedAb.Should().BeTrue(
+            "the trivial-turn scenario is read-only and shares no mutable state between A/B arms");
+        scenario.IncludeInDefaultRun.Should().BeTrue(
+            "it must run in CI, or the saving it measures can regress unobserved");
+    }
+
+    [Fact]
+    public void Select_TrivialTurnScenario_ReturnsOnlyThatScenario()
+    {
+        var selected = PerfScenarios.Select("PERF-R-09");
+
+        selected.Should().ContainSingle();
+        selected[0].Id.Should().Be("PERF-R-09");
+    }
 }

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
@@ -19,7 +19,7 @@ public sealed class AbstractionsContractGuardTests
     private const int DocumentedServiceInterfaces = 41; // +IMultiSessionUnifiedMemoryExtractor (M-27-V2 LAB-B1)
     private const int DocumentedRepositoryInterfaces = 11;
     private const int DocumentedDomainRecords = 52; // +MemoryContextSectionDiagnostics (PLAN 4.1)
-    private const int DocumentedEnums = 26; // +TemporalValidityMode (prospective memory: fills valid_from/valid_until, which had substrate but no writer; Ignore preserves prior prompts byte-for-byte). // +AssistantContentMode (L3b: what extraction does with assistant turns — Ignore preserves prior behaviour byte-for-byte). // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType, +MemoryNodeKind, +MemoryOperationAccess, +MemoryIsolationMode (#100); +IngestionStatus, +IngestionStage, +IngestionItemStatus, +MemoryItemKind, +IngestionFailureMode (#101); +MemoryTrustLevel (#92 Phase 3)
+    private const int DocumentedEnums = 27; // +ValidTimeMode (PLAN 1.1)
 
     private static IEnumerable<Type> PublicTypes() =>
         Abstractions.GetTypes().Where(t => t.IsPublic);

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/AbstractionsContractGuardTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Xml.Linq;
 using FluentAssertions;
 using AgentMemory.Abstractions.Services;
@@ -18,7 +18,7 @@ public sealed class AbstractionsContractGuardTests
     // Counts mirrored in docs/architecture.md §3.1 and docs/design.md §5/§6.
     private const int DocumentedServiceInterfaces = 41; // +IMultiSessionUnifiedMemoryExtractor (M-27-V2 LAB-B1)
     private const int DocumentedRepositoryInterfaces = 11;
-    private const int DocumentedDomainRecords = 51; // +UnifiedExtractionResult (M-27-V2 LAB-U1)
+    private const int DocumentedDomainRecords = 52; // +MemoryContextSectionDiagnostics (PLAN 4.1)
     private const int DocumentedEnums = 26; // +TemporalValidityMode (prospective memory: fills valid_from/valid_until, which had substrate but no writer; Ignore preserves prior prompts byte-for-byte). // +AssistantContentMode (L3b: what extraction does with assistant turns — Ignore preserves prior behaviour byte-for-byte). // +MemoryProfile, +RankingIntent, +DuplicateStatus, +EntityMatchType, +MemoryNodeKind, +MemoryOperationAccess, +MemoryIsolationMode (#100); +IngestionStatus, +IngestionStage, +IngestionItemStatus, +MemoryItemKind, +IngestionFailureMode (#101); +MemoryTrustLevel (#92 Phase 3)
 
     private static IEnumerable<Type> PublicTypes() =>

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/Neo4jTransactionRunnerTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/Neo4jTransactionRunnerTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using AgentMemory.Abstractions.Diagnostics;
@@ -213,7 +213,7 @@ public sealed class Neo4jTransactionRunnerTests
         var session = Substitute.For<IAsyncSession>();
         var transaction = Substitute.For<IAsyncTransaction>();
         factory.OpenSession(AccessMode.Write).Returns(session);
-        session.BeginTransactionAsync().Returns(transaction);
+        session.BeginTransactionAsync(Arg.Any<Action<TransactionConfigBuilder>?>()).Returns(transaction);
 
         var result = await runner.ExecuteAtomicWriteAsync(async cancellationToken =>
         {
@@ -232,7 +232,8 @@ public sealed class Neo4jTransactionRunnerTests
 
         result.Should().Be(42);
         factory.Received(1).OpenSession(AccessMode.Write);
-        await session.Received(1).BeginTransactionAsync();
+        // Null config == the no-argument form; the runner always takes the config-taking overload now.
+        await session.Received(1).BeginTransactionAsync(null);
         await transaction.Received(1).CommitAsync();
         await transaction.DidNotReceive().RollbackAsync();
         await session.DidNotReceive().ExecuteWriteAsync(Arg.Any<Func<IAsyncQueryRunner, Task<int>>>());
@@ -246,7 +247,7 @@ public sealed class Neo4jTransactionRunnerTests
         var session = Substitute.For<IAsyncSession>();
         var transaction = Substitute.For<IAsyncTransaction>();
         factory.OpenSession(AccessMode.Write).Returns(session);
-        session.BeginTransactionAsync().Returns(transaction);
+        session.BeginTransactionAsync(Arg.Any<Action<TransactionConfigBuilder>?>()).Returns(transaction);
 
         var act = async () => await runner.ExecuteAtomicWriteAsync<int>(async cancellationToken =>
         {

--- a/tests/AgentMemory.Tests.Unit/Infrastructure/TransactionTimeoutTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Infrastructure/TransactionTimeoutTests.cs
@@ -1,0 +1,156 @@
+﻿using AgentMemory.Neo4j.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Neo4j.Driver;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Infrastructure;
+
+/// <summary>
+/// A configured transaction deadline must reach <b>every</b> transaction entry point.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing bounded a query before this. The Neo4j driver takes no <see cref="CancellationToken"/> on
+/// its transaction APIs, so an in-flight query cannot be interrupted from this side — cooperative
+/// cancellation only checks <em>before</em> work starts. A server-enforced timeout is the only thing
+/// that actually bounds one.
+/// </para>
+/// <para>
+/// <b>Why each path gets its own test.</b> There are three entry points — managed read, managed write,
+/// and the explicit atomic write used by fused persistence — and covering two of three would be worse
+/// than covering none: the uncovered one is the longest-running write in the system, and an operator
+/// who set a timeout would reasonably believe it applied everywhere.
+/// </para>
+/// </remarks>
+public sealed class TransactionTimeoutTests
+{
+    private readonly INeo4jSessionFactory _factory = Substitute.For<INeo4jSessionFactory>();
+    private readonly IAsyncSession _session = Substitute.For<IAsyncSession>();
+
+    public TransactionTimeoutTests()
+    {
+        _factory.OpenSession(Arg.Any<AccessMode>()).Returns(_session);
+    }
+
+    private Neo4jTransactionRunner CreateSut(TimeSpan? timeout) =>
+        new(_factory,
+            NullLogger<Neo4jTransactionRunner>.Instance,
+            Options.Create(new Neo4jOptions { TransactionTimeout = timeout }));
+
+    [Fact]
+    public async Task ReadWithNoTimeoutConfigured_PassesNullConfig_ByteIdenticalToBefore()
+    {
+        // The byte-identical guarantee for every existing deployment: an unconfigured runner must emit
+        // exactly the driver call it emitted before this option existed.
+        _session.ExecuteReadAsync(
+                Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), Arg.Any<Action<TransactionConfigBuilder>?>())
+            .Returns(Task.FromResult(7));
+
+        var result = await CreateSut(timeout: null).ReadAsync(_ => Task.FromResult(7));
+
+        result.Should().Be(7);
+        await _session.Received(1).ExecuteReadAsync(
+            Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), null);
+    }
+
+    [Fact]
+    public async Task ReadWithTimeoutConfigured_PassesTransactionConfigToTheDriver()
+    {
+        _session.ExecuteReadAsync(
+                Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), Arg.Any<Action<TransactionConfigBuilder>>())
+            .Returns(Task.FromResult(7));
+
+        await CreateSut(TimeSpan.FromSeconds(5)).ReadAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).ExecuteReadAsync(
+            Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(),
+            Arg.Is<Action<TransactionConfigBuilder>?>(c => c != null));
+    }
+
+    [Fact]
+    public async Task WriteWithTimeoutConfigured_PassesTransactionConfigToTheDriver()
+    {
+        _session.ExecuteWriteAsync(
+                Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), Arg.Any<Action<TransactionConfigBuilder>>())
+            .Returns(Task.FromResult(7));
+
+        await CreateSut(TimeSpan.FromSeconds(5)).WriteAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).ExecuteWriteAsync(
+            Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(),
+            Arg.Is<Action<TransactionConfigBuilder>?>(c => c != null));
+    }
+
+    [Fact]
+    public async Task WriteWithNoTimeoutConfigured_PassesNullConfig_ByteIdenticalToBefore()
+    {
+        _session.ExecuteWriteAsync(
+                Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), Arg.Any<Action<TransactionConfigBuilder>?>())
+            .Returns(Task.FromResult(7));
+
+        await CreateSut(timeout: null).WriteAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).ExecuteWriteAsync(
+            Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), null);
+    }
+
+    [Fact]
+    public async Task TheAtomicWritePathIsCoveredToo()
+    {
+        // The path fused persistence takes. It begins an EXPLICIT transaction rather than a managed one,
+        // so it needed wiring of its own -- and it is the longest-running write in the system, i.e. the
+        // one an operator most needs bounded.
+        var transaction = Substitute.For<IAsyncTransaction>();
+        _session.BeginTransactionAsync(Arg.Any<Action<TransactionConfigBuilder>?>())
+            .Returns(Task.FromResult(transaction));
+
+        await CreateSut(TimeSpan.FromSeconds(5))
+            .ExecuteAtomicWriteAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).BeginTransactionAsync(
+            Arg.Is<Action<TransactionConfigBuilder>?>(c => c != null));
+    }
+
+    [Fact]
+    public async Task TheAtomicWritePathIsUnchangedWhenNoTimeoutIsConfigured()
+    {
+        var transaction = Substitute.For<IAsyncTransaction>();
+        _session.BeginTransactionAsync(Arg.Any<Action<TransactionConfigBuilder>?>())
+            .Returns(Task.FromResult(transaction));
+
+        await CreateSut(timeout: null).ExecuteAtomicWriteAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).BeginTransactionAsync(null);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task ANonPositiveTimeoutDegradesToNoDeadline_NeverToAZeroOne(int seconds)
+    {
+        // Defence in depth behind the startup validator: if a non-positive value ever reaches the
+        // runner it must degrade to today's behaviour, never be handed to the driver as a deadline --
+        // a zero deadline would fail every query instantly.
+        //
+        // The first version of this test asserted only that the runner constructed. That passes against
+        // a runner that hands 0 straight to the driver, i.e. against the exact bug it names.
+        _session.ExecuteReadAsync(
+                Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), Arg.Any<Action<TransactionConfigBuilder>?>())
+            .Returns(Task.FromResult(7));
+
+        await CreateSut(TimeSpan.FromSeconds(seconds)).ReadAsync(_ => Task.FromResult(7));
+
+        await _session.Received(1).ExecuteReadAsync(
+            Arg.Any<Func<IAsyncQueryRunner, Task<int>>>(), null);
+    }
+
+    [Fact]
+    public void TheOptionDefaultsToNull()
+    {
+        new Neo4jOptions().TransactionTimeout.Should().BeNull(
+            "no deadline is today's behaviour, and the right value depends on deployment shape");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/McpServer/ReasoningToolOwnerScopingTests.cs
+++ b/tests/AgentMemory.Tests.Unit/McpServer/ReasoningToolOwnerScopingTests.cs
@@ -1,0 +1,62 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.McpServer;
+using AgentMemory.McpServer.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.McpServer;
+
+/// <summary>
+/// An MCP-started reasoning trace must carry the caller's owner, like every other tenant-facing tool.
+/// </summary>
+/// <remarks>
+/// <c>memory_start_trace</c> passed no owner at all, so the trace went to the shared/global bucket —
+/// while <c>MemoryQueryFacade</c> READS traces through the ambient owner context. The result was an
+/// isolation asymmetry in which a trace written by one tenant could be invisible to that same tenant
+/// on recall, and visible to every other one.
+/// </remarks>
+public sealed class ReasoningToolOwnerScopingTests
+{
+    private readonly IReasoningMemoryService _reasoning = Substitute.For<IReasoningMemoryService>();
+
+    private static readonly IOptions<AgentMemoryMcpOptions> Options =
+        Microsoft.Extensions.Options.Options.Create(new AgentMemoryMcpOptions());
+
+    public ReasoningToolOwnerScopingTests()
+    {
+        _reasoning.StartTraceAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float[]?>(),
+                Arg.Any<IReadOnlyDictionary<string, object>?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ReasoningTrace
+            {
+                TraceId = "t1", SessionId = "s1", Task = "task", StartedAtUtc = DateTimeOffset.UnixEpoch,
+            }));
+    }
+
+    [Fact]
+    public async Task TheCallersUserIdBecomesTheTraceOwner()
+    {
+        await ReasoningTools.MemoryStartTrace(
+            _reasoning, Options, task: "solve it", sessionId: "s1", userId: "tenant-a");
+
+        await _reasoning.Received(1).StartTraceAsync(
+            "s1", "solve it", Arg.Any<float[]?>(), Arg.Any<IReadOnlyDictionary<string, object>?>(),
+            "tenant-a", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AnOmittedUserIdStillMeansSharedRatherThanThrowing()
+    {
+        // Single-tenant hosts pass no user id and must keep working: null flows to the isolation
+        // policy, which decides. The tool must not invent an owner of its own.
+        await ReasoningTools.MemoryStartTrace(
+            _reasoning, Options, task: "solve it", sessionId: "s1");
+
+        await _reasoning.Received(1).StartTraceAsync(
+            "s1", "solve it", Arg.Any<float[]?>(), Arg.Any<IReadOnlyDictionary<string, object>?>(),
+            null, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/InstrumentedMemoryServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using FluentAssertions;
 using AgentMemory.Abstractions.Domain;
@@ -355,7 +355,12 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
 
         var activity = _capturedActivities.Should().ContainSingle(
             a => a.OperationName == "memory.extract_from_session").Subject;
-        activity.GetTagItem("memory.user_id").Should().Be("alice");
+
+        // Default changed: a tenant identifier is tenant data in a trace backend, so the owner
+        // DIMENSION is emitted as a boolean and the VALUE only when a host opts in. See
+        // TelemetryOwnerPrivacyTests for the opt-in path.
+        activity.GetTagItem("memory.user_id").Should().BeNull();
+        activity.GetTagItem("memory.owner_scoped").Should().Be(true);
     }
 
     [Fact]
@@ -369,6 +374,8 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
         var activity = _capturedActivities.Should().ContainSingle(
             a => a.OperationName == "memory.extract_from_session").Subject;
         activity.GetTagItem("memory.user_id").Should().BeNull("a shared/global turn must not emit an owner tag");
+        activity.GetTagItem("memory.owner_scoped").Should().Be(false,
+            "the dimension is still reported -- false distinguishes an unscoped turn from an unmeasured one");
     }
 
     [Fact]
@@ -381,7 +388,8 @@ public sealed class InstrumentedMemoryServiceTests : IDisposable
 
         var activity = _capturedActivities.Should().ContainSingle(
             a => a.OperationName == "memory.extract_from_conversation").Subject;
-        activity.GetTagItem("memory.user_id").Should().Be("bob");
+        activity.GetTagItem("memory.user_id").Should().BeNull();
+        activity.GetTagItem("memory.owner_scoped").Should().Be(true);
     }
 
     [Fact]

--- a/tests/AgentMemory.Tests.Unit/Observability/RecallMissMetricsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/RecallMissMetricsTests.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics.Metrics;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Observability;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Observability;
+
+/// <summary>
+/// A recall that came back with nothing must leave a record.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The misses are the roadmap, and nothing recorded them.</b> A <c>:MemoryReadAudit</c> row is
+/// created inside <c>MATCH (n:{label} {id: $id})</c>, so a row exists only for a <b>hit</b>. There was
+/// no record anywhere that an owner asked and memory had nothing.
+/// </para>
+/// <para>
+/// A counter, not a stored node: a node per miss grows without bound on exactly the workload that
+/// produces the most misses.
+/// </para>
+/// </remarks>
+[Collection("Observability")]
+public sealed class RecallMissMetricsTests
+{
+    private static MemoryContextSection<T> Section<T>(
+        bool searched, int limit, int returned, IReadOnlyList<T> items) =>
+        new()
+        {
+            Items = items,
+            Diagnostics = new MemoryContextSectionDiagnostics(searched, limit, returned, null, null, 0.7),
+        };
+
+    private static (IMemoryService Sut, List<(string Name, long Value, string? Category)> Measurements, MeterListener Listener)
+        Create(MemoryContext context)
+    {
+        var inner = Substitute.For<IMemoryService>();
+        inner.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RecallResult { Context = context });
+
+        var measurements = new List<(string, long, string?)>();
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name.StartsWith("memory.recall.section.", StringComparison.Ordinal))
+                    l.EnableMeasurementEvents(instrument);
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            string? category = null;
+            foreach (var tag in tags)
+                if (tag.Key == "memory.category") category = tag.Value?.ToString();
+            measurements.Add((instrument.Name, value, category));
+        });
+        listener.Start();
+
+        return (new InstrumentedMemoryService(inner, new MemoryMetrics()), measurements, listener);
+    }
+
+    [Fact]
+    public async Task ASearchedButEmptyFactSectionIsCounted()
+    {
+        var context = new MemoryContext
+        {
+            SessionId = "s1",
+            AssembledAtUtc = DateTimeOffset.UnixEpoch,
+            RelevantFacts = Section(searched: true, limit: 10, returned: 0, Array.Empty<Fact>()),
+        };
+
+        var (sut, measurements, listener) = Create(context);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "q" });
+            listener.RecordObservableInstruments();
+        }
+
+        measurements.Should().Contain(m =>
+            m.Name == "memory.recall.section.empty" && m.Category == "facts" && m.Value == 1);
+    }
+
+    [Fact]
+    public async Task ASectionThatWasNeverSearchedIsNotCountedAsAMiss()
+    {
+        // The distinction the whole instrument exists for. A section excluded by a recall policy says
+        // nothing about the store, and counting it would inflate the miss rate with turns that never
+        // asked -- which would make the metric actively misleading rather than merely incomplete.
+        var context = new MemoryContext
+        {
+            SessionId = "s1",
+            AssembledAtUtc = DateTimeOffset.UnixEpoch,
+            RelevantFacts = Section(searched: false, limit: 0, returned: 0, Array.Empty<Fact>()),
+        };
+
+        var (sut, measurements, listener) = Create(context);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "q" });
+        }
+
+        measurements.Should().NotContain(m => m.Category == "facts");
+    }
+
+    [Fact]
+    public async Task NothingIsEmittedWithoutDiagnostics()
+    {
+        // Diagnostics are off by default. Emitting a guess would be worse than emitting nothing:
+        // "empty" and "never searched" are different, and only the diagnostics can tell them apart.
+        var context = new MemoryContext
+        {
+            SessionId = "s1",
+            AssembledAtUtc = DateTimeOffset.UnixEpoch,
+        };
+
+        var (sut, measurements, listener) = Create(context);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "q" });
+        }
+
+        measurements.Should().BeEmpty();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Observability/TelemetryOwnerPrivacyTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Observability/TelemetryOwnerPrivacyTests.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Observability;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Observability;
+
+/// <summary>
+/// A tenant identifier must not reach telemetry unless the host asks for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A trace backend is usually less access-controlled than the database the value came from, retained
+/// on a different schedule, and often exported to a third party. The rest of this codebase already
+/// takes that position: every owner-scoped vector search tags <c>memory.vector.owner_scoped</c> as a
+/// <b>boolean</b>, never the identifier.
+/// </para>
+/// <para>
+/// The observability decorator was the one place that did the opposite, emitting
+/// <c>memory.user_id</c> unconditionally.
+/// </para>
+/// </remarks>
+[Collection("Observability")]
+public sealed class TelemetryOwnerPrivacyTests
+{
+    private static (IMemoryService Sut, List<Activity> Activities, IDisposable Listener) Create(
+        bool includeOwnerId)
+    {
+        var inner = Substitute.For<IMemoryService>();
+        inner.RecallAsync(Arg.Any<RecallRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RecallResult
+            {
+                Context = new MemoryContext { SessionId = "s1", AssembledAtUtc = DateTimeOffset.UnixEpoch },
+            });
+
+        var activities = new List<Activity>();
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == MemoryActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var sut = new InstrumentedMemoryService(
+            inner,
+            new MemoryMetrics(),
+            extractionOptions: null,
+            observabilityOptions: Options.Create(new ObservabilityOptions
+            {
+                IncludeOwnerIdInTelemetry = includeOwnerId,
+            }));
+
+        return (sut, activities, listener);
+    }
+
+    [Fact]
+    public async Task ByDefaultTheRawOwnerIdNeverReachesASpanTag()
+    {
+        var (sut, activities, listener) = Create(includeOwnerId: false);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest
+            {
+                SessionId = "s1",
+                Query = "q",
+                UserId = "tenant-secret-42",
+            });
+        }
+
+        activities.Should().NotBeEmpty();
+        activities.SelectMany(a => a.TagObjects)
+            .Should().NotContain(tag => Equals(tag.Value, "tenant-secret-42"),
+                "a tenant identifier in a trace is tenant data in a less access-controlled system");
+    }
+
+    [Fact]
+    public async Task ByDefaultTheOwnerDimensionIsStillObservableAsABoolean()
+    {
+        // Removing the value must not remove the signal: an operator still needs to tell a scoped
+        // operation from an unscoped one, which is the actual diagnostic question.
+        var (sut, activities, listener) = Create(includeOwnerId: false);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "q", UserId = "tenant-a" });
+        }
+
+        // TagObjects, not Tags: Activity.Tags surfaces only string-valued tags, and this one is a bool
+        // -- deliberately, matching memory.vector.owner_scoped elsewhere in the codebase.
+        activities.SelectMany(a => a.TagObjects)
+            .Should().Contain(tag => tag.Key == "memory.owner_scoped" && Equals(tag.Value, true));
+    }
+
+    [Fact]
+    public async Task AHostThatOptsInStillGetsTheIdentifier()
+    {
+        // Deliberately still reachable. Some hosts correlate traces by user and have decided their
+        // identifier is safe to export; the point is that it is now a decision, not a default.
+        var (sut, activities, listener) = Create(includeOwnerId: true);
+        using (listener)
+        {
+            await sut.RecallAsync(new RecallRequest { SessionId = "s1", Query = "q", UserId = "tenant-a" });
+        }
+
+        activities.SelectMany(a => a.TagObjects)
+            .Should().Contain(tag => tag.Key == "memory.user_id" && Equals(tag.Value, "tenant-a"));
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using AgentMemory.Neo4j.Queries;
 
 namespace AgentMemory.Tests.Unit.Queries;
@@ -15,7 +15,16 @@ public sealed class ScopedVectorSearchQueryTests
 {
     public static IEnumerable<object[]> AllSearchByVector()
     {
-        yield return new object[] { "Fact", (Func<bool, bool, int, bool, string>)FactQueries.SearchByVector, "fact_embedding_idx" };
+        // Fact's SearchByVector gained a valid-time parameter; adapt it to the shared shape so this
+        // scoping contract still covers all three. The gate is off here on purpose -- these tests are
+        // about OWNER scoping, and ValidTimeGateQueryTests covers the new clause.
+        yield return new object[]
+        {
+            "Fact",
+            (Func<bool, bool, int, bool, string>)((owner, shared, topK, rerank) =>
+                FactQueries.SearchByVector(owner, shared, topK, rerank)),
+            "fact_embedding_idx",
+        };
         yield return new object[] { "Entity", (Func<bool, bool, int, bool, string>)EntityQueries.SearchByVector, "entity_embedding_idx" };
         yield return new object[] { "Preference", (Func<bool, bool, int, bool, string>)PreferenceQueries.SearchByVector, "preference_embedding_idx" };
     }

--- a/tests/AgentMemory.Tests.Unit/Queries/ValidTimeGateQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/ValidTimeGateQueryTests.cs
@@ -1,0 +1,80 @@
+using AgentMemory.Neo4j.Queries;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Queries;
+
+/// <summary>
+/// Live fact recall must be able to honour a fact's valid-time window — on <b>both</b> live paths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>valid_from</c>/<c>valid_until</c> persist, are writable through the public API, and the
+/// point-in-time path already filters on them. Live recall did not: it filtered on similarity,
+/// <c>invalidated_at</c> and owner, and nothing else. So a fact valid from six months hence was
+/// returned <i>today</i>, and a fact whose <c>valid_until</c> had passed was returned <b>forever</b>.
+/// </para>
+/// <para>
+/// The gap stopped being inert in 1.4.0, which shipped <c>TemporalValidityMode.Extract</c> — the
+/// writer it had been waiting for.
+/// </para>
+/// </remarks>
+public sealed class ValidTimeGateQueryTests
+{
+    [Fact]
+    public void TheIndexedPathIsUnchangedWhenTheGateIsOff()
+    {
+        // The byte-identical guarantee. Default is Ignore, so no deployment silently recalls less.
+        var gated = FactQueries.SearchByVector(true, true, 60, false, currentValidTime: false);
+
+        gated.Should().NotContain("valid_from");
+        gated.Should().NotContain("valid_until");
+    }
+
+    [Fact]
+    public void TheIndexedPathGatesOnValidTimeWhenAsked()
+    {
+        var gated = FactQueries.SearchByVector(true, true, 60, false, currentValidTime: true);
+
+        gated.Should().Contain("node.valid_from IS NULL OR node.valid_from <= datetime($now)");
+        gated.Should().Contain("node.valid_until IS NULL OR node.valid_until > datetime($now)");
+    }
+
+    [Fact]
+    public void TheOwnerScopedFallbackIsUnchangedWhenTheGateIsOff()
+    {
+        var ungated = FactQueries.SearchByVectorOwnerScopedFallback(true, currentValidTime: false);
+
+        ungated.Should().NotContain("valid_from");
+        ungated.Should().NotContain("valid_until");
+    }
+
+    [Fact]
+    public void TheOwnerScopedFallbackGatesTooWhenAsked()
+    {
+        // The path every prior analysis of this gap predates -- it did not exist before 1.4.1. Gating
+        // only the indexed query would leave valid time silently bypassed for exactly the starved
+        // multi-tenant owners this fallback was added to rescue, which is the worst possible subset to
+        // miss: the ones already receiving the least.
+        var gated = FactQueries.SearchByVectorOwnerScopedFallback(true, currentValidTime: true);
+
+        gated.Should().Contain("f.valid_from  IS NULL OR f.valid_from  <= datetime($now)");
+        gated.Should().Contain("f.valid_until IS NULL OR f.valid_until >  datetime($now)");
+    }
+
+    [Fact]
+    public void BothPathsUseTheSameClauseShapeAsThePointInTimePath()
+    {
+        // Copied verbatim from TemporalQueries rather than re-derived, so the two clocks cannot drift.
+        // NULL means "unbounded", never "excluded" -- a fact with no window is always current, which is
+        // what keeps the gate inert over a corpus whose facts carry no validity bounds.
+        var indexed = FactQueries.SearchByVector(false, true, 60, false, currentValidTime: true);
+        var fallback = FactQueries.SearchByVectorOwnerScopedFallback(true, currentValidTime: true);
+
+        foreach (var cypher in new[] { indexed, fallback })
+        {
+            cypher.Should().Contain("IS NULL OR");
+            cypher.Should().Contain("datetime($now)");
+        }
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/RecallEmbeddingElisionTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/RecallEmbeddingElisionTests.cs
@@ -1,0 +1,198 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// The query embedding must not be generated when no retrieval that needs one will run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A task-aware recall policy narrows a turn by zeroing the per-category <c>MaxX</c> limits, and every
+/// vector search is already gated on its own limit. The <b>embedding was not</b>: it was generated
+/// unconditionally whenever <c>includeMemory</c> held, so narrowing a turn down to recent messages
+/// alone still paid for a provider round trip whose result nothing then read.
+/// </para>
+/// <para>
+/// That cost is the largest single stage of a remote-shaped recall (~120 ms), so a policy that skips
+/// categories to save work was <b>relocating</b> the call rather than eliminating it. Gating it in the
+/// assembler — rather than in one caller — also covers the Semantic Kernel adapter, the CLI and the
+/// facade, which reach this same method.
+/// </para>
+/// <para>
+/// <b>Byte-identical at defaults.</b> Every shipped <c>RecallOptions</c> default leaves at least one
+/// vector limit nonzero, so the gate is true and the call happens exactly as before. The tests below
+/// assert that direction too: eliding an embedding a search then needed would turn a cost saving into
+/// silent recall loss.
+/// </para>
+/// </remarks>
+public sealed class RecallEmbeddingElisionTests
+{
+    private readonly IShortTermMemoryService _shortTerm = Substitute.For<IShortTermMemoryService>();
+    private readonly ILongTermMemoryService _longTerm = Substitute.For<ILongTermMemoryService>();
+    private readonly IReasoningMemoryService _reasoning = Substitute.For<IReasoningMemoryService>();
+    private readonly IEmbeddingOrchestrator _embeddings = Substitute.For<IEmbeddingOrchestrator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    private static readonly IMemoryIsolationPolicy SingleTenant =
+        new DefaultMemoryIsolationPolicy(
+            Options.Create(new MemoryIsolationOptions()),
+            NullLogger<DefaultMemoryIsolationPolicy>.Instance);
+
+    public RecallEmbeddingElisionTests()
+    {
+        _clock.UtcNow.Returns(new DateTimeOffset(2026, 8, 11, 12, 0, 0, TimeSpan.Zero));
+
+        _embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[8]));
+
+        _shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _shortTerm.GetRecentMessagesAsOfAsync(
+                Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _shortTerm.SearchMessagesAsync(
+                Arg.Any<string?>(), Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _longTerm.SearchEntitiesAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Entity>>(Array.Empty<Entity>()));
+        _longTerm.SearchPreferencesAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Preference>>(Array.Empty<Preference>()));
+        _longTerm.SearchFactsAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>()));
+        _reasoning.SearchSimilarTracesAsync(
+                Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(Array.Empty<ReasoningTrace>()));
+    }
+
+    private MemoryContextAssembler CreateSut() =>
+        new(_shortTerm, _longTerm, _reasoning, null, _embeddings, _clock,
+            Options.Create(new MemoryOptions()),
+            NullLogger<MemoryContextAssembler>.Instance, SingleTenant);
+
+    /// <summary>Recent messages are session-scoped and time-ordered — they need no vector at all.</summary>
+    private static RecallOptions RecentMessagesOnly() => new()
+    {
+        MaxRecentMessages = 10,
+        MaxRelevantMessages = 0,
+        MaxEntities = 0,
+        MaxPreferences = 0,
+        MaxFacts = 0,
+        MaxTraces = 0,
+        MaxGraphRagItems = 0,
+    };
+
+    [Fact]
+    public async Task NoEmbeddingIsGeneratedWhenEveryVectorCategoryIsExcluded()
+    {
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "hi",
+            Options = RecentMessagesOnly(),
+        });
+
+        await _embeddings.DidNotReceive()
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NoEmbeddingIsGeneratedOnTheAsOfPathEither()
+    {
+        // Two recall paths have already diverged on one option before (SuccessfulTracesOnly is passed
+        // live and hardcoded null as-of), so the as-of path gets its own assertion rather than an
+        // assumption that it mirrors the live one.
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsOfAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "hi",
+            Options = RecentMessagesOnly(),
+        }, _clock.UtcNow, _clock.UtcNow);
+
+        await _embeddings.DidNotReceive()
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(nameof(RecallOptions.MaxRelevantMessages))]
+    [InlineData(nameof(RecallOptions.MaxEntities))]
+    [InlineData(nameof(RecallOptions.MaxPreferences))]
+    [InlineData(nameof(RecallOptions.MaxFacts))]
+    [InlineData(nameof(RecallOptions.MaxTraces))]
+    public async Task AnySurvivingVectorCategoryStillGeneratesTheEmbedding(string category)
+    {
+        // The direction that matters most: eliding an embedding a search then needs would convert a
+        // cost saving into silent recall loss. One case per category, so a future edit cannot drop
+        // one of them from the gate without a red test.
+        var options = category switch
+        {
+            nameof(RecallOptions.MaxRelevantMessages) => RecentMessagesOnly() with { MaxRelevantMessages = 5 },
+            nameof(RecallOptions.MaxEntities) => RecentMessagesOnly() with { MaxEntities = 5 },
+            nameof(RecallOptions.MaxPreferences) => RecentMessagesOnly() with { MaxPreferences = 5 },
+            nameof(RecallOptions.MaxFacts) => RecentMessagesOnly() with { MaxFacts = 5 },
+            nameof(RecallOptions.MaxTraces) => RecentMessagesOnly() with { MaxTraces = 5 },
+            _ => throw new ArgumentOutOfRangeException(nameof(category)),
+        };
+
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "what did we decide",
+            Options = options,
+        });
+
+        await _embeddings.Received(1)
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShippedDefaultsAreUnchangedAndStillEmbedExactlyOnce()
+    {
+        // The byte-identical guarantee for every existing host: no shipped default excludes all five
+        // vector categories, so the gate is true and the call happens exactly as it did before.
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "what did we decide",
+            Options = RecallOptions.Default,
+        });
+
+        await _embeddings.Received(1)
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ACallerSuppliedEmbeddingIsNeverRegenerated()
+    {
+        var sut = CreateSut();
+
+        await sut.AssembleContextAsync(new RecallRequest
+        {
+            SessionId = "s",
+            Query = "what did we decide",
+            QueryEmbedding = new float[] { 1f },
+            Options = RecallOptions.Default,
+        });
+
+        await _embeddings.DidNotReceive()
+            .EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/RecallSectionDiagnosticsTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/RecallSectionDiagnosticsTests.cs
@@ -1,0 +1,192 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// An empty recall section must say <b>why</b> it is empty.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three causes need opposite responses and looked identical from the outside: the section was never
+/// searched, the store genuinely holds nothing, or candidates existed and were filtered away — by the
+/// similarity floor, or by an owner post-filter applied after the vector index chose a global top-K.
+/// </para>
+/// <para>
+/// This is not hypothetical. Analysing recorded benchmark runs turned up a question that retrieved
+/// <b>2 facts from a 710-fact graph</b> with the answer demonstrably present in memory, and no
+/// artifact could say which of the three had happened — the investigation stopped there for want of
+/// exactly this signal.
+/// </para>
+/// </remarks>
+public sealed class RecallSectionDiagnosticsTests
+{
+    private readonly IShortTermMemoryService _shortTerm = Substitute.For<IShortTermMemoryService>();
+    private readonly ILongTermMemoryService _longTerm = Substitute.For<ILongTermMemoryService>();
+    private readonly IReasoningMemoryService _reasoning = Substitute.For<IReasoningMemoryService>();
+    private readonly IEmbeddingOrchestrator _embeddings = Substitute.For<IEmbeddingOrchestrator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    private static readonly IMemoryIsolationPolicy SingleTenant =
+        new DefaultMemoryIsolationPolicy(
+            Options.Create(new MemoryIsolationOptions()),
+            NullLogger<DefaultMemoryIsolationPolicy>.Instance);
+
+    public RecallSectionDiagnosticsTests()
+    {
+        _clock.UtcNow.Returns(DateTimeOffset.UnixEpoch);
+        _embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[8]));
+        _shortTerm.GetRecentMessagesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _shortTerm.SearchMessagesAsync(
+                Arg.Any<string?>(), Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _longTerm.SearchEntitiesAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Entity>>(Array.Empty<Entity>()));
+        _longTerm.SearchPreferencesAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Preference>>(Array.Empty<Preference>()));
+        _longTerm.SearchFactsAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>()));
+        _reasoning.SearchSimilarTracesAsync(
+                Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(Array.Empty<ReasoningTrace>()));
+    }
+
+    private MemoryContextAssembler CreateSut() =>
+        new(_shortTerm, _longTerm, _reasoning, null, _embeddings, _clock,
+            Options.Create(new MemoryOptions()),
+            NullLogger<MemoryContextAssembler>.Instance, SingleTenant);
+
+    private static RecallRequest Request(RecallOptions options) => new()
+    {
+        SessionId = "s",
+        Query = "what did we decide",
+        Options = options,
+    };
+
+    [Fact]
+    public async Task DiagnosticsAreAbsentByDefault()
+    {
+        // Off unless asked for: every section keeps its null default and none of this work runs.
+        var context = await CreateSut().AssembleContextAsync(Request(RecallOptions.Default));
+
+        context.RelevantFacts.Diagnostics.Should().BeNull();
+        context.RelevantEntities.Diagnostics.Should().BeNull();
+        context.RecentMessages.Diagnostics.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ASearchedButEmptySectionIsDistinguishableFromAnUnsearchedOne()
+    {
+        // The load-bearing case. Facts were searched and came back empty; traces were excluded by a
+        // zero limit. Both sections hold zero items, and before this they were indistinguishable.
+        var context = await CreateSut().AssembleContextAsync(Request(
+            RecallOptions.Default with { IncludeDiagnostics = true, MaxTraces = 0 }));
+
+        context.RelevantFacts.Diagnostics!.Searched.Should().BeTrue();
+        context.RelevantFacts.Diagnostics!.SearchedAndEmpty.Should().BeTrue();
+
+        context.SimilarTraces.Diagnostics!.Searched.Should().BeFalse();
+        context.SimilarTraces.Diagnostics!.SearchedAndEmpty.Should().BeFalse(
+            "a section that never ran says nothing about the store, and must not read as 'found nothing'");
+    }
+
+    [Fact]
+    public async Task AShortResultIsVisibleAsShort()
+    {
+        // The owner-starvation shape: the index picks a global top-K and the owner filter is applied
+        // afterwards, so a SHORT result can mean crowded out rather than genuinely sparse. Escalation
+        // fires only on a total zero, so this case is otherwise invisible.
+        _longTerm.SearchFactsAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(), Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(new[]
+            {
+                new Fact
+                {
+                    FactId = "f1", Subject = "a", Predicate = "b", Object = "c",
+                    Confidence = 0.9, CreatedAtUtc = DateTimeOffset.UnixEpoch,
+                },
+            }));
+
+        var context = await CreateSut().AssembleContextAsync(Request(
+            RecallOptions.Default with { IncludeDiagnostics = true, MaxFacts = 10 }));
+
+        var diagnostics = context.RelevantFacts.Diagnostics!;
+        diagnostics.Returned.Should().Be(1);
+        diagnostics.RequestedLimit.Should().Be(10);
+        diagnostics.SearchedAndShort.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TheSimilarityFloorIsRecordedSoBelowThresholdIsCheckable()
+    {
+        var context = await CreateSut().AssembleContextAsync(Request(
+            RecallOptions.Default with { IncludeDiagnostics = true, MinSimilarityScore = 0.83 }));
+
+        context.RelevantFacts.Diagnostics!.MinimumScore.Should().Be(0.83);
+    }
+
+    [Fact]
+    public async Task AnUnscoreableSectionReportsNullScoresRatherThanZero()
+    {
+        // Zero is a real score. A provider that cannot supply scores must produce null, or a reader
+        // cannot tell "scored badly" from "not scored".
+        var context = await CreateSut().AssembleContextAsync(Request(
+            RecallOptions.Default with { IncludeDiagnostics = true }));
+
+        context.RelevantFacts.Diagnostics!.TopScore.Should().BeNull();
+        context.RelevantFacts.Diagnostics!.LowestScore.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WhenNoEmbeddingIsAvailableEveryVectorSectionReportsNotSearched()
+    {
+        // Degraded embedding: the vector searches genuinely did not run, and the sections must say so
+        // rather than implying the store was queried and found wanting.
+        _embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Array.Empty<float>()));
+
+        var context = await CreateSut().AssembleContextAsync(Request(
+            RecallOptions.Default with { IncludeDiagnostics = true }));
+
+        context.RelevantFacts.Diagnostics!.Searched.Should().BeFalse();
+        context.RelevantEntities.Diagnostics!.Searched.Should().BeFalse();
+        context.RelevantPreferences.Diagnostics!.Searched.Should().BeFalse();
+        context.SimilarTraces.Diagnostics!.Searched.Should().BeFalse();
+        context.RecentMessages.Diagnostics!.Searched.Should().BeTrue(
+            "recent messages are session-scoped and time-ordered, so they need no vector");
+    }
+
+    [Fact]
+    public async Task TheAsOfPathReportsDiagnosticsToo()
+    {
+        // Asserted separately rather than assumed: these two paths have already drifted apart once on
+        // a single option (SuccessfulTracesOnly is passed live and hardcoded null as-of).
+        _shortTerm.GetRecentMessagesAsOfAsync(
+                Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()));
+        _longTerm.SearchFactsAsOfAsync(
+                Arg.Any<float[]>(), Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<double>(),
+                Arg.Any<MemoryScope?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Fact>>(Array.Empty<Fact>()));
+
+        var context = await CreateSut().AssembleContextAsOfAsync(
+            Request(RecallOptions.Default with { IncludeDiagnostics = true, MaxTraces = 0 }),
+            DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+
+        context.RelevantFacts.Diagnostics.Should().NotBeNull();
+        context.RelevantFacts.Diagnostics!.SearchedAndEmpty.Should().BeTrue();
+        context.SimilarTraces.Diagnostics!.Searched.Should().BeFalse();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/TraceOutcomeRenderingTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/TraceOutcomeRenderingTests.cs
@@ -1,0 +1,96 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// A trace whose outcome was never recorded must not be shown to the model as a failure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ReasoningTrace.Success</c> is <c>bool?</c> and null means <b>unrecorded</b>. Null is also the
+/// common case: <c>AgentTraceRecorder</c> had no success parameter at all until recently, so every
+/// trace it wrote carries null.
+/// </para>
+/// <para>
+/// Rendering that as <c>✗</c> presented the model with a precedent library in which everything had
+/// failed — which is worse than showing nothing at all. <b>A wrong precedent is acted on; an absent
+/// one is investigated.</b>
+/// </para>
+/// </remarks>
+public sealed class TraceOutcomeRenderingTests
+{
+    private readonly ILongTermMemoryService _longTerm = Substitute.For<ILongTermMemoryService>();
+    private readonly IReasoningMemoryService _reasoning = Substitute.For<IReasoningMemoryService>();
+    private readonly IEmbeddingOrchestrator _embeddings = Substitute.For<IEmbeddingOrchestrator>();
+
+    private static ReasoningTrace Trace(string id, bool? success) => new()
+    {
+        TraceId = id,
+        SessionId = "s1",
+        Task = $"task-{id}",
+        Outcome = $"outcome-{id}",
+        Success = success,
+        StartedAtUtc = DateTimeOffset.UnixEpoch,
+    };
+
+    private MemoryQueryFacade CreateSut(params ReasoningTrace[] traces)
+    {
+        _embeddings.EmbedQueryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0.1f }));
+        _reasoning.SearchSimilarTracesAsync(
+                Arg.Any<float[]>(), Arg.Any<bool?>(), Arg.Any<int>(), Arg.Any<double>(),
+                Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReasoningTrace>>(traces));
+
+        var clock = Substitute.For<IClock>();
+        clock.UtcNow.Returns(DateTimeOffset.UnixEpoch);
+
+        return new MemoryQueryFacade(
+            _longTerm, _reasoning, _embeddings, clock,
+            Substitute.For<IIdGenerator>(),
+            NullLogger<MemoryQueryFacade>.Instance,
+            new DefaultMemoryIsolationPolicy(
+                Options.Create(new MemoryIsolationOptions()),
+                NullLogger<DefaultMemoryIsolationPolicy>.Instance));
+    }
+
+    [Fact]
+    public async Task AnUnrecordedOutcomeRendersAsUnknown_NotAsFailure()
+    {
+        var result = await CreateSut(Trace("a", success: null)).FindSimilarTasksAsync("anything");
+
+        result.Text.Should().Contain("[?]");
+        result.Text.Should().NotContain("[✗]",
+            "an unrecorded outcome is not a failed one, and every MAF-recorded trace carries null");
+    }
+
+    [Fact]
+    public async Task ARealSuccessAndARealFailureStillRenderDistinctly()
+    {
+        // The fix must not collapse the two states that ARE recorded.
+        var result = await CreateSut(
+            Trace("ok", success: true),
+            Trace("bad", success: false),
+            Trace("unknown", success: null)).FindSimilarTasksAsync("anything");
+
+        result.Text.Should().Contain("[✓] task-ok");
+        result.Text.Should().Contain("[✗] task-bad");
+        result.Text.Should().Contain("[?] task-unknown");
+    }
+
+    [Fact]
+    public async Task NoTracesStillReportsNothingFound()
+    {
+        var result = await CreateSut().FindSimilarTasksAsync("anything");
+
+        result.Text.Should().Contain("No similar tasks found");
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Services/ValidTimeRecallWiringTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/ValidTimeRecallWiringTests.cs
@@ -1,0 +1,89 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// <c>RecallOptions.ValidTime</c> must reach the repository, or it is an option that does nothing.
+/// </summary>
+/// <remarks>
+/// The failure mode this guards is the one this track keeps finding: a capability that exists in the
+/// options surface, reads correctly in review, and is wired to nothing. The Cypher gate and the enum
+/// are both worthless unless the value actually travels the whole chain — assembler → service →
+/// repository.
+/// </remarks>
+public sealed class ValidTimeRecallWiringTests
+{
+    private readonly IFactRepository _facts = Substitute.For<IFactRepository>();
+    private readonly IEntityRepository _entities = Substitute.For<IEntityRepository>();
+    private readonly IPreferenceRepository _preferences = Substitute.For<IPreferenceRepository>();
+    private readonly IRelationshipRepository _relationships = Substitute.For<IRelationshipRepository>();
+
+    private static readonly IMemoryIsolationPolicy SingleTenant =
+        new DefaultMemoryIsolationPolicy(
+            Options.Create(new MemoryIsolationOptions()),
+            NullLogger<DefaultMemoryIsolationPolicy>.Instance);
+
+    private LongTermMemoryService CreateSut()
+    {
+        _facts.SearchByVectorAsync(
+                Arg.Any<float[]>(), Arg.Any<ValidTimeMode>(), Arg.Any<int>(), Arg.Any<double>(),
+                Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Fact, double)>>(Array.Empty<(Fact, double)>()));
+
+        return new LongTermMemoryService(
+            _entities, _facts, _preferences, _relationships,
+            Substitute.For<IEmbeddingOrchestrator>(),
+            Options.Create(new LongTermMemoryOptions()),
+            NullLogger<LongTermMemoryService>.Instance,
+            SingleTenant);
+    }
+
+    [Fact]
+    public async Task CurrentReachesTheRepository()
+    {
+        await CreateSut().SearchFactsAsync(
+            new float[] { 1f }, ValidTimeMode.Current, 10, 0.0, null, CancellationToken.None);
+
+        await _facts.Received(1).SearchByVectorAsync(
+            Arg.Any<float[]>(), ValidTimeMode.Current, Arg.Any<int>(), Arg.Any<double>(),
+            Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AnUngatedRecallEmitsTheORIGINALRepositoryCall()
+    {
+        // Byte-identical rather than merely equivalent. An ungated recall must take the overload it
+        // always took -- which also means a third-party IFactRepository that never implements the
+        // valid-time overload is only ever reached through it when a caller explicitly asked to gate.
+        _facts.SearchByVectorAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(),
+                Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Fact, double)>>(Array.Empty<(Fact, double)>()));
+
+        await CreateSut().SearchFactsAsync(new float[] { 1f }, 10, 0.0, null, CancellationToken.None);
+
+        await _facts.Received(1).SearchByVectorAsync(
+            Arg.Any<float[]>(), Arg.Any<int>(), Arg.Any<double>(),
+            Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+        await _facts.DidNotReceive().SearchByVectorAsync(
+            Arg.Any<float[]>(), Arg.Any<ValidTimeMode>(), Arg.Any<int>(), Arg.Any<double>(),
+            Arg.Any<MemoryScope?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void TheOptionDefaultsToIgnore()
+    {
+        new RecallOptions().ValidTime.Should().Be(ValidTimeMode.Ignore,
+            "no existing deployment may silently start recalling less than it did");
+        RecallOptions.Default.ValidTime.Should().Be(ValidTimeMode.Ignore);
+    }
+}

--- a/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
+++ b/tools/AgentMemory.Cli/Perf/PerfScenarios.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
@@ -87,6 +87,10 @@ public static partial class PerfScenarios
             "PERF-R-01",
             "Greeting-only turn at the shipped default recall policy",
             GreetingRecallAsync),
+        new(
+            "PERF-R-09",
+            "Trivial acknowledgement turn narrowed to recent messages at the shipped default policy",
+            TrivialTurnRecallAsync),
         new("PERF-R-04", "Full multi-category recall at shipped defaults", RecallAsync),
         new(
             "PERF-R-07",
@@ -320,9 +324,24 @@ public static partial class PerfScenarios
     }
 
     /// <summary>
-    /// PERF-R-01 — a greeting/acknowledgement turn with no memory-retrieval intent. The shipped default
-    /// policy still recalls, so this captures the work that matrix rank 1 must eliminate.
+    /// PERF-R-01 — a conversational turn the shipped default policy treats as REAL, and therefore the
+    /// full-recall control.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Historically described as "greeting-only". It is not, under the policy shipped since
+    /// <c>TrivialTurnRecallPolicy</c> became the default: the turn is <c>"thanks, that's great"</c>, and
+    /// <c>that's</c> is not an acknowledgement token, so the turn is correctly classified as real and
+    /// receives full recall. The scenario's own failure message anticipated exactly this — *"rank 1 must
+    /// change product behavior and update this expectation explicitly"*.
+    /// </para>
+    /// <para>
+    /// <b>Its expectations are deliberately unchanged, and the acknowledgement list was deliberately NOT
+    /// widened to match this text.</b> Doing that would tune the mechanism to move a metric, and it would
+    /// break this scenario's own assertion. <see cref="TrivialTurnRecallAsync"/> (PERF-R-09) is the
+    /// measurement of the narrowed path; this one stays the control it has always been.
+    /// </para>
+    /// </remarks>
     private static async Task GreetingRecallAsync(ScenarioContext ctx)
     {
         var identity = ctx.Variant is null
@@ -367,6 +386,65 @@ public static partial class PerfScenarios
                 "current hash-bucket overlap is part of this locked scenario shape. Do not configure " +
                 "a skipping policy inside this fixture: rank 1 must change product behavior and update " +
                 "this expectation explicitly.");
+        }
+    }
+
+    /// <summary>
+    /// PERF-R-09 — a genuinely trivial turn under the shipped default policy: the measurement of what
+    /// task-aware recall actually saves.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// PERF-R-01 is the full-recall control; this is its sibling. The turn is a single acknowledgement
+    /// token, so <c>TrivialTurnRecallPolicy</c> narrows the turn to recent messages and every
+    /// vector-consuming category is excluded — which is what lets the assembler and the provider elide
+    /// the query embedding entirely.
+    /// </para>
+    /// <para>
+    /// <b>Recent messages must still arrive.</b> The policy narrows rather than skips precisely so an
+    /// acknowledgement like "ok, go ahead" keeps the conversation it is agreeing to, and a regression
+    /// that turned this into a full skip would look like an even better perf result while silently
+    /// removing context. The self-check below therefore asserts BOTH directions: no semantic work, and
+    /// no loss of recent messages.
+    /// </para>
+    /// </remarks>
+    private static async Task TrivialTurnRecallAsync(ScenarioContext ctx)
+    {
+        var identity = ctx.Variant is null
+            ? PerfFixture.DefaultIdentity
+            : PerfFixture.ForVariant(ctx.Variant);
+        var messages = new[]
+        {
+            new ChatMessage(ChatRole.User, "thanks"),
+        };
+
+        var context = await ctx.Provider.BuildContextAsync(
+            messages,
+            identity.SessionId,
+            identity.ConversationId,
+            ctx.CancellationToken,
+            identity.OwnerId).ConfigureAwait(false);
+
+        RecordContext(ctx.Turn, context);
+
+        var recent = ctx.Turn.Counter("items.recent");
+        var retrieved = ctx.Turn.Counter("items.retrieved");
+        var embeddings = ctx.Turn.Counter("embed.requests");
+        var semantic =
+            ctx.Turn.Counter("items.relevant") +
+            ctx.Turn.Counter("items.entities") +
+            ctx.Turn.Counter("items.facts") +
+            ctx.Turn.Counter("items.preferences") +
+            ctx.Turn.Counter("items.traces");
+
+        if (recent != 10 || retrieved != 10 || semantic != 0 || embeddings != 0)
+        {
+            throw new InvalidOperationException(
+                $"PERF-R-09 did not exercise the narrowed trivial-turn path (items.recent={recent}/10, " +
+                $"items.retrieved={retrieved}/10, semantic items={semantic}/0, " +
+                $"embed.requests={embeddings}/0). embed.requests > 0 means the embedding gate stopped " +
+                "working; items.recent < 10 means the policy started SKIPPING rather than narrowing, " +
+                "which would drop the conversation an acknowledgement turn still needs.");
         }
     }
 

--- a/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
+++ b/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
@@ -23,7 +23,7 @@
     here depends on source access.
   -->
   <ItemGroup>
-    <PackageReference Include="AgentEval" Version="0.19.0-beta" />
+    <PackageReference Include="AgentEval" Version="0.20.0-beta" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />

--- a/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
+++ b/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
@@ -48,4 +48,10 @@
     <InternalsVisibleTo Include="AgentMemory.Tests.Unit.LongMemEval" />
   </ItemGroup>
 
+
+  <!-- The memory-type mapping is embedded so it versions with the code that scores against it. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Taxonomy\memory-type-map.json" />
+  </ItemGroup>
+
 </Project>

--- a/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
+++ b/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -23,10 +23,20 @@
     here depends on source access.
   -->
   <ItemGroup>
-    <PackageReference Include="AgentEval" Version="0.18.0-beta" />
+    <PackageReference Include="AgentEval" Version="0.19.0-beta" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <!--
+      A real tokenizer, for the publication path only. The chars/4 heuristic stays for RATIOS between
+      arms, where a consistent approximation is sufficient and cheap. It is not sufficient for a
+      number we publish: a reader will compare a published token count against provider billing.
+      This is a tool, never packaged, so the dependency costs consumers nothing.
+    -->
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
+    <!-- Embedded vocabularies, so counting never needs a network fetch at run time. -->
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />
     <PackageReference Include="Testcontainers.Neo4j" Version="4.11.0" />
   </ItemGroup>
 

--- a/tools/AgentMemory.LongMemEval/LongMemEvalAnswerPresence.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalAnswerPresence.cs
@@ -1,4 +1,4 @@
-namespace AgentMemory.LongMemEval;
+﻿namespace AgentMemory.LongMemEval;
 
 /// <summary>
 /// Whether a question's gold answer appears in stored memory <b>at all</b>.
@@ -67,12 +67,30 @@ internal static class LongMemEvalAnswerPresence
         var matched = answerTokens.Where(memoryTokens.Contains).ToArray();
         var coverage = (double)matched.Length / answerTokens.Length;
 
+        // A gold answer made only of numbers is DERIVED as often as it is stored -- "17 fish total" is
+        // the sum of counts held separately, "$750" is a difference -- so the numeral itself was never
+        // written to memory and token overlap cannot find it. Reporting that as "absent" blames
+        // extraction for an answer the model computed correctly from evidence that was present.
+        //
+        // Found by reconciling two questions where this gate and the judge disagreed: eeda8a6d ("17
+        // fish total") and 1f2b8d4f ("$750"). Both were scored CORRECT by the judge while this gate
+        // reported the answer absent from memory. Neither was wrong -- they were answering different
+        // questions -- but the disagreement read as a defect in one of them for weeks.
+        //
+        // Uncheckable, not absent. The distinction already exists here precisely so that "we cannot
+        // tell" never becomes "it is missing", which is what turns a floor into a false alarm.
+        if (answerTokens.All(IsNumeric))
+            return new LongMemEvalAnswerPresenceResult(false, false, [], 0);
+
         return new LongMemEvalAnswerPresenceResult(
             Checkable: true,
             Present: coverage >= PresenceThreshold,
             MatchedTokens: matched,
             Coverage: coverage);
     }
+
+    /// <summary>Whether a token is purely digits — i.e. carries no lexical evidence of its own.</summary>
+    private static bool IsNumeric(string token) => token.All(char.IsDigit);
 
     /// <summary>Lowercase alphanumeric runs. Punctuation and case carry no evidence here.</summary>
     private static IEnumerable<string> Tokenize(string? text)

--- a/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
@@ -1,4 +1,4 @@
-using AgentEval.Memory.External.LongMemEval;
+﻿using AgentEval.Memory.External.LongMemEval;
 using AgentEval.Memory.External.Models;
 
 namespace AgentMemory.LongMemEval;
@@ -11,7 +11,8 @@ internal static class LongMemEvalBenchmarkProtocol
         int seed,
         int judgeRetryAttempts,
         LongMemEvalEvidenceDetail evidenceDetail,
-        int maxRelevantMessages) =>
+        int maxRelevantMessages,
+        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText) =>
         new()
         {
             DatasetPath = datasetPath,
@@ -33,6 +34,22 @@ internal static class LongMemEvalBenchmarkProtocol
             // from our own rendering was. Raw keeps the model's actual text (bounded to 4096 chars by
             // AgentEval), which is the only way to tell a WRONG judge from an UNPARSEABLE one.
             JudgeEvidenceMode = JudgeEvidenceMode.Raw,
+            // Decouples "what we keep" from "what we render". Today JudgeEvidenceMode.Raw already
+            // retains the model's text, so this changes nothing -- it exists so that a later move to a
+            // shorter evidence mode cannot silently take the raw response away with it, which is the
+            // only thing that distinguishes a WRONG judge from an UNPARSEABLE one.
+            RetainRawJudgeResponse = true,
+            // FreeText by default, deliberately. StructuredJson is strictly better at the job --
+            // AgentEval's own docs name the free-text failure mode as vetoing a leading "yes" when the
+            // word "no" appears later in the response, which is exactly the systematic failure seen on
+            // question 7405e8b1 -- but the same docs are explicit that enabling it "changes verdicts on
+            // the questions the free-text parser mis-scored" and therefore "makes results
+            // non-comparable with a base recorded under the free-text protocol".
+            //
+            // Every sealed base in this project was recorded under FreeText. Flipping this default
+            // would silently invalidate all of them, so it is a per-run decision the caller states out
+            // loud rather than something inherited.
+            JudgeVerdictProtocol = verdictProtocol,
             EvidenceCaptureMode = evidenceDetail switch
             {
                 LongMemEvalEvidenceDetail.None => EvidenceCaptureMode.None,

--- a/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
@@ -12,7 +12,11 @@ internal static class LongMemEvalBenchmarkProtocol
         int judgeRetryAttempts,
         LongMemEvalEvidenceDetail evidenceDetail,
         int maxRelevantMessages,
-        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText) =>
+        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText,
+        IReadOnlyList<string>? includeQuestionTypes = null,
+        AbstentionSamplingPolicy abstentionPolicy = AbstentionSamplingPolicy.AsSampled,
+        double? abstentionTargetProportion = null,
+        bool suppressSyntheticBoundaries = false) =>
         new()
         {
             DatasetPath = datasetPath,
@@ -50,6 +54,25 @@ internal static class LongMemEvalBenchmarkProtocol
             // would silently invalidate all of them, so it is a per-run decision the caller states out
             // loud rather than something inherited.
             JudgeVerdictProtocol = verdictProtocol,
+            // Type-filtered sampling (0.20). Null/empty reproduces the stratified-across-all-6 default
+            // exactly. This is what makes a per-memory-type claim possible at all: a 50-question
+            // stratified sample yields ~6 single-session-assistant questions, and 6 cannot carry one.
+            IncludeQuestionTypes = includeQuestionTypes is { Count: > 0 }
+                ? includeQuestionTypes.ToList()
+                : null,
+            // Abstention (0.20). AsSampled is the pre-0.20 behaviour. Across 52 recorded runs of ours,
+            // NOT ONE _abs question ever ran -- and nothing said so, which is why the realised count now
+            // travels on the result rather than being inferred.
+            AbstentionPolicy = abstentionPolicy,
+            AbstentionTargetProportion = abstentionTargetProportion,
+            // Full provenance (0.20): dataset SHA-256, judge-prompt fingerprint, AgentEval version and a
+            // fingerprint of the selected question ids. Sealed-base comparability was previously checked
+            // by hand-diffing AgentEval's source between releases; now it is mechanical.
+            RunProvenanceMode = RunProvenanceMode.Full,
+            // Synthetic session boilerplate (0.20). For two failing questions, 30 of 30 retrieved
+            // messages were this boilerplate, and it read as a defect in OUR retrieval for weeks.
+            // Empty marker == omit. Default keeps the historical text so sealed bases stay comparable.
+            SyntheticTurnMarker = suppressSyntheticBoundaries ? string.Empty : null,
             EvidenceCaptureMode = evidenceDetail switch
             {
                 LongMemEvalEvidenceDetail.None => EvidenceCaptureMode.None,

--- a/tools/AgentMemory.LongMemEval/LongMemEvalMemoryTypeMap.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalMemoryTypeMap.cs
@@ -1,0 +1,104 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Maps LongMemEval's <b>task</b> labels onto <b>memory types</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The dataset labels a question by what it asks for; a memory type describes which retrieval key
+/// answers it. <b>A task taxonomy is not a memory-type taxonomy</b>, and treating one as the other
+/// silently is how a per-type table ends up measuring something other than what it claims.
+/// </para>
+/// <para>
+/// The mapping is embedded <b>data</b>, not code: it is an opinion, it will be revised, and a reader
+/// disagreeing with it should be able to see and change it without touching the harness. Every
+/// per-type figure inherits its choices, so <see cref="Revision"/> travels with any output.
+/// </para>
+/// </remarks>
+internal sealed class LongMemEvalMemoryTypeMap
+{
+    private const string ResourceName = "AgentMemory.LongMemEval.Taxonomy.memory-type-map.json";
+
+    /// <summary>The metamemory type, reached only through abstention questions.</summary>
+    internal const string MetaMemory = "metamemory";
+
+    /// <summary>Reported for a task label the mapping does not cover.</summary>
+    internal const string Unmapped = "unmapped";
+
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _byTaskType;
+    private readonly IReadOnlyList<string> _abstentionTypes;
+
+    /// <summary>The mapping revision, so a per-type figure can name the opinion it came from.</summary>
+    internal string Revision { get; }
+
+    private LongMemEvalMemoryTypeMap(
+        string revision,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> byTaskType,
+        IReadOnlyList<string> abstentionTypes)
+    {
+        Revision = revision;
+        _byTaskType = byTaskType;
+        _abstentionTypes = abstentionTypes;
+    }
+
+    /// <summary>The embedded mapping.</summary>
+    internal static LongMemEvalMemoryTypeMap Default { get; } = Load();
+
+    private static LongMemEvalMemoryTypeMap Load()
+    {
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded memory-type map '{ResourceName}' is missing. Every per-type figure depends "
+                + "on it, so an absent mapping fails loudly rather than defaulting to an invented one.");
+
+        var document = JsonSerializer.Deserialize<MapDocument>(stream, SerializerOptions)
+            ?? throw new InvalidOperationException("Embedded memory-type map could not be deserialized.");
+
+        var byTask = document.TaskTypes.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<string>)pair.Value.MemoryTypes,
+            StringComparer.OrdinalIgnoreCase);
+
+        return new LongMemEvalMemoryTypeMap(
+            document.Revision,
+            byTask,
+            document.Abstention?.MemoryTypes ?? [MetaMemory]);
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// The memory types a question exercises.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="isAbstention"/> takes precedence: an <c>_abs</c> question is answerable only by
+    /// knowing memory does <i>not</i> hold the answer, whatever its task label says it is about. An
+    /// unrecognised label maps to <see cref="Unmapped"/> rather than being dropped — a shrinking
+    /// denominator is how a metric stops adding up.
+    /// </remarks>
+    internal IReadOnlyList<string> ForQuestion(string? taskType, bool isAbstention)
+    {
+        if (isAbstention) return _abstentionTypes;
+        if (taskType is not null && _byTaskType.TryGetValue(taskType, out var types)) return types;
+        return [Unmapped];
+    }
+
+    private sealed class MapDocument
+    {
+        [JsonPropertyName("revision")] public string Revision { get; set; } = "unknown";
+        [JsonPropertyName("taskTypes")] public Dictionary<string, TaskTypeEntry> TaskTypes { get; set; } = [];
+        [JsonPropertyName("abstention")] public TaskTypeEntry? Abstention { get; set; }
+    }
+
+    private sealed class TaskTypeEntry
+    {
+        [JsonPropertyName("memoryTypes")] public List<string> MemoryTypes { get; set; } = [];
+    }
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalRunValidator.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalRunValidator.cs
@@ -1,4 +1,4 @@
-using AgentEval.Memory.External.Models;
+﻿using AgentEval.Memory.External.Models;
 
 namespace AgentMemory.LongMemEval;
 
@@ -73,6 +73,26 @@ internal static class LongMemEvalRunValidator
 
         if (questionCount == 0)
             issues.Add("AgentEval returned no LongMemEval questions.");
+
+        // A judged run that measured no answer presence cannot separate an extraction failure from a
+        // retrieval one, and every downstream reading of its failures is a guess. That is not fatal --
+        // the accuracy number is still valid -- so it is recorded as an issue rather than a rejection.
+        //
+        // Grouping 52 recorded runs by date showed answer-presence data appearing only from the day the
+        // gate was built, which is benign; what is NOT benign is a report that looks the same either
+        // way. Absence must be visible in the artifact, not inferred by a reader who happens to check.
+        // Gated on there being FAILURES to attribute. A run that answered everything has nothing to
+        // explain, and flagging it would train readers to ignore the message; a Raw-mode arm has no
+        // extracted memory to probe at all and would trip it forever.
+        var unattributedFailures = questionResults.Count(result => result.Correct == false);
+        if (unattributedFailures > 0 && telemetry.Count > 0 &&
+            telemetry.All(item => item.AnswerPresence is null))
+        {
+            issues.Add(
+                $"{unattributedFailures} question(s) scored incorrect and no answer-presence measurement "
+                + "was recorded, so this run cannot distinguish an extraction failure from a retrieval "
+                + "failure. Wire a graph probe, or read these failures as unattributed.");
+        }
 
         if (questionResults.Count != questionCount)
         {

--- a/tools/AgentMemory.LongMemEval/LongMemEvalTokenCounter.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalTokenCounter.cs
@@ -1,0 +1,98 @@
+using Microsoft.ML.Tokenizers;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>How a token figure was produced. Never inferred by a reader — always recorded.</summary>
+internal enum TokenCountMethod
+{
+    /// <summary>Four characters per token. Fine for ratios between arms; not a billing figure.</summary>
+    CharacterHeuristic = 0,
+
+    /// <summary>A real BPE tokenizer for the configured model.</summary>
+    Exact = 1,
+}
+
+/// <summary>
+/// Exact token counting for figures we intend to <b>publish</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="LongMemEvalContextSize"/>'s four-characters-per-token estimate is deliberate and stays:
+/// the question it answers is whether one arm costs several times another, and a ratio survives a
+/// consistent approximation.
+/// </para>
+/// <para>
+/// <b>It stops being sufficient the moment a number leaves this repository.</b> A published token
+/// count invites comparison against a provider's bill, and 4-chars-per-token is wrong by a
+/// double-digit percentage on real text. Zep's "1.6k context tokens versus 115k" is the most
+/// persuasive number in this category precisely because a token count cannot be inflated by a better
+/// answer model — which is exactly why ours has to be right before we print it.
+/// </para>
+/// <para>
+/// <b>Fails soft, and says so.</b> If no tokenizer can be constructed for the configured model, this
+/// returns the heuristic and reports <see cref="TokenCountMethod.CharacterHeuristic"/> rather than
+/// throwing. A missing vocabulary must not fail a benchmark run — but it must also never be silently
+/// reported as an exact count, which is why the method travels with every figure.
+/// </para>
+/// </remarks>
+internal sealed class LongMemEvalTokenCounter
+{
+    private readonly Tokenizer? _tokenizer;
+
+    /// <summary>How every count from this instance was produced.</summary>
+    internal TokenCountMethod Method { get; }
+
+    /// <summary>The encoding actually used, or null when falling back to the heuristic.</summary>
+    internal string? Encoding { get; }
+
+    internal LongMemEvalTokenCounter(string? modelId)
+    {
+        // Model ids reaching here are deployment names as often as canonical model names, so an
+        // unknown one is expected rather than exceptional -- hence try/catch over a lookup table that
+        // would go stale.
+        try
+        {
+            _tokenizer = TiktokenTokenizer.CreateForModel(NormalizeModel(modelId));
+            Method = TokenCountMethod.Exact;
+            Encoding = NormalizeModel(modelId);
+        }
+        catch (Exception)
+        {
+            _tokenizer = null;
+            Method = TokenCountMethod.CharacterHeuristic;
+            Encoding = null;
+        }
+    }
+
+    /// <summary>
+    /// Maps a deployment name onto a model the tokenizer library knows.
+    /// </summary>
+    /// <remarks>
+    /// Deployment names are operator-chosen ("gpt-4o-eval-2", "judge"), so substring matching is the
+    /// only thing that works; anything unrecognised falls through to the heuristic rather than being
+    /// silently counted with the wrong vocabulary, which would be worse than not counting at all.
+    /// </remarks>
+    private static string NormalizeModel(string? modelId)
+    {
+        var id = (modelId ?? string.Empty).ToLowerInvariant();
+        if (id.Contains("gpt-4o", StringComparison.Ordinal) ||
+            id.Contains("gpt-5", StringComparison.Ordinal) ||
+            id.Contains("o200k", StringComparison.Ordinal))
+            return "gpt-4o";
+        if (id.Contains("gpt-4", StringComparison.Ordinal) ||
+            id.Contains("gpt-35", StringComparison.Ordinal) ||
+            id.Contains("gpt-3.5", StringComparison.Ordinal) ||
+            id.Contains("cl100k", StringComparison.Ordinal))
+            return "gpt-4";
+        throw new NotSupportedException($"No known tokenizer vocabulary for model id '{modelId}'.");
+    }
+
+    /// <summary>Token count for <paramref name="content"/>, by whichever method this instance uses.</summary>
+    internal int Count(string? content)
+    {
+        if (string.IsNullOrEmpty(content)) return 0;
+        return _tokenizer is null
+            ? LongMemEvalContextSize.Estimate(content)
+            : _tokenizer.CountTokens(content);
+    }
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalTypedAccuracy.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalTypedAccuracy.cs
@@ -1,0 +1,101 @@
+namespace AgentMemory.LongMemEval;
+
+/// <summary>Accuracy and failure attribution for one memory type.</summary>
+/// <param name="MemoryType">The type, per the embedded mapping.</param>
+/// <param name="Questions">Questions exercising this type.</param>
+/// <param name="Correct">How many were judged correct.</param>
+/// <param name="ExtractionFailures">
+/// Judged wrong AND the gate found the answer nowhere in memory — no retrieval change can help these.
+/// </param>
+/// <param name="RetrievalFailures">
+/// Judged wrong while the answer WAS in memory. The answer exists and did not reach the reader.
+/// </param>
+/// <param name="Unattributable">
+/// Judged wrong but the gate could not check — e.g. a purely numeric gold answer, which is derived
+/// rather than stored. Counted apart so "we cannot tell" never reads as "it is missing".
+/// </param>
+internal sealed record LongMemEvalTypedAccuracy(
+    string MemoryType,
+    int Questions,
+    int Correct,
+    int ExtractionFailures,
+    int RetrievalFailures,
+    int Unattributable)
+{
+    /// <summary>Accuracy over this type, or null when it has no questions.</summary>
+    public double? Accuracy => Questions == 0 ? null : (double)Correct / Questions;
+
+    /// <summary>
+    /// Half-width of the band a single question represents, in accuracy points.
+    /// </summary>
+    /// <remarks>
+    /// Emitted beside every per-type figure on purpose. A per-type subset is small — six questions is
+    /// 16.7 points each — and a bare percentage over six questions invites exactly the comparison it
+    /// cannot support. This is the crudest possible honesty check, not a confidence interval; the
+    /// measured per-type noise floor is a separate and larger piece of work.
+    /// </remarks>
+    public double? PointsPerQuestion => Questions == 0 ? null : 100.0 / Questions;
+}
+
+/// <summary>
+/// Groups a run's questions by memory type rather than by task label.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every number this project has published is a whole-system number over a dataset that is
+/// overwhelmingly semantic, so nothing could say which memory type earned or lost a point. Neither
+/// can anyone else: <b>no vendor in the surveyed field publishes a per-memory-type ablation.</b>
+/// </para>
+/// <para>
+/// This is the retrospective half — it runs over results already in hand, needs no model call and no
+/// rebuild, and is therefore the cheapest possible first step.
+/// </para>
+/// </remarks>
+internal static class LongMemEvalTypedBreakdown
+{
+    /// <summary>One row per memory type, ordered by question count.</summary>
+    internal static IReadOnlyList<LongMemEvalTypedAccuracy> Summarise(
+        IReadOnlyList<LongMemEvalQuestionTelemetry> telemetry,
+        IReadOnlyDictionary<string, bool> correctByQuestionId,
+        IReadOnlyDictionary<string, bool>? abstentionByQuestionId = null,
+        LongMemEvalMemoryTypeMap? map = null)
+    {
+        ArgumentNullException.ThrowIfNull(telemetry);
+        ArgumentNullException.ThrowIfNull(correctByQuestionId);
+        map ??= LongMemEvalMemoryTypeMap.Default;
+
+        var accumulators = new Dictionary<string, int[]>(StringComparer.Ordinal);
+
+        foreach (var item in telemetry)
+        {
+            if (item.QuestionId is not { Length: > 0 } id) continue;
+            if (!correctByQuestionId.TryGetValue(id, out var correct)) continue;
+
+            var isAbstention = abstentionByQuestionId is not null
+                && abstentionByQuestionId.TryGetValue(id, out var abs) && abs;
+
+            // A question mapped to several types counts once under EACH: the types are not a partition,
+            // and forcing one would silently discard the second reading rather than report both.
+            foreach (var type in map.ForQuestion(item.QuestionType, isAbstention))
+            {
+                if (!accumulators.TryGetValue(type, out var slot))
+                    accumulators[type] = slot = new int[5];
+
+                slot[0]++;                                   // questions
+                if (correct) { slot[1]++; continue; }        // correct
+
+                var presence = item.AnswerPresence;
+                if (presence is null || !presence.Checkable) slot[4]++;      // unattributable
+                else if (presence.Present) slot[3]++;                        // retrieval-side
+                else slot[2]++;                                              // extraction-side
+            }
+        }
+
+        return accumulators
+            .Select(pair => new LongMemEvalTypedAccuracy(
+                pair.Key, pair.Value[0], pair.Value[1], pair.Value[2], pair.Value[3], pair.Value[4]))
+            .OrderByDescending(row => row.Questions)
+            .ThenBy(row => row.MemoryType, StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/tools/AgentMemory.LongMemEval/Taxonomy/memory-type-map.json
+++ b/tools/AgentMemory.LongMemEval/Taxonomy/memory-type-map.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "revision": "2026-08-12",
+  "$comment": [
+    "LongMemEval labels questions by TASK. This maps those labels onto MEMORY TYPES.",
+    "A task taxonomy is not a memory-type taxonomy and must not be silently treated as one:",
+    "the dataset's labels describe what a question asks for, while a memory type describes",
+    "which retrieval key answers it. Keeping the mapping as DATA rather than code means it can",
+    "be revised, versioned and disagreed with without a rebuild -- and it is an opinion, so it",
+    "will be revised.",
+    "",
+    "Every per-type number computed from this file inherits its choices. Cite the revision."
+  ],
+  "memoryTypes": {
+    "semantic": "What is true? Retrieved by the meaning of the claim.",
+    "episodic": "What happened, and when? Retrieved by time, participant, event.",
+    "temporal": "What is true NOW, or was true THEN? Retrieved against a clock.",
+    "procedural": "How do I do this? Retrieved by similarity of the TASK, not the topic.",
+    "metamemory": "Do I even know this? A threshold on a confidence signal."
+  },
+  "taskTypes": {
+    "single-session-user": {
+      "memoryTypes": ["semantic"],
+      "why": "A fact the user stated, recalled by meaning. The core semantic case."
+    },
+    "single-session-preference": {
+      "memoryTypes": ["semantic"],
+      "why": "The preference tier of semantic memory; same retrieval key, different node label."
+    },
+    "multi-session": {
+      "memoryTypes": ["semantic"],
+      "why": "Aggregation over semantic facts spread across sessions. Note the caveat below: completeness, not similarity, is what these need."
+    },
+    "single-session-assistant": {
+      "memoryTypes": ["episodic"],
+      "why": "What the ASSISTANT said or did. Unanswerable from semantic memory alone, because a semantic store keeps the claim and discards the act."
+    },
+    "temporal-reasoning": {
+      "memoryTypes": ["temporal"],
+      "why": "Ordering and duration over events; answered against a clock rather than by similarity."
+    },
+    "knowledge-update": {
+      "memoryTypes": ["temporal"],
+      "why": "Which version of a changed fact holds now. This is supersession plus valid time, i.e. the transaction and valid clocks."
+    }
+  },
+  "abstention": {
+    "memoryTypes": ["metamemory"],
+    "why": "An _abs question is answerable only by knowing that memory does NOT hold the answer. It is the one place this dataset scores metamemory at all."
+  },
+  "unreachable": {
+    "procedural": [
+      "LongMemEval-S is chat QA. It contains no build commands, no tool invocations and no fix",
+      "trajectories, so the workload a procedural tier targets is not in the dataset AT ANY",
+      "SAMPLE SIZE. No amount of extending this harness substitutes for a task-repetition",
+      "benchmark. Publishing a LongMemEval number as evidence for a procedural tier is the exact",
+      "metric substitution this mapping exists to prevent."
+    ]
+  },
+  "caveats": [
+    "multi-session is mapped to semantic, but its failures are usually COMPLETENESS failures",
+    "rather than matching failures -- top-K cannot answer 'how many' regardless of how well it",
+    "ranks. Reading a low multi-session score as a semantic-retrieval problem would be wrong.",
+    "",
+    "temporal-reasoning and knowledge-update are grouped, but they exercise different clocks:",
+    "the first is mostly valid time, the second mostly the transaction clock plus supersession.",
+    "Split them before drawing a conclusion about either one specifically."
+  ]
+}


### PR DESCRIPTION
Thirteen commits from the post-1.4.1 track. **17 plan tasks resolved** — including four where the work corrected the plan.

## Measured: a greeting no longer costs a full recall

`PERF-R-09` is the new scenario that measures it:

| | PERF-R-01 (control) | PERF-R-09 (trivial turn) |
|---|---:|---:|
| `neo4j.queries` | 13 | **1** |
| `neo4j.tx.read` | 12 | **1** |
| `neo4j.tx.write` | 1 | **0** |
| `embed.requests` | 1 | **0** |
| `items.recent` | 10 | **10** — conversation preserved |

`TrivialTurnRecallPolicy` **narrows rather than skips**: skipping would drop recent messages, and *"ok, go ahead"* is exactly the turn where the agent needs the conversation it is agreeing to. Enabled by a companion fix — the query embedding was generated even when no vector search would run, so narrowing *relocated* the ~120 ms call rather than removing it.

## Correctness and safety

- **Query deadlines.** `Neo4jOptions.TransactionTimeout` (null by default). Nothing bounded a query before — the driver takes no `CancellationToken`. Wired into **all three** transaction entry points, including the explicit atomic write fused persistence uses.
- **Tenant ids out of telemetry.** `InstrumentedMemoryService` emitted `memory.user_id` unconditionally, while every vector search here already tags a *boolean*. Now `memory.owner_scoped`, with opt-in for hosts that need the value. Writing the guard the plan asked for is what found the leak.
- **An unrecorded trace outcome is no longer rendered as a failure.** `Success` is `bool?`; null meant *unrecorded*, and null was the common case — so every MAF trace appeared as a failed precedent. A wrong precedent is acted on; an absent one is investigated.
- **`memory_start_trace` now scopes to its caller.** It passed no owner, so traces landed in the shared bucket while recall is owner-scoped.

## Instruments

- **`MemoryContextSection<T>.Diagnostics`** — an empty section can now say *why*: never searched, genuinely empty, or filtered away. `SearchedAndShort` exposes the owner-starvation shape that escalation can't see, because escalation only fires on a total zero.
- **Derived answers no longer read as extraction failures.** Both gate-vs-judge disagreements (`eeda8a6d` "17 fish", `1f2b8d4f` "$750") were *computed* answers never stored verbatim. Neither side was wrong. Fixed → extraction failures **1 → 0** in both arms.
- **AgentEval 0.19**, plus real tokenization for figures that leave the repo (the chars/4 estimate stays for ratios).

## Four times the work corrected the plan

1. **My headline prediction was wrong.** I expected extraction to be the ceiling. It is **0 extraction failures** — 100% of failures had the answer already in memory.
2. **I shipped a bug and the perf run caught it.** DI registered the new default while the *constructor* returned the old one.
3. **I rejected planned task 3.2.** `JudgeStatus` is still inferred from `Correct`, so "stop parsing the explanation" would reintroduce a bug an existing test catches.
4. **I reverted 2.3.** The embedding memo outlived a turn; the scenario self-check caught it.

## Baseline

`PERF-R-01` re-recorded to 13/12 — the starvation rescue firing on empty categories, the price of a fix that took tenants from 0 to 4 of 4 at 4,000 competing rows. It had been failing on `main` and every open PR. **Gate now passes.**

## Verification

4,042 core + 283 LongMemEval tests green · Release 0 warnings · quality gate 1.000/1.000 · perf gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE