### PR TITLE
Copilot Studio connector, 5.8 closed upstream, 2.1 unblocked

### DIFF
--- a/connectors/copilot-studio/README.md
+++ b/connectors/copilot-studio/README.md
@@ -1,0 +1,72 @@
+# Copilot Studio custom connector (D6)
+
+A custom-connector definition pointing Microsoft Copilot Studio at the AgentMemory MCP server, so a
+Copilot Studio agent gets persistent graph-backed memory across sessions.
+
+**This lane is open.** No memory provider in the competitive survey ships a Copilot Studio
+integration, and the only gate this task ever had — "there is no installable server with an HTTP
+transport to point at" — closed when the `dotnet tool` MCP host and its container image landed.
+
+## What is here, and what is not
+
+| | Status |
+|---|---|
+| Connector definition (`apiDefinition.swagger.json`) | ✅ In this repo |
+| Import + configuration steps | ✅ Below |
+| **Validation in a real Copilot Studio tenant** | ❌ **Not done — needs a tenant** |
+
+The definition is written against the documented `mcp-streamable-1.0` agentic-protocol contract and
+the route this server actually serves, but **it has not been imported into a live tenant**. Treat the
+steps below as untested-in-anger until someone runs them. Saying so is the point: a connector that
+looks right and has never been imported is exactly the kind of thing that gets announced and then
+fails on first contact.
+
+## 1. Run the MCP host with the HTTP transport
+
+```bash
+dotnet tool install --global AgentMemory.McpHost
+agentmemory-mcp --transport http --http-url http://0.0.0.0:8080 \
+  --neo4j-uri bolt://your-neo4j:7687
+```
+
+Or the container image, whose `docker-compose.yml` sits beside the host project.
+
+`MapMcp()` serves the MCP endpoint at the **root path**, which is why the connector's single
+operation is `POST /`.
+
+## 2. Expose it over HTTPS
+
+Copilot Studio will not call a plaintext endpoint. Put the host behind a reverse proxy or an Azure
+Container App with a TLS ingress, and set `host` in `apiDefinition.swagger.json` to that hostname.
+
+> **The host has no authentication of its own.** The `api_key` security definition forwards an
+> `Authorization` header, but nothing in the MCP host validates it — enforcement has to live in the
+> proxy in front. Exposing the host directly to the internet publishes read *and write* access to
+> every memory it holds. This is the one step that is genuinely dangerous to skim.
+
+## 3. Import the connector
+
+Power Apps / Power Automate → **Custom connectors** → **New custom connector** → *Import an OpenAPI
+file* → select `apiDefinition.swagger.json`.
+
+## 4. Add it to an agent
+
+Copilot Studio → your agent → **Tools** → **Add a tool** → **Model Context Protocol** → pick the
+connector. The tool list is discovered from the server at runtime rather than declared in the
+definition, so `memory_search`, `memory_add_entity` and the rest appear without the swagger listing
+them one by one — and stay correct when the server's tool surface changes.
+
+## Which tools an agent gets
+
+Governed by the host's own access flags, not by this connector:
+
+- `--read-only` restricts the surface to recall and inspection.
+- `--enable-graph-query` opts into raw Cypher (`nams_graph_query` remains deferred).
+
+Configure that at the host. A connector cannot narrow what the server offers, so an agent that must
+not write needs a host started `--read-only` rather than a connector that merely omits the tools.
+
+## Related
+
+- [MCP server tools](../../docs/memory-map.md)
+- [Security notes](../../docs/security)

--- a/connectors/copilot-studio/apiDefinition.swagger.json
+++ b/connectors/copilot-studio/apiDefinition.swagger.json
@@ -1,0 +1,47 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AgentMemory",
+    "description": "Persistent graph-backed agent memory over Neo4j. Recalls prior knowledge before a turn and persists new knowledge after it, across sessions and process restarts.",
+    "version": "1.0"
+  },
+  "host": "REPLACE-WITH-YOUR-HOST",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "summary": "AgentMemory MCP server",
+        "description": "Streamable HTTP MCP endpoint exposing the AgentMemory tool surface: memory_search, memory_get_context, memory_store_message, memory_add_entity, memory_add_preference and the entity, reasoning, conversation and maintenance tools.",
+        "operationId": "InvokeMCP",
+        "x-ms-agentic-protocol": "mcp-streamable-1.0",
+        "responses": {
+          "default": {
+            "description": "default"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Authorization",
+      "description": "Bearer token forwarded to the MCP host. The host is NOT authenticated by default — see the README before exposing it beyond a private network."
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ]
+}


### PR DESCRIPTION
Three items previously classed as blocked, re-examined.

**5.8 — already done.** The generic half (type-filtered sampling, abstention control, run provenance) landed upstream as AgentEval PR #156, released in `v0.20.0-beta`, which this repo already references. Verified we consume the upstream types rather than a fork: `AbstentionSamplingPolicy` is defined nowhere here.

**12.8 — definition shipped.** The connector was never outside this repo; only the tenant is. `connectors/copilot-studio/` carries an OpenAPI 2.0 definition using `x-ms-agentic-protocol: mcp-streamable-1.0` against the root route `MapMcp()` serves. Marked untested-in-anger — it has never been imported into a live tenant. The README leads with the real hazard: **the MCP host does no authentication of its own**, so the forwarded `Authorization` header is never validated and exposing the host directly publishes read *and write* access to every memory it holds.

**2.1 — blocker dissolved.** Confirmed by inspection that `/search_messages`, `/search_entities` and `/search_preferences` all serialise `Embedding` from a vector search, which is why the reverted prototype needed a 178-case TCK run. Making the projection **opt-in on the search call** is TCK-safe *by construction* — the assembler drops the vector, the bridge does not. Not implemented here: it touches the hottest path across five query families, and a subtly wrong projection there is the looks-correct-silently-wrong shape this track exists to prevent. Ready to build first, no external dependency.

Docs and a connector definition only — no source changes. Release build 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE