### PR TITLE
Frozen-corpus registry, drift-refusing reuse, and the AUC on the path runs actually take

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/PreparedCorpusDriftTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/PreparedCorpusDriftTests.cs
@@ -1,0 +1,211 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// A frozen corpus may only be evaluated by a run that would have built it the same way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A cold build is ~684 extraction calls and 7–9 hours, so every real measurement reuses a frozen
+/// corpus. Reuse read the sealed manifest, printed its fingerprint and proceeded — and
+/// <c>VerifyIntegrity</c> only checks the manifest against <i>itself</i>. Nothing compared it to the
+/// run adopting it.
+/// </para>
+/// <para>
+/// The failure that allows is the worst kind: a corpus ingested with <c>AssistantContent=Utterance</c>
+/// evaluated by a run configured for <c>Ignore</c> produces a report whose fingerprint describes the
+/// run while every fact came from the other configuration. Internally consistent, reproducible, and
+/// wrong.
+/// </para>
+/// </remarks>
+public sealed class PreparedCorpusDriftTests
+{
+    private static LongMemEvalPreparedQuestion Question(int number) => new(
+        number, $"q-{number}", "history-sha", "scope-sha", 10, 2, 3,
+        new LongMemEvalGraphSnapshot(1, 1, 1, 1, 1, 1, 1, 1, 1));
+
+    private static LongMemEvalPreparationManifest Prepared(
+        string assistantContent = "Ignore",
+        string extractionModel = "gpt-5.5",
+        string datasetSha = "dataset-sha",
+        int seed = 42,
+        int questions = 2,
+        IReadOnlyList<string>? memoryTypes = null) =>
+        LongMemEvalPreparationManifest.Create(
+            preparationId: "prep-1",
+            datasetSha256: datasetSha,
+            agentEvalRevision: "0.20.0",
+            scopeRunId: "scope",
+            answerModelId: "gpt-5.5",
+            judgeModelId: "gpt-5.5",
+            extractionModelId: extractionModel,
+            embeddingModelId: "text-embedding-3-small",
+            embeddingDimensions: 1536,
+            maxRelevantMessages: 30,
+            extractionSourceTime: "metadata-only",
+            questions: Enumerable.Range(1, questions).Select(Question).ToArray(),
+            initialExtractionCalls: 100,
+            useUnifiedExtraction: true,
+            useMultiSessionBatchExtraction: true,
+            assistantContent: assistantContent,
+            usePredicateVocabulary: true,
+            extractionVocabularySha256: "vocab-sha",
+            queryRelationLexiconSha256: "lexicon-sha",
+            preparedAtUtc: "2026-08-10T09:26:14Z",
+            description: "the stratified 50",
+            memoryTypes: memoryTypes ?? [],
+            questionSeed: seed);
+
+    private static PreparedCorpusIdentity Current(
+        string assistantContent = "Ignore",
+        string extractionModel = "gpt-5.5",
+        string datasetSha = "dataset-sha",
+        int seed = 42,
+        int questions = 2,
+        IReadOnlyList<string>? memoryTypes = null) => new()
+    {
+        DatasetSha256 = datasetSha,
+        ExtractionModelId = extractionModel,
+        EmbeddingModelId = "text-embedding-3-small",
+        EmbeddingDimensions = 1536,
+        AssistantContent = assistantContent,
+        ExtractionProvenance = "Batch",
+        UsePredicateVocabulary = true,
+        ExtractionVocabularySha256 = "vocab-sha",
+        QueryRelationLexiconSha256 = "lexicon-sha",
+        QuestionSeed = seed,
+        QuestionCount = questions,
+        MemoryTypes = memoryTypes ?? [],
+    };
+
+    [Fact]
+    public void AMatchingCorpusReportsNoDrift()
+    {
+        // Reuse must stay the normal case. A check that flags a legitimate reuse trains the operator
+        // to pass the override, which is worse than having no check at all.
+        LongMemEvalPreparedCorpusDrift.Compare(Prepared(), Current()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AssistantContentDriftIsCaught()
+    {
+        // THE case. Recorded corpora on this machine were built with Utterance; today's default is
+        // Ignore, and nothing would have noticed.
+        var drift = LongMemEvalPreparedCorpusDrift.Compare(
+            Prepared(assistantContent: "Utterance"), Current(assistantContent: "Ignore"));
+
+        drift.Should().ContainSingle().Which.Field.Should().Be("assistantContent");
+    }
+
+    [Theory]
+    [InlineData("extractionModel")]
+    [InlineData("datasetSha256")]
+    [InlineData("questionSeed")]
+    [InlineData("questionCount")]
+    [InlineData("memoryTypes")]
+    public void EveryIngestionAffectingFieldIsCompared(string field)
+    {
+        var drift = field switch
+        {
+            "extractionModel" => LongMemEvalPreparedCorpusDrift.Compare(
+                Prepared(extractionModel: "gpt-4o"), Current(extractionModel: "gpt-5.5")),
+            "datasetSha256" => LongMemEvalPreparedCorpusDrift.Compare(
+                Prepared(datasetSha: "old"), Current(datasetSha: "new")),
+            "questionSeed" => LongMemEvalPreparedCorpusDrift.Compare(
+                Prepared(seed: 42), Current(seed: 7)),
+            "questionCount" => LongMemEvalPreparedCorpusDrift.Compare(
+                Prepared(questions: 2), Current(questions: 3)),
+            "memoryTypes" => LongMemEvalPreparedCorpusDrift.Compare(
+                Prepared(memoryTypes: []), Current(memoryTypes: ["episodic"])),
+            _ => throw new ArgumentOutOfRangeException(nameof(field)),
+        };
+
+        drift.Select(d => d.Field).Should().Contain(field);
+    }
+
+    [Fact]
+    public void AnEpisodicSampleCannotSilentlyReuseAStratifiedCorpus()
+    {
+        // The concrete consequence for 8.3b, asserted rather than assumed: --memory-types episodic
+        // selects DIFFERENT questions, whose histories were never ingested into the stratified corpus,
+        // so it needs its own cold build. Without this the run would evaluate episodic questions
+        // against a graph that has never seen them and report a very low score as a finding.
+        var drift = LongMemEvalPreparedCorpusDrift.Compare(
+            Prepared(memoryTypes: []), Current(memoryTypes: ["episodic"]));
+
+        drift.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void AnOlderManifestThatRecordedNothingIsDriftNotAgreement()
+    {
+        // Schema 5 and earlier did not record assistantContent at all, so the field comes back empty.
+        // "We do not know how this was built" must never read as "it matches" -- treating unknown as
+        // equal is precisely how a check stops being able to fail.
+        var legacy = Prepared() with { AssistantContent = "", ExtractionVocabularySha256 = "" };
+
+        var drift = LongMemEvalPreparedCorpusDrift.Compare(legacy, Current());
+
+        drift.Select(d => d.Field)
+            .Should().Contain("assistantContent").And.Contain("extractionVocabularySha256");
+    }
+
+    [Fact]
+    public void EvaluationOnlySettingsAreNotDrift()
+    {
+        // The reusability that makes a frozen corpus worth keeping. The answer model, judge, recall
+        // budget and evidence mode are applied at evaluation time and change no stored fact, so a
+        // corpus is legitimately reusable across them -- and flagging them would make every reuse
+        // "stale".
+        var prepared = Prepared() with { AnswerModelId = "gpt-4o", MaxRelevantMessages = 10 };
+
+        LongMemEvalPreparedCorpusDrift.Compare(prepared, Current()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheRefusalNamesEveryDriftedFieldAndTheOverride()
+    {
+        // An operator who cannot find the escape hatch reaches for a cold build instead, which spends
+        // nine hours to avoid a warning.
+        var drift = LongMemEvalPreparedCorpusDrift.Compare(
+            Prepared(assistantContent: "Utterance", seed: 42), Current(assistantContent: "Ignore", seed: 7));
+
+        var message = LongMemEvalPreparedCorpusDrift.Explain("vol-1", "2026-08-10T09:26:14Z", drift);
+
+        message.Should().Contain("vol-1").And.Contain("2026-08-10")
+            .And.Contain("assistantContent").And.Contain("questionSeed")
+            .And.Contain("--allow-stale-prepared");
+    }
+
+    [Fact]
+    public void AnUnrecordedPreparationDateStillProducesAReadableRefusal()
+    {
+        var drift = LongMemEvalPreparedCorpusDrift.Compare(
+            Prepared(seed: 42), Current(seed: 7));
+
+        LongMemEvalPreparedCorpusDrift.Explain("vol-1", "", drift).Should().Contain("unknown date");
+    }
+
+    [Fact]
+    public void TheFingerprintSeparatesTwoCorporaThatDifferOnlyInIngestion()
+    {
+        // The manifest fingerprint is what a report cites. Before schema 6 these two hashed
+        // identically, so two materially different corpora were indistinguishable in every artifact.
+        Prepared(assistantContent: "Utterance").Fingerprint
+            .Should().NotBe(Prepared(assistantContent: "Ignore").Fingerprint);
+    }
+
+    [Fact]
+    public void TheDescriptionDoesNotChangeTheFingerprint()
+    {
+        // Catalog metadata is for humans. Two corpora that differ only in their description are the
+        // same corpus, and making a note change the identity would force needless rebuilds.
+        var a = Prepared();
+        var b = a with { Description = "something else" };
+
+        LongMemEvalPreparationManifest.ComputeFingerprint(b).Should().Be(a.Fingerprint);
+    }
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparationManifest.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparationManifest.cs
@@ -39,9 +39,26 @@ internal sealed record LongMemEvalPreparationManifest(
     int MaxConcurrentExtractionBatches,
     IReadOnlyList<LongMemEvalPreparedQuestion> Questions,
     long InitialExtractionCalls,
-    string Fingerprint)
+    string Fingerprint,
+    // ── Ingestion identity (schema 6) ────────────────────────────────────
+    // Everything below changes WHAT WAS STORED, and none of it was recorded. A volume built with
+    // AssistantContent=Utterance could be adopted by a run configured for Ignore, and the report's
+    // fingerprint would describe the run's configuration while the graph came from the other one.
+    // Recorded here so a reuse can be refused instead of quietly measuring the wrong corpus.
+    string AssistantContent = "Ignore",
+    bool UsePredicateVocabulary = false,
+    string ExtractionVocabularySha256 = "",
+    string QueryRelationLexiconSha256 = "",
+    string ExtractionProvenance = "Batch",
+    // ── Catalog metadata (schema 6) ──────────────────────────────────────
+    // Not part of the fingerprint: these describe the build for a human, and two corpora that differ
+    // only in their description are the same corpus.
+    string PreparedAtUtc = "",
+    string Description = "",
+    IReadOnlyList<string>? MemoryTypes = null,
+    int QuestionSeed = 0)
 {
-    public const int CurrentSchemaVersion = 5;
+    public const int CurrentSchemaVersion = 6;
 
     internal int MessagesPrepared => Questions.Sum(question => question.MessagesPrepared);
 
@@ -70,7 +87,16 @@ internal sealed record LongMemEvalPreparationManifest(
         int maxSessionsPerBatch = 1,
         int maxInputTokens = 100_000,
         int maxConcurrentBatchesPerExtraction = 1,
-        int maxConcurrentExtractionBatches = 0)
+        int maxConcurrentExtractionBatches = 0,
+        string assistantContent = "Ignore",
+        bool usePredicateVocabulary = false,
+        string extractionVocabularySha256 = "",
+        string queryRelationLexiconSha256 = "",
+        string extractionProvenance = "Batch",
+        string preparedAtUtc = "",
+        string description = "",
+        IReadOnlyList<string>? memoryTypes = null,
+        int questionSeed = 0)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(preparationId);
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetSha256);
@@ -133,7 +159,16 @@ internal sealed record LongMemEvalPreparationManifest(
             maxConcurrentExtractionBatches,
             materialized,
             initialExtractionCalls,
-            Fingerprint: string.Empty);
+            Fingerprint: string.Empty,
+            AssistantContent: assistantContent,
+            UsePredicateVocabulary: usePredicateVocabulary,
+            ExtractionVocabularySha256: extractionVocabularySha256,
+            QueryRelationLexiconSha256: queryRelationLexiconSha256,
+            ExtractionProvenance: extractionProvenance,
+            PreparedAtUtc: preparedAtUtc,
+            Description: description,
+            MemoryTypes: memoryTypes ?? [],
+            QuestionSeed: questionSeed);
         return manifest with { Fingerprint = ComputeFingerprint(manifest) };
     }
 
@@ -167,6 +202,15 @@ internal sealed record LongMemEvalPreparationManifest(
             manifest.EmbeddingDimensions,
             manifest.MaxRelevantMessages,
             manifest.ExtractionSourceTime,
+            // Schema 6. These five decide what the extractor was asked for and therefore what the
+            // graph contains; leaving them out of the fingerprint is what let two materially different
+            // corpora hash identically.
+            manifest.AssistantContent,
+            manifest.UsePredicateVocabulary,
+            manifest.ExtractionVocabularySha256,
+            manifest.QueryRelationLexiconSha256,
+            manifest.ExtractionProvenance,
+            manifest.QuestionSeed,
             manifest.UseJsonResponseFormat,
             manifest.ExtractionResponseContract,
             manifest.UseUnifiedExtraction,

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparedCorpusDrift.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparedCorpusDrift.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Whether a frozen corpus was built the way the current run intends to evaluate it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A cold build costs ~684 extraction calls and 7–9 hours, so every real measurement reuses a frozen
+/// one. Reuse read the sealed manifest, printed its fingerprint, and proceeded — and
+/// <c>VerifyIntegrity</c> only checks the manifest against <i>itself</i>, that its recorded fingerprint
+/// matches its recorded contents. Nothing compared it to <b>this</b> run.
+/// </para>
+/// <para>
+/// So a corpus ingested with <c>AssistantContent=Utterance</c> under one model could be evaluated by a
+/// run configured for <c>Ignore</c> under another, and the report's own fingerprint block would
+/// describe the run's configuration while every fact in the graph came from the other one. The number
+/// would be wrong, internally consistent, and reproducible — the worst combination. That is the
+/// failure this exists to make impossible.
+/// </para>
+/// <para>
+/// <b>What counts as drift is deliberately narrow: only what changed the stored graph.</b> The answer
+/// model, the judge, the recall budget and the evidence mode all matter to a result but are applied at
+/// evaluation time, so a frozen corpus is legitimately reusable across them — that reusability is the
+/// entire point. Flagging them would make every reuse "stale" and train the operator to pass the
+/// override, which is worse than having no check.
+/// </para>
+/// </remarks>
+internal static class LongMemEvalPreparedCorpusDrift
+{
+    /// <summary>One field whose value differs between the frozen corpus and this run.</summary>
+    internal readonly record struct Difference(string Field, string Prepared, string Current)
+    {
+        public override string ToString() =>
+            $"{Field}: corpus={Format(Prepared)} run={Format(Current)}";
+
+        private static string Format(string value) =>
+            string.IsNullOrEmpty(value) ? "(unrecorded)" : value;
+    }
+
+    /// <summary>
+    /// The ingestion-affecting fields on which <paramref name="prepared"/> and the current run differ.
+    /// </summary>
+    /// <param name="prepared">The manifest sealed inside the frozen corpus.</param>
+    /// <param name="current">What this run would have built, had it built one.</param>
+    /// <remarks>
+    /// A field the corpus never recorded — anything sealed under schema 5 or earlier — is reported as
+    /// a difference rather than skipped. "We do not know what this corpus was built with" is not
+    /// evidence that it matches; treating unknown as equal is how a check stops being able to fail.
+    /// </remarks>
+    internal static IReadOnlyList<Difference> Compare(
+        LongMemEvalPreparationManifest prepared, PreparedCorpusIdentity current)
+    {
+        ArgumentNullException.ThrowIfNull(prepared);
+        ArgumentNullException.ThrowIfNull(current);
+
+        var differences = new List<Difference>();
+
+        void Check(string field, string preparedValue, string currentValue)
+        {
+            if (!string.Equals(preparedValue, currentValue, StringComparison.Ordinal))
+                differences.Add(new Difference(field, preparedValue, currentValue));
+        }
+
+        Check("datasetSha256", prepared.DatasetSha256, current.DatasetSha256);
+        Check("extractionModel", prepared.ExtractionModelId, current.ExtractionModelId);
+        Check("embeddingModel", prepared.EmbeddingModelId, current.EmbeddingModelId);
+        Check("embeddingDimensions",
+            prepared.EmbeddingDimensions.ToString(CultureInfo.InvariantCulture),
+            current.EmbeddingDimensions.ToString(CultureInfo.InvariantCulture));
+        Check("assistantContent", prepared.AssistantContent, current.AssistantContent);
+        Check("extractionProvenance", prepared.ExtractionProvenance, current.ExtractionProvenance);
+        Check("usePredicateVocabulary",
+            prepared.UsePredicateVocabulary.ToString(), current.UsePredicateVocabulary.ToString());
+        Check("extractionVocabularySha256",
+            prepared.ExtractionVocabularySha256, current.ExtractionVocabularySha256);
+        Check("queryRelationLexiconSha256",
+            prepared.QueryRelationLexiconSha256, current.QueryRelationLexiconSha256);
+        Check("questionSeed",
+            prepared.QuestionSeed.ToString(CultureInfo.InvariantCulture),
+            current.QuestionSeed.ToString(CultureInfo.InvariantCulture));
+        Check("questionCount",
+            prepared.Questions.Count.ToString(CultureInfo.InvariantCulture),
+            current.QuestionCount.ToString(CultureInfo.InvariantCulture));
+        Check("memoryTypes",
+            string.Join(",", (prepared.MemoryTypes ?? []).OrderBy(t => t, StringComparer.Ordinal)),
+            string.Join(",", current.MemoryTypes.OrderBy(t => t, StringComparer.Ordinal)));
+
+        return differences;
+    }
+
+    /// <summary>
+    /// The operator-facing explanation of a refusal, naming every drifted field.
+    /// </summary>
+    /// <remarks>
+    /// Names the override and what it means, because there is a legitimate use for it — deliberately
+    /// evaluating an older corpus with a newer answer model, say — and an operator who cannot find the
+    /// escape hatch reaches for a cold build instead, which costs nine hours to avoid a warning.
+    /// </remarks>
+    internal static string Explain(
+        string volumeName, string preparedAtUtc, IReadOnlyList<Difference> differences)
+    {
+        var age = string.IsNullOrEmpty(preparedAtUtc) ? "unknown date" : $"prepared {preparedAtUtc}";
+        var lines = string.Join(Environment.NewLine, differences.Select(d => $"  - {d}"));
+        return
+            $"Prepared corpus '{volumeName}' ({age}) was not built the way this run would build it. "
+            + $"{differences.Count} ingestion-affecting field(s) differ:{Environment.NewLine}{lines}"
+            + Environment.NewLine
+            + "Evaluating it anyway would report THIS run's configuration over a graph built with "
+            + "another one — a result that is internally consistent, reproducible, and wrong. Either "
+            + "prepare a fresh corpus, or pass --allow-stale-prepared if the difference is one you "
+            + "intend (evaluating an older corpus with a newer answer model, for example); the "
+            + "override records the drift in the report rather than hiding it.";
+    }
+}
+
+/// <summary>
+/// What a run would build: the ingestion-affecting half of its configuration.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="LongMemEvalPreparationManifest"/> on purpose. The manifest describes a
+/// corpus that exists, with per-question hashes and call counts; this describes an intent, and can be
+/// constructed before anything is built or adopted — which is what lets the check run before the first
+/// provider call rather than after.
+/// </remarks>
+internal sealed record PreparedCorpusIdentity
+{
+    internal required string DatasetSha256 { get; init; }
+    internal required string ExtractionModelId { get; init; }
+    internal required string EmbeddingModelId { get; init; }
+    internal required int EmbeddingDimensions { get; init; }
+    internal required string AssistantContent { get; init; }
+    internal string ExtractionProvenance { get; init; } = "Batch";
+    internal required bool UsePredicateVocabulary { get; init; }
+    internal required string ExtractionVocabularySha256 { get; init; }
+    internal required string QueryRelationLexiconSha256 { get; init; }
+    internal required int QuestionSeed { get; init; }
+    internal required int QuestionCount { get; init; }
+    internal IReadOnlyList<string> MemoryTypes { get; init; } = [];
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparedCorpusRegistry.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparedCorpusRegistry.cs
@@ -1,0 +1,177 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// The catalog of frozen corpora on this machine: what each one is, when it was built, and how.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A cold build costs ~684 extraction calls and 7–9 hours, so frozen corpora are kept and reused for
+/// weeks. Until now the only record of what any of them contained was the volume name, a timestamp in
+/// it, and whatever a human remembered — so "is this one still usable?" was answered from notes lying
+/// around, which is exactly how a run ends up measuring the wrong corpus.
+/// </para>
+/// <para>
+/// <b>The registry is a convenience, never the guarantee.</b> The authority is the manifest sealed
+/// <i>inside</i> each corpus, which travels with the data and cannot drift from it; this file can be
+/// deleted, hand-edited or lost without making a single reuse unsafe, because
+/// <see cref="LongMemEvalPreparedCorpusDrift"/> reads the sealed manifest rather than this. What the
+/// registry buys is the ability to answer "what do I have, and which one should I reuse?" without
+/// starting a container per candidate.
+/// </para>
+/// <para>
+/// Machine-local by design, and it lives under <c>artifacts/</c> — the corpora it describes are local
+/// Docker volumes, so a shared copy would list things that do not exist wherever it was read.
+/// </para>
+/// </remarks>
+internal static class LongMemEvalPreparedCorpusRegistry
+{
+    internal const string DefaultPath = "artifacts/evaluation/prepared-corpora.json";
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>Appends (or replaces) the entry for a corpus that has just been sealed.</summary>
+    /// <remarks>
+    /// Best-effort on purpose: a registry write must never fail a build that already cost nine hours
+    /// and is already sealed and usable. The corpus is complete whether or not it gets catalogued.
+    /// </remarks>
+    internal static void Record(
+        string volumeName,
+        LongMemEvalPreparationManifest manifest,
+        TextWriter diagnostics,
+        string? path = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(volumeName);
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        var file = path ?? DefaultPath;
+        try
+        {
+            var entries = Read(file).Where(e => !string.Equals(e.Volume, volumeName, StringComparison.Ordinal))
+                .ToList();
+            entries.Add(new PreparedCorpusEntry
+            {
+                Volume = volumeName,
+                PreparationId = manifest.PreparationId,
+                PreparedAtUtc = manifest.PreparedAtUtc,
+                Description = manifest.Description,
+                Questions = manifest.Questions.Count,
+                Seed = manifest.QuestionSeed,
+                MemoryTypes = manifest.MemoryTypes is { Count: > 0 } types ? [.. types] : ["all"],
+                ManifestSchemaVersion = manifest.SchemaVersion,
+                Fingerprint = manifest.Fingerprint,
+                DatasetSha256 = manifest.DatasetSha256,
+                ExtractionModel = manifest.ExtractionModelId,
+                EmbeddingModel = manifest.EmbeddingModelId,
+                EmbeddingDimensions = manifest.EmbeddingDimensions,
+                AssistantContent = manifest.AssistantContent,
+                ExtractionProvenance = manifest.ExtractionProvenance,
+                ExtractionVocabularySha256 = manifest.ExtractionVocabularySha256,
+                AgentEvalRevision = manifest.AgentEvalRevision,
+            });
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(file));
+            if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+            File.WriteAllText(file, JsonSerializer.Serialize(entries, Json));
+            diagnostics.WriteLine($"longmemeval: catalogued prepared corpus '{volumeName}' in {file}.");
+        }
+        catch (Exception ex)
+        {
+            diagnostics.WriteLine(
+                $"longmemeval: could not update the prepared-corpus registry ({ex.Message}). The corpus "
+                + "is sealed and reusable regardless -- the registry is a convenience, and the manifest "
+                + "inside the volume is what reuse actually checks.");
+        }
+    }
+
+    /// <summary>Every catalogued corpus, newest first. Empty when the registry does not exist yet.</summary>
+    internal static IReadOnlyList<PreparedCorpusEntry> Read(string? path = null)
+    {
+        var file = path ?? DefaultPath;
+        if (!File.Exists(file)) return [];
+        try
+        {
+            return JsonSerializer.Deserialize<List<PreparedCorpusEntry>>(File.ReadAllText(file), Json)
+                ?.OrderByDescending(e => e.PreparedAtUtc, StringComparer.Ordinal).ToList() ?? [];
+        }
+        catch (JsonException)
+        {
+            // A corrupt registry is not a reason to fail; it is a reason to say so and carry on with
+            // nothing catalogued, because the sealed manifests remain the authority either way.
+            return [];
+        }
+    }
+
+    /// <summary>A human-readable listing, for the <c>--list-prepared-corpora</c> verb.</summary>
+    /// <remarks>
+    /// Age is shown because staleness is usually a judgement rather than a hard mismatch: a corpus can
+    /// match on every ingestion field and still predate a change to the extraction prompt that nobody
+    /// fingerprinted. Naming the date lets the operator apply that judgement; naming only "OK" would
+    /// invite them not to.
+    /// </remarks>
+    internal static string Describe(IReadOnlyList<PreparedCorpusEntry> entries, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        if (entries.Count == 0)
+        {
+            return "No prepared corpora catalogued. A cold build costs ~684 extraction calls and 7-9 "
+                + "hours for 50 questions, so build one with --prepared-pair --retain-prepared-volumes "
+                + "--description \"...\" and it will be listed here.";
+        }
+
+        var lines = entries.Select(entry =>
+        {
+            var age = DateTimeOffset.TryParse(
+                entry.PreparedAtUtc, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var when)
+                ? $"{(now - when).TotalDays:0} day(s) old"
+                : "age unknown";
+            var types = entry.MemoryTypes is { Count: > 0 } t ? string.Join("+", t) : "all";
+            var schema = entry.ManifestSchemaVersion < LongMemEvalPreparationManifest.CurrentSchemaVersion
+                ? $" [manifest schema {entry.ManifestSchemaVersion} < {LongMemEvalPreparationManifest.CurrentSchemaVersion}"
+                  + " - some ingestion settings were not recorded, so reuse will report them as drift]"
+                : string.Empty;
+            return $"  {entry.Volume}\n"
+                + $"    {entry.Questions}q seed={entry.Seed} types={types} | {age} ({entry.PreparedAtUtc})\n"
+                + $"    extraction={entry.ExtractionModel} embedding={entry.EmbeddingModel}/{entry.EmbeddingDimensions}"
+                + $" assistantContent={entry.AssistantContent} provenance={entry.ExtractionProvenance}\n"
+                + $"    {(string.IsNullOrWhiteSpace(entry.Description) ? "(no description)" : entry.Description)}{schema}";
+        });
+
+        return $"{entries.Count} prepared corpus/corpora:\n" + string.Join("\n", lines);
+    }
+}
+
+/// <summary>One catalogued corpus.</summary>
+/// <remarks>
+/// Mirrors the sealed manifest's ingestion identity rather than referencing it, so the listing can be
+/// read without attaching to a container — which is the whole point of having a catalog.
+/// </remarks>
+internal sealed record PreparedCorpusEntry
+{
+    public string Volume { get; init; } = "";
+    public string PreparationId { get; init; } = "";
+    public string PreparedAtUtc { get; init; } = "";
+    public string Description { get; init; } = "";
+    public int Questions { get; init; }
+    public int Seed { get; init; }
+    public IReadOnlyList<string> MemoryTypes { get; init; } = [];
+    public int ManifestSchemaVersion { get; init; }
+    public string Fingerprint { get; init; } = "";
+    public string DatasetSha256 { get; init; } = "";
+    public string ExtractionModel { get; init; } = "";
+    public string EmbeddingModel { get; init; } = "";
+    public int EmbeddingDimensions { get; init; }
+    public string AssistantContent { get; init; } = "";
+    public string ExtractionProvenance { get; init; } = "";
+    public string ExtractionVocabularySha256 { get; init; } = "";
+    public string AgentEvalRevision { get; init; } = "";
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
@@ -68,7 +68,12 @@ internal static class LongMemEvalPreparedPairProgram
                 options.Seed,
                 options.JudgeRetryAttempts,
                 options.EvidenceDetail,
-                options.MaxRelevantMessages);
+                options.MaxRelevantMessages,
+                // Typed sampling reaches the PREPARATION, not only the evaluation: an episodic-only
+                // sample selects different questions, whose conversation histories have to be ingested
+                // for the corpus to answer them at all. This is why an episodic arm cannot reuse a
+                // stratified corpus and needs its own cold build.
+                includeQuestionTypes: LongMemEvalMemoryTypeSelection.TaskTypesFor(options.MemoryTypes));
             var datasetSha256 = Convert.ToHexStringLower(
                 SHA256.HashData(
                     await File.ReadAllBytesAsync(options.DatasetPath).ConfigureAwait(false)));
@@ -138,6 +143,7 @@ internal static class LongMemEvalPreparedPairProgram
                 new ProviderCompatibleExtractionChatClient(
                     azureClient.GetChatClient(extractionDeployment).AsIChatClient()));
             LongMemEvalPreparationManifest manifest;
+            IReadOnlyList<LongMemEvalPreparedCorpusDrift.Difference> reuseDrift = [];
             IReadOnlyList<LongMemEvalQuestionTelemetry> preparationTelemetry;
             LongMemEvalPreparedBatchExecution? batchExecution = null;
             var profileStartup = Stopwatch.StartNew();
@@ -196,9 +202,47 @@ internal static class LongMemEvalPreparedPairProgram
                     // empty rather than zeroed-out real work. Reporting them as empty keeps a reused
                     // run from being mistaken for a cold build that happened to be instant.
                     preparationTelemetry = Array.Empty<LongMemEvalQuestionTelemetry>();
+
+                    // The check that makes reuse safe. VerifyIntegrity only proves the manifest is
+                    // self-consistent; nothing compared it to THIS run. A corpus ingested under other
+                    // settings evaluates perfectly well and reports the wrong configuration over it.
+                    reuseDrift = LongMemEvalPreparedCorpusDrift.Compare(
+                        manifest,
+                        new PreparedCorpusIdentity
+                        {
+                            DatasetSha256 = datasetSha256,
+                            ExtractionModelId = extractionDeployment,
+                            EmbeddingModelId = embeddingDeployment,
+                            EmbeddingDimensions = embeddingDimensions,
+                            AssistantContent = options.AssistantContent.ToString(),
+                            UsePredicateVocabulary = options.UsePredicateVocabulary,
+                            ExtractionVocabularySha256 = MemoryPredicateSeedVocabulary.Fingerprint,
+                            QueryRelationLexiconSha256 = MemoryRelationSeedTable.Fingerprint,
+                            QuestionSeed = options.Seed,
+                            QuestionCount = options.Questions,
+                            MemoryTypes = options.MemoryTypes,
+                        });
+
+                    if (reuseDrift.Count > 0 && !options.AllowStalePrepared)
+                    {
+                        throw new InvalidOperationException(
+                            LongMemEvalPreparedCorpusDrift.Explain(
+                                options.ReusePreparedVolume!, manifest.PreparedAtUtc, reuseDrift));
+                    }
+                    if (reuseDrift.Count > 0)
+                    {
+                        Console.Error.WriteLine(
+                            $"longmemeval: WARNING - reusing a corpus that drifted on {reuseDrift.Count} "
+                            + "ingestion-affecting field(s); --allow-stale-prepared was passed, and the "
+                            + "drift is recorded in the report.");
+                        foreach (var difference in reuseDrift)
+                            Console.Error.WriteLine($"  - {difference}");
+                    }
+
                     Console.WriteLine(
                         $"longmemeval: reusing prepared build {preparationId}; " +
-                        $"fingerprint {manifest.Fingerprint}; no extraction will run.");
+                        $"fingerprint {manifest.Fingerprint}; prepared {manifest.PreparedAtUtc}; " +
+                        "no extraction will run.");
                 }
                 else
                 {
@@ -536,11 +580,26 @@ internal static class LongMemEvalPreparedPairProgram
                     maxSessionsPerBatch: options.MaxSessionsPerBatch,
                     maxInputTokens: options.MaxInputTokens,
                     maxConcurrentBatchesPerExtraction: options.MaxConcurrentBatchesPerExtraction,
-                    maxConcurrentExtractionBatches: options.MaxConcurrentExtractionBatches);
+                    maxConcurrentExtractionBatches: options.MaxConcurrentExtractionBatches,
+                    // Schema 6. The corpus now describes how it was ingested, so a later reuse can be
+                    // refused instead of silently measuring a graph built under other settings.
+                    assistantContent: options.AssistantContent.ToString(),
+                    usePredicateVocabulary: options.UsePredicateVocabulary,
+                    extractionVocabularySha256: MemoryPredicateSeedVocabulary.Fingerprint,
+                    queryRelationLexiconSha256: MemoryRelationSeedTable.Fingerprint,
+                    preparedAtUtc: DateTimeOffset.UtcNow.ToString("O"),
+                    description: options.Description ?? string.Empty,
+                    memoryTypes: options.MemoryTypes,
+                    questionSeed: options.Seed);
 
                 var seal = Stopwatch.StartNew();
                 var store = new Neo4jLongMemEvalPreparationStore(driver);
                 await store.SealAsync(manifest).ConfigureAwait(false);
+                // Catalogued after sealing, never before: an entry for a corpus that failed to seal
+                // would advertise something unusable, and the registry's only job is to be trustworthy
+                // enough to pick from.
+                if (options.RetainPreparedVolumes)
+                    LongMemEvalPreparedCorpusRegistry.Record(baseVolumeName, manifest, Console.Out);
                 var sealedManifest = await store.ReadAsync(preparationId).ConfigureAwait(false);
                 seal.Stop();
                 manifestSealMilliseconds = seal.Elapsed.TotalMilliseconds;
@@ -700,6 +759,12 @@ internal static class LongMemEvalPreparedPairProgram
                     // Without these the artifact would not record which tables produced it.
                     extractionVocabularySha256 = MemoryPredicateSeedVocabulary.Fingerprint,
                     queryRelationLexiconSha256 = MemoryRelationSeedTable.Fingerprint,
+                    // Empty on a cold build and on a matching reuse. Non-empty only when
+                    // --allow-stale-prepared was used, so a result taken over a drifted corpus carries
+                    // that fact with it instead of looking like any other run.
+                    preparedCorpusDrift = reuseDrift.Select(d => d.ToString()).ToArray(),
+                    preparedCorpusPreparedAtUtc = reusing ? manifest.PreparedAtUtc : null,
+                    preparedCorpusDescription = reusing ? manifest.Description : options.Description,
                     evidenceDetail = options.EvidenceDetail.ToString().ToLowerInvariant(),
                     oracleMode = options.OracleMode.ToString().ToLowerInvariant(),
                     judgeRetryAttempts = options.JudgeRetryAttempts,
@@ -1212,6 +1277,7 @@ internal static class LongMemEvalPreparedPairProgram
         "--preflight-only", "--preparation-workers", "--provider-no-progress-timeout-seconds",
         "--questions", "--resolve-query-relations", "--retain-prepared-volumes",
         "--reuse-prepared-volumes", "--seed", "--single-session-unified",
+        "--description", "--memory-types", "--allow-stale-prepared",
         "--use-predicate-vocabulary",
     ];
 
@@ -1272,7 +1338,28 @@ internal static class LongMemEvalPreparedPairProgram
                 DefaultProviderNoProgressTimeoutSeconds,
                 "--provider-no-progress-timeout-seconds"),
             Has("--no-orphan-sweep"),
-            ParseNonNegative(Value("--graphrag-items"), 0, "--graphrag-items"));
+            ParseNonNegative(Value("--graphrag-items"), 0, "--graphrag-items"),
+            Value("--description"),
+            ParseMemoryTypes(Value("--memory-types")),
+            Has("--allow-stale-prepared"));
+    }
+
+    /// <summary>
+    /// Parses <c>--memory-types episodic</c> for a preparation, validating it before anything is built.
+    /// </summary>
+    /// <remarks>
+    /// Validated here rather than at sampling time because the cost of being wrong is a 7-9 hour cold
+    /// build of the wrong corpus. An unreachable type -- procedural, which this dataset does not
+    /// contain at any sample size -- must stop the run at the command line.
+    /// </remarks>
+    private static IReadOnlyList<string> ParseMemoryTypes(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return [];
+        var types = value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+        LongMemEvalMemoryTypeSelection.TaskTypesFor(types);
+        return types;
     }
 
     private static void Validate(PreparedPairOptions options)
@@ -1515,8 +1602,16 @@ internal static class LongMemEvalPreparedPairProgram
         int CheckpointTimeoutSeconds,
         int ProviderNoProgressTimeoutSeconds,
         bool NoOrphanSweep,
-        int GraphRagItems)
+        int GraphRagItems,
+        // A frozen corpus is reused for months; these three are what make it findable and safe to
+        // reuse later, when nobody remembers what it was built for.
+        string? Description = null,
+        IReadOnlyList<string>? MemoryTypesRequested = null,
+        bool AllowStalePrepared = false)
     {
+        /// <summary>The memory types this corpus was sampled for; empty means every type.</summary>
+        internal IReadOnlyList<string> MemoryTypes => MemoryTypesRequested ?? [];
+
         internal bool IsDiagnostic =>
             DiagnosticQuestionPosition is not null &&
             DiagnosticSourceSessionOrdinal is not null;

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
@@ -995,6 +995,11 @@ internal static class LongMemEvalPreparedPairProgram
             // holds the two prices, never their difference). Reported as a group so a derived-answer
             // type's absences are not read as extraction failures.
             answerPresenceByType = LongMemEvalAnswerPresence.SummariseByType(arm.Telemetry),
+            // PLAN 4.2. Emitted here as well as on the plain verb, because THIS is where the
+            // 50-question runs happen: the plain verb's cold build costs ~684 extraction calls and
+            // 7-9 hours, so every real measurement goes through the prepared pair. An instrument that
+            // reports only on the path nobody runs is the same dead-option defect as an unwired flag.
+            sufficiencyAuc = LongMemEvalSufficiencyReport.From(arm.Telemetry),
             // The judge's own record, kept alongside our telemetry. AgentEval has always handed us
             // the agent's answer, the judge's explanation and a TYPED status; the report dropped all
             // three, so "do you agree with the judge?" was unanswerable and a disagreement between

--- a/tools/AgentMemory.LongMemEval/Program.cs
+++ b/tools/AgentMemory.LongMemEval/Program.cs
@@ -54,6 +54,15 @@ internal static class LongMemEvalProgram
             return await LongMemEvalExtractionCompareProgram.RunAsync(args).ConfigureAwait(false);
         }
 
+        if (args.Contains("--list-prepared-corpora", StringComparer.Ordinal))
+        {
+            // Read-only and credential-free: answering "which frozen corpus should I reuse?" must not
+            // need the credentials of a paid run, or it stops being asked.
+            Console.WriteLine(LongMemEvalPreparedCorpusRegistry.Describe(
+                LongMemEvalPreparedCorpusRegistry.Read(), DateTimeOffset.UtcNow));
+            return 0;
+        }
+
         if (args.Contains("--prepared-pair", StringComparer.Ordinal))
         {
             return await LongMemEvalPreparedPairProgram.RunAsync(args)
@@ -369,6 +378,7 @@ internal static class LongMemEvalProgram
     private static readonly string[] KnownOptions =
     [
         "--reference-arm", "--surface-probe", "--predicate-distribution", "--prepared-pair",
+        "--list-prepared-corpora",
         "--extraction-compare", "--help",
         "--chronological-context", "--dataset", "--evidence-detail",
         "--exclude-synthetic-messages", "--judge-retries", "--max-items-per-session",


### PR DESCRIPTION
Two independent problems, both about a measurement quietly describing something other than what it measured.

## 1. Reuse could not refuse

A cold build is **~684 extraction calls and 7–9 hours** for 50 questions, so every real measurement reuses a frozen corpus. Reuse read the sealed manifest, printed its fingerprint, and proceeded — and `VerifyIntegrity` only checks the manifest against **itself**. Nothing compared it to the run adopting it.

A corpus on this machine was ingested with `AssistantContent=Utterance` under AgentEval 0.16. Today's default is `Ignore`. Evaluating it now produces a report whose fingerprint describes **this** run while every fact came from the other configuration — internally consistent, reproducible, and wrong.

- **Manifest schema 5 → 6** records how a corpus was ingested: assistant-content mode, predicate-vocabulary flag, extraction-vocabulary and query-lexicon hashes, provenance mode, seed, memory types, date, description. The ingestion-affecting fields join the fingerprint, so two materially different corpora stop hashing identically. The description does not — two corpora differing only in a note are the same corpus.
- **Drift comparison refuses** a mismatched reuse unless `--allow-stale-prepared`, naming every drifted field. Drift is deliberately narrow: only what changed the **stored graph**. Answer model, judge, recall budget and evidence mode are evaluation-time, so a corpus stays legitimately reusable across them — flagging those would make every reuse "stale" and train the operator to pass the override.
- **An older manifest that recorded nothing reports as drift, not agreement.** "We don't know how this was built" must never read as "it matches".

## 2. A registry, so this doesn't live in notes

`artifacts/evaluation/prepared-corpora.json`, written on retained preparations, listed by `--list-prepared-corpora` with age and a schema-too-old warning. Machine-local, because the corpora are local Docker volumes.

It is a **convenience, never the guarantee** — the authority is the manifest sealed inside each corpus, which travels with the data and cannot drift from it. Deleting the registry makes no reuse unsafe.

## 3. `--memory-types` now reaches preparation

An episodic-only sample selects *different questions*, whose histories must be ingested for the corpus to answer them. That is exactly why 8.3b needs its own cold build and cannot reuse the stratified one — asserted in the drift tests rather than assumed.

## 4. The AUC on the path runs actually take

4.2's instrument was wired into the plain verb only — the one that cold-builds for 7–9 hours. Every real measurement goes through `--prepared-pair`, so the instrument reported only on the path nobody runs. Same dead-option shape this branch already found twice, this time in my own work.

**Verification:** 4,158 unit + 362 LongMemEval green, Release 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE