### PR TITLE
Recall payload projection (2.1): stop shipping the vector back

### DIFF
--- a/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
@@ -174,6 +174,34 @@ public sealed record MemoryOptions
     /// </remarks>
     public bool ResolveTemporalQueries { get; init; }
 
+    /// <summary>
+    /// Stops vector recall shipping the stored embedding back with every hit (rank 13 / payload).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every entity, fact and preference vector search returns the whole node — including its
+    /// embedding, which at 384 dimensions is roughly <b>3 KB per item and ~130 KB per turn</b> moved
+    /// across the wire, deserialized, and thrown away. Nothing on the recall path reads it: the
+    /// similarity was computed inside the index.
+    /// </para>
+    /// <para>
+    /// A measured prototype showed <b>−91% on the entity transaction and −21% on the whole turn</b>
+    /// with every quality guard flat.
+    /// </para>
+    /// <para>
+    /// <b>Opt-in, and that is a correctness decision rather than caution.</b> Recalled memories come
+    /// back with <c>Embedding = null</c> when this is on. Anything that re-uses a recalled vector —
+    /// notably the TCK conformance bridge, which serialises embeddings on three search endpoints —
+    /// must leave it off. Making it a setting the caller enables means such a consumer is unaffected
+    /// <i>by construction</i>, rather than by remembering to check.
+    /// </para>
+    /// <para>
+    /// Honoured by the entity, fact and preference vector searches, which share one query finisher.
+    /// Message and trace searches keep returning whole nodes.
+    /// </para>
+    /// </remarks>
+    public bool OmitEmbeddingsFromRecall { get; init; }
+
     // NOTE: extraction at the Core layer is explicit (call ExtractAndPersistAsync /
     // ExtractFromSessionAsync). Automatic extraction on message persist is an adapter concern, configured
     // by AgentFrameworkOptions.AutoExtractOnPersist. The former EnableAutoExtraction flag here was read

--- a/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/EntityQueries.cs
@@ -95,14 +95,15 @@ internal static class EntityQueries
     /// <paramref name="recencyRerank"/> is set (D1) the clamped ACT-R retention score is blended into the
     /// order key; when unset the query is byte-for-byte today's semantic-only ranking.
     /// </summary>
-    public static string SearchByVector(bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false) =>
+    public static string SearchByVector(
+        bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false, bool omitEmbedding = false) =>
         VectorRerank.Finish(
             new CypherBuilder()
                 .WithVectorSearch("entity_embedding_idx", "$embedding", "node", topK)
                 .Where("score >= $minScore")
                 .And("node.invalidated_at IS NULL")
                 .And(includeShared ? "(node.owner_id = $ownerId OR node.owner_id IS NULL)" : "node.owner_id = $ownerId", when: hasOwnerFilter),
-            recencyRerank);
+            recencyRerank, omitEmbedding);
 
     // ── GetByTypeAsync ─────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/FactQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/FactQueries.cs
@@ -303,7 +303,8 @@ internal static class FactQueries
     /// order key (<c>$tmpWeight</c>); when unset the query is byte-for-byte today's semantic-only ranking.
     /// </summary>
     public static string SearchByVector(
-        bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false, bool currentValidTime = false) =>
+        bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false,
+        bool currentValidTime = false, bool omitEmbedding = false) =>
         VectorRerank.Finish(
             new CypherBuilder()
                 .WithVectorSearch("fact_embedding_idx", "$embedding", "node", topK)
@@ -317,7 +318,7 @@ internal static class FactQueries
                 .And("(node.valid_from IS NULL OR node.valid_from <= datetime($now))", when: currentValidTime)
                 .And("(node.valid_until IS NULL OR node.valid_until > datetime($now))", when: currentValidTime)
                 .And(includeShared ? "(node.owner_id = $ownerId OR node.owner_id IS NULL)" : "node.owner_id = $ownerId", when: hasOwnerFilter),
-            recencyRerank);
+            recencyRerank, omitEmbedding);
 
     /// <summary>
     /// Last-resort owner-scoped similarity search that does NOT use the global vector index.

--- a/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/PreferenceQueries.cs
@@ -77,14 +77,15 @@ internal static class PreferenceQueries
     /// <paramref name="recencyRerank"/> is set (D1) the clamped ACT-R retention score is blended into the
     /// order key; when unset the query is byte-for-byte today's semantic-only ranking.
     /// </summary>
-    public static string SearchByVector(bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false) =>
+    public static string SearchByVector(
+        bool hasOwnerFilter, bool includeShared, int topK, bool recencyRerank = false, bool omitEmbedding = false) =>
         VectorRerank.Finish(
             new CypherBuilder()
                 .WithVectorSearch("preference_embedding_idx", "$embedding", "node", topK)
                 .Where("score >= $minScore")
                 .And("node.invalidated_at IS NULL")
                 .And(includeShared ? "(node.owner_id = $ownerId OR node.owner_id IS NULL)" : "node.owner_id = $ownerId", when: hasOwnerFilter),
-            recencyRerank);
+            recencyRerank, omitEmbedding);
 
     // ── Dedup-on-create ────────────────────────────────────────────────
 

--- a/src/AgentMemory.Neo4j/Queries/VectorRerank.cs
+++ b/src/AgentMemory.Neo4j/Queries/VectorRerank.cs
@@ -35,8 +35,18 @@ internal static class VectorRerank
     /// </summary>
     /// <param name="builder">A builder already carrying the CALL+YIELD and any owner WHERE clauses.</param>
     /// <param name="recencyRerank">When true, blend the clamped retention score into the order key.</param>
-    public static string Finish(CypherBuilder builder, bool recencyRerank)
+    public static string Finish(CypherBuilder builder, bool recencyRerank, bool omitEmbedding = false)
     {
+        // The embedding is projected away at the FINAL return only. The recency branch below still
+        // reads node.last_accessed_at and node.created_at in its WITH clauses, so stripping earlier
+        // would silently disable the re-ranker rather than shrink the payload.
+        //
+        // `node {.*, embedding: NULL}` keeps every other property and yields a MAP, not a Node --
+        // which is why the read sites need dictionary mappers. That is the documented trap here, and
+        // the reason this is projected rather than removed with an all-but-one helper that Cypher
+        // does not have.
+        var projection = omitEmbedding ? "node {.*, embedding: NULL} AS node" : "node";
+
         if (recencyRerank)
         {
             builder = builder
@@ -46,11 +56,11 @@ internal static class VectorRerank
                 // Retention score clamped to [0,1] so it is scale-comparable to the cosine score.
                 .With($"node, score, CASE WHEN ({RetentionExpr}) > 1.0 THEN 1.0 ELSE ({RetentionExpr}) END AS sTmp")
                 // Convex blend: (1−w)·semantic + w·recency.
-                .Return("node, ((1.0 - $tmpWeight) * score + $tmpWeight * sTmp) AS score");
+                .Return($"{projection}, ((1.0 - $tmpWeight) * score + $tmpWeight * sTmp) AS score");
         }
         else
         {
-            builder = builder.Return("node, score");
+            builder = builder.Return($"{projection}, score");
         }
 
         return builder

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jEntityRepository.cs
@@ -20,6 +20,8 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
 
     private readonly INeo4jTransactionRunner _tx;
     private readonly bool _rescueShortOwnerResults;
+    /// <summary>Payload projection: drop the ~3 KB vector nothing on the recall path reads.</summary>
+    private readonly bool _omitEmbeddingsFromRecall;
     private readonly ILogger<Neo4jEntityRepository> _logger;
     private readonly MemoryRankingOptions _ranking;
     private readonly MemoryDecayOptions _decay;
@@ -66,6 +68,7 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
         IOptions<MemoryOptions>? memoryOptions = null)
     {
         _rescueShortOwnerResults = memoryOptions?.Value.RescueShortOwnerResults ?? false;
+        _omitEmbeddingsFromRecall = memoryOptions?.Value.OmitEmbeddingsFromRecall ?? false;
         _tx = tx;
         _logger = logger;
         _ranking = ranking?.Value ?? MemoryRankingOptions.Default;
@@ -213,9 +216,12 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
 
         var ranking = _rankingContext?.Current ?? _ranking;   // per-request intent (D3) overrides the configured ranking
         bool recencyRerank = ranking.RecencyRerankEnabled;
+        // Payload projection: nothing on the recall path reads the vector back, and it is ~3 KB an item.
+        bool omitEmbedding = _omitEmbeddingsFromRecall;
         async Task<List<(Entity, double)>> QueryAsync(int width, CancellationToken ct)
         {
-            var cypher = EntityQueries.SearchByVector(hasOwner, includeShared, width, recencyRerank);
+            var cypher = EntityQueries.SearchByVector(
+                hasOwner, includeShared, width, recencyRerank, omitEmbedding);
             var parameters = new Dictionary<string, object?>
             {
                 ["embedding"] = queryEmbedding.ToList(),
@@ -231,8 +237,12 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
                 var records = await cursor.ToListAsync().ConfigureAwait(false);
                 return records.Select(r =>
                 {
-                    var node = r["node"].As<INode>();
                     var score = r["score"].As<double>();
+                    // Projected recall returns a MAP, not a Node, and carries no embedding to read.
+                    if (omitEmbedding)
+                        return (MapToEntity(r["node"].As<IReadOnlyDictionary<string, object>>(), null), score);
+
+                    var node = r["node"].As<INode>();
                     return (MapToEntity(node, ReadEmbedding(node)), score);
                 }).ToList();
             }, ct).ConfigureAwait(false) ?? [];
@@ -592,11 +602,17 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    private static Entity MapToEntity(INode node, float[]? embedding)
+    /// <summary>Maps from a node's properties, so a projected MAP maps identically to a Node.</summary>
+    /// <remarks>
+    /// The recall payload projection returns <c>node {.*, embedding: NULL}</c>, which is a MAP rather
+    /// than a Node. Both paths share this body so the two cannot drift into mapping the same stored
+    /// entity differently depending on which query fetched it.
+    /// </remarks>
+    private static Entity MapToEntity(IReadOnlyDictionary<string, object> properties, float[]? embedding)
     {
         double? latitude = null;
         double? longitude = null;
-        if (node.Properties.TryGetValue("location", out var locValue) && locValue is Point pt)
+        if (properties.TryGetValue("location", out var locValue) && locValue is Point pt)
         {
             // WGS-84: X = longitude, Y = latitude
             latitude = pt.Y;
@@ -605,31 +621,34 @@ internal sealed partial class Neo4jEntityRepository : IEntityRepository, IUpsert
 
         return new Entity
         {
-            EntityId = node["id"].As<string>(),
-            OwnerId = node.Properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
-            Name = node["name"].As<string>(),
-            CanonicalName = node.Properties.TryGetValue("canonical_name", out var cn) ? cn.As<string>() : null,
-            Type = node["type"].As<string>(),
-            Subtype = node.Properties.TryGetValue("subtype", out var st) ? st.As<string>() : null,
-            Description = node.Properties.TryGetValue("description", out var desc) ? desc.As<string>() : null,
-            Confidence = node["confidence"].As<double>(),
+            EntityId = properties["id"].As<string>(),
+            OwnerId = properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
+            Name = properties["name"].As<string>(),
+            CanonicalName = properties.TryGetValue("canonical_name", out var cn) ? cn.As<string>() : null,
+            Type = properties["type"].As<string>(),
+            Subtype = properties.TryGetValue("subtype", out var st) ? st.As<string>() : null,
+            Description = properties.TryGetValue("description", out var desc) ? desc.As<string>() : null,
+            Confidence = properties["confidence"].As<double>(),
             Embedding = embedding,
             Latitude = latitude,
             Longitude = longitude,
-            Aliases = node.Properties.TryGetValue("aliases", out var al)
+            Aliases = properties.TryGetValue("aliases", out var al)
                                 ? al.As<IList<object>>().Select(a => a.ToString()!).ToList()
                                 : Array.Empty<string>(),
-            Attributes = DeserializeMetadata(node.Properties.TryGetValue("attributes", out var attr) ? attr.As<string>() : null),
-            SourceMessageIds = node.Properties.TryGetValue("source_message_ids", out var sm)
+            Attributes = DeserializeMetadata(properties.TryGetValue("attributes", out var attr) ? attr.As<string>() : null),
+            SourceMessageIds = properties.TryGetValue("source_message_ids", out var sm)
                                 ? sm.As<IList<object>>().Select(v => v.ToString()!).ToList()
                                 : Array.Empty<string>(),
-            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(node["created_at"]),
-            UpdatedAtUtc = node.Properties.TryGetValue("updated_at", out var ua) && ua is not null
+            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(properties["created_at"]),
+            UpdatedAtUtc = properties.TryGetValue("updated_at", out var ua) && ua is not null
                                 ? Neo4jDateTimeHelper.ReadNullableDateTimeOffset(ua)
                                 : null,
-            Metadata = DeserializeMetadata(node.Properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
+            Metadata = DeserializeMetadata(properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
         };
     }
+
+    private static Entity MapToEntity(INode node, float[]? embedding) =>
+        MapToEntity(node.Properties, embedding);
 
     public async Task<Entity?> ApplyConfidenceDeltaAsync(
         string entityId, double delta, MemoryScope? scope = null, CancellationToken cancellationToken = default)

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jFactRepository.cs
@@ -24,6 +24,8 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
 
     private readonly INeo4jTransactionRunner _tx;
     private readonly bool _rescueShortOwnerResults;
+    /// <summary>Payload projection: drop the ~3 KB vector nothing on the recall path reads.</summary>
+    private readonly bool _omitEmbeddingsFromRecall;
     private readonly double _reinforceAlpha;
     private readonly ILogger<Neo4jFactRepository> _logger;
     private readonly MemoryRankingOptions _ranking;
@@ -39,6 +41,7 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
         IOptions<MemoryOptions>? memoryOptions = null)
     {
         _rescueShortOwnerResults = memoryOptions?.Value.RescueShortOwnerResults ?? false;
+        _omitEmbeddingsFromRecall = memoryOptions?.Value.OmitEmbeddingsFromRecall ?? false;
         _reinforceAlpha = memoryOptions?.Value.ConfidenceReinforcementAlpha ?? 0.0;
         _tx = tx;
         _logger = logger;
@@ -386,15 +389,20 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
         async Task<List<(Fact, double)>> QueryAsync(int width, CancellationToken ct)
         {
             var cypher = FactQueries.SearchByVector(
-                hasOwner, includeShared, width, recencyRerank, currentValidTime);
+                hasOwner, includeShared, width, recencyRerank, currentValidTime,
+                omitEmbedding: _omitEmbeddingsFromRecall);
             return await _tx.ReadAsync(async runner =>
             {
                 var cursor = await runner.RunAsync(cypher, parameters).ConfigureAwait(false);
                 var records = await cursor.ToListAsync().ConfigureAwait(false);
                 return records.Select(r =>
                 {
-                    var node = r["node"].As<INode>();
                     var score = r["score"].As<double>();
+                    // Projected recall returns a MAP, not a Node, and carries no embedding to read.
+                    if (_omitEmbeddingsFromRecall)
+                        return (MapToFact(r["node"].As<IReadOnlyDictionary<string, object>>(), null), score);
+
+                    var node = r["node"].As<INode>();
                     return (MapToFact(node, ReadEmbedding(node)), score);
                 }).ToList();
             }, ct).ConfigureAwait(false) ?? [];
@@ -578,32 +586,41 @@ internal sealed partial class Neo4jFactRepository : IFactRepository, IUpsertPers
         string subject, string predicate, string @object, string ownerKey)
         => (subject, predicate, @object, ownerKey);
 
-    private static Fact MapToFact(INode node, float[]? embedding) =>
+    /// <summary>Maps from properties, so a projected MAP maps identically to a Node.</summary>
+    /// <remarks>
+    /// Recall payload projection returns <c>node {.*, embedding: NULL}</c> — a MAP, not a Node.
+    /// Both paths share this body so the same stored row cannot map differently depending on
+    /// which query fetched it.
+    /// </remarks>
+    private static Fact MapToFact(IReadOnlyDictionary<string, object> properties, float[]? embedding) =>
         new()
         {
-            FactId = node["id"].As<string>(),
-            Subject = node["subject"].As<string>(),
-            Predicate = node["predicate"].As<string>(),
-            Object = node["object"].As<string>(),
-            OwnerId = node.Properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
-            Category = node.Properties.TryGetValue("category", out var cat) ? cat.As<string>() : null,
-            Confidence = node["confidence"].As<double>(),
-            ValidFrom = node.Properties.TryGetValue("valid_from", out var vf)
+            FactId = properties["id"].As<string>(),
+            Subject = properties["subject"].As<string>(),
+            Predicate = properties["predicate"].As<string>(),
+            Object = properties["object"].As<string>(),
+            OwnerId = properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
+            Category = properties.TryGetValue("category", out var cat) ? cat.As<string>() : null,
+            Confidence = properties["confidence"].As<double>(),
+            ValidFrom = properties.TryGetValue("valid_from", out var vf)
                                 ? Neo4jDateTimeHelper.ReadNullableDateTimeOffset(vf)
                                 : null,
-            ValidUntil = node.Properties.TryGetValue("valid_until", out var vu)
+            ValidUntil = properties.TryGetValue("valid_until", out var vu)
                                 ? Neo4jDateTimeHelper.ReadNullableDateTimeOffset(vu)
                                 : null,
-            InvalidatedAtUtc = node.Properties.TryGetValue("invalidated_at", out var iat)
+            InvalidatedAtUtc = properties.TryGetValue("invalidated_at", out var iat)
                                 ? Neo4jDateTimeHelper.ReadNullableDateTimeOffset(iat)
                                 : null,
             Embedding = embedding,
-            SourceMessageIds = node.Properties.TryGetValue("source_message_ids", out var sm)
+            SourceMessageIds = properties.TryGetValue("source_message_ids", out var sm)
                                 ? sm.As<IList<object>>().Select(v => v.ToString()!).ToList()
                                 : Array.Empty<string>(),
-            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(node["created_at"]),
-            Metadata = DeserializeMetadata(node.Properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
+            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(properties["created_at"]),
+            Metadata = DeserializeMetadata(properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
         };
+
+    private static Fact MapToFact(INode node, float[]? embedding) =>
+        MapToFact(node.Properties, embedding);
 
     private static float[]? ReadEmbedding(INode node)
     {

--- a/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
+++ b/src/AgentMemory.Neo4j/Repositories/Neo4jPreferenceRepository.cs
@@ -20,6 +20,8 @@ internal sealed partial class Neo4jPreferenceRepository : IPreferenceRepository,
 
     private readonly INeo4jTransactionRunner _tx;
     private readonly bool _rescueShortOwnerResults;
+    /// <summary>Payload projection: drop the ~3 KB vector nothing on the recall path reads.</summary>
+    private readonly bool _omitEmbeddingsFromRecall;
     private readonly ILogger<Neo4jPreferenceRepository> _logger;
     private readonly MemoryRankingOptions _ranking;
     private readonly MemoryDecayOptions _decay;
@@ -66,6 +68,7 @@ internal sealed partial class Neo4jPreferenceRepository : IPreferenceRepository,
         IOptions<MemoryOptions>? memoryOptions = null)
     {
         _rescueShortOwnerResults = memoryOptions?.Value.RescueShortOwnerResults ?? false;
+        _omitEmbeddingsFromRecall = memoryOptions?.Value.OmitEmbeddingsFromRecall ?? false;
         _tx = tx;
         _logger = logger;
         _ranking = ranking?.Value ?? MemoryRankingOptions.Default;
@@ -230,7 +233,8 @@ internal sealed partial class Neo4jPreferenceRepository : IPreferenceRepository,
         bool recencyRerank = ranking.RecencyRerankEnabled;
         async Task<List<(Preference, double)>> QueryAsync(int width, CancellationToken ct)
         {
-            var cypher = PreferenceQueries.SearchByVector(hasOwner, includeShared, width, recencyRerank);
+            var cypher = PreferenceQueries.SearchByVector(
+                hasOwner, includeShared, width, recencyRerank, _omitEmbeddingsFromRecall);
             var parameters = new Dictionary<string, object?>
             {
                 ["embedding"] = queryEmbedding.ToList(),
@@ -246,8 +250,12 @@ internal sealed partial class Neo4jPreferenceRepository : IPreferenceRepository,
                 var records = await cursor.ToListAsync().ConfigureAwait(false);
                 return records.Select(r =>
                 {
-                    var node = r["node"].As<INode>();
                     var score = r["score"].As<double>();
+                    // Projected recall returns a MAP, not a Node, and carries no embedding to read.
+                    if (_omitEmbeddingsFromRecall)
+                        return (MapToPreference(r["node"].As<IReadOnlyDictionary<string, object>>(), null), score);
+
+                    var node = r["node"].As<INode>();
                     return (MapToPreference(node, ReadEmbedding(node)), score);
                 }).ToList();
             }, ct).ConfigureAwait(false) ?? [];
@@ -495,22 +503,31 @@ internal sealed partial class Neo4jPreferenceRepository : IPreferenceRepository,
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    private static Preference MapToPreference(INode node, float[]? embedding) =>
+    /// <summary>Maps from properties, so a projected MAP maps identically to a Node.</summary>
+    /// <remarks>
+    /// Recall payload projection returns <c>node {.*, embedding: NULL}</c> — a MAP, not a Node.
+    /// Both paths share this body so the same stored row cannot map differently depending on
+    /// which query fetched it.
+    /// </remarks>
+    private static Preference MapToPreference(IReadOnlyDictionary<string, object> properties, float[]? embedding) =>
         new()
         {
-            PreferenceId = node["id"].As<string>(),
-            OwnerId = node.Properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
-            Category = node["category"].As<string>(),
-            PreferenceText = node["preference"].As<string>(),
-            Context = node.Properties.TryGetValue("context", out var ctx) ? ctx.As<string>() : null,
-            Confidence = node["confidence"].As<double>(),
+            PreferenceId = properties["id"].As<string>(),
+            OwnerId = properties.TryGetValue("owner_id", out var oid) ? oid.As<string>() : null,
+            Category = properties["category"].As<string>(),
+            PreferenceText = properties["preference"].As<string>(),
+            Context = properties.TryGetValue("context", out var ctx) ? ctx.As<string>() : null,
+            Confidence = properties["confidence"].As<double>(),
             Embedding = embedding,
-            SourceMessageIds = node.Properties.TryGetValue("source_message_ids", out var sm)
+            SourceMessageIds = properties.TryGetValue("source_message_ids", out var sm)
                                 ? sm.As<IList<object>>().Select(v => v.ToString()!).ToList()
                                 : Array.Empty<string>(),
-            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(node["created_at"]),
-            Metadata = DeserializeMetadata(node.Properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
+            CreatedAtUtc = Neo4jDateTimeHelper.ReadDateTimeOffset(properties["created_at"]),
+            Metadata = DeserializeMetadata(properties.TryGetValue("metadata", out var md) ? md.As<string>() : null)
         };
+
+    private static Preference MapToPreference(INode node, float[]? embedding) =>
+        MapToPreference(node.Properties, embedding);
 
     private static float[]? ReadEmbedding(INode node)
     {

--- a/tests/AgentMemory.Tests.Integration/Repositories/RecallPayloadProjectionIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Repositories/RecallPayloadProjectionIntegrationTests.cs
@@ -1,0 +1,156 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Neo4j.Repositories;
+using AgentMemory.Tests.Integration.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace AgentMemory.Tests.Integration.Repositories;
+
+/// <summary>
+/// The payload projection against a real database, where a MAP is not a Node.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Cypher shape is unit-tested. What only Neo4j can show is that <c>node {.*, embedding: NULL}</c>
+/// deserializes into the <i>same</i> memory the un-projected query returns — because the projected
+/// path takes a different mapper overload, and a property that silently stopped arriving would show
+/// up as a null field rather than as an error.
+/// </para>
+/// <para>
+/// That is the whole risk of this change: it is on the hottest path in the system, and getting it
+/// subtly wrong produces memories that look fine.
+/// </para>
+/// </remarks>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public class RecallPayloadProjectionIntegrationTests : IAsyncLifetime
+{
+    private readonly Neo4jIntegrationFixture _fixture;
+
+    public RecallPayloadProjectionIntegrationTests(Neo4jIntegrationFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.CleanDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // Four dimensions: the integration fixture's vector indexes are built at that width, and the
+    // driver rejects a mismatched query vector outright.
+    private static readonly float[] Vector = [0.5f, 0.5f, 0.5f, 0.5f];
+    private static readonly MemoryScope Alice = MemoryScope.For("alice", includeShared: false);
+
+    private Neo4jEntityRepository Entities(bool omit) =>
+        new(_fixture.TransactionRunner, NullLogger<Neo4jEntityRepository>.Instance,
+            memoryOptions: Options.Create(new MemoryOptions { OmitEmbeddingsFromRecall = omit }));
+
+    private Neo4jFactRepository Facts(bool omit) =>
+        new(_fixture.TransactionRunner, NullLogger<Neo4jFactRepository>.Instance,
+            memoryOptions: Options.Create(new MemoryOptions { OmitEmbeddingsFromRecall = omit }));
+
+    private async Task SeedEntityAsync() =>
+        await Entities(false).UpsertAsync(new Entity
+        {
+            EntityId = "e-1",
+            Name = "Alice",
+            Type = "Person",
+            Subtype = "Colleague",
+            Description = "works in the Zurich office",
+            Confidence = 0.87,
+            OwnerId = "alice",
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Embedding = Vector,
+        });
+
+    [Fact]
+    public async Task TheProjectedEntityMatchesTheUnprojectedOneFieldForField()
+    {
+        // THE test. Two mapper overloads reading the same stored row must produce the same memory --
+        // everything except the vector, which is the point.
+        await SeedEntityAsync();
+
+        var full = await Entities(false).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+        var projected = await Entities(true).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+
+        full.Should().ContainSingle();
+        projected.Should().ContainSingle();
+
+        var a = full[0].Entity;
+        var b = projected[0].Entity;
+
+        b.EntityId.Should().Be(a.EntityId);
+        b.Name.Should().Be(a.Name);
+        b.Type.Should().Be(a.Type);
+        b.Subtype.Should().Be(a.Subtype);
+        b.Description.Should().Be(a.Description);
+        b.Confidence.Should().Be(a.Confidence);
+        b.OwnerId.Should().Be(a.OwnerId);
+        b.CreatedAtUtc.Should().Be(a.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task TheVectorIsPresentByDefaultAndAbsentWhenProjected()
+    {
+        // Both halves in one assertion pair. The first is what keeps the TCK bridge working; the
+        // second is the ~3 KB an item that stops crossing the wire.
+        await SeedEntityAsync();
+
+        (await Entities(false).SearchByVectorAsync(Vector, 10, 0.0, Alice))[0]
+            .Entity.Embedding.Should().NotBeNullOrEmpty();
+
+        (await Entities(true).SearchByVectorAsync(Vector, 10, 0.0, Alice))[0]
+            .Entity.Embedding.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ScoresAreUnchangedByTheProjection()
+    {
+        // Similarity is computed inside the index, so projecting the payload must not touch ranking.
+        // If it did, the change would trade a payload win for a silent relevance regression.
+        await SeedEntityAsync();
+
+        var full = await Entities(false).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+        var projected = await Entities(true).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+
+        projected[0].Score.Should().BeApproximately(full[0].Score, 1e-9);
+    }
+
+    [Fact]
+    public async Task FactsProjectEquivalentlyToo()
+    {
+        await Facts(false).UpsertAsync(new Fact
+        {
+            FactId = "f-1",
+            Subject = "Alice",
+            Predicate = "lives in",
+            Object = "Zurich",
+            Confidence = 0.91,
+            OwnerId = "alice",
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Embedding = Vector,
+        });
+
+        var full = await Facts(false).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+        var projected = await Facts(true).SearchByVectorAsync(Vector, 10, 0.0, Alice);
+
+        projected.Should().ContainSingle();
+        projected[0].Fact.Subject.Should().Be(full[0].Fact.Subject);
+        projected[0].Fact.Predicate.Should().Be(full[0].Fact.Predicate);
+        projected[0].Fact.Object.Should().Be(full[0].Fact.Object);
+        projected[0].Fact.Confidence.Should().Be(full[0].Fact.Confidence);
+        projected[0].Fact.Embedding.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task OwnerIsolationSurvivesTheProjection()
+    {
+        // R1 is enforced in the WHERE clause, which the projection does not touch -- asserted rather
+        // than assumed, because a payload change that widened visibility would be the worst possible
+        // way to save 3 KB.
+        await SeedEntityAsync();
+
+        var otherOwner = await Entities(true)
+            .SearchByVectorAsync(Vector, 10, 0.0, MemoryScope.For("bob", includeShared: false));
+
+        otherOwner.Should().BeEmpty();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Queries/RecallPayloadProjectionTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/RecallPayloadProjectionTests.cs
@@ -1,0 +1,94 @@
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Neo4j.Queries;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Queries;
+
+/// <summary>
+/// Not shipping the stored vector back with every recall hit (rank 13 / payload projection).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every entity, fact and preference vector search returned the whole node — including a 384-dim
+/// embedding, roughly <b>3 KB per item and ~130 KB per turn</b> moved across the wire, deserialized,
+/// and discarded. Nothing on the recall path reads it; the similarity was computed inside the index.
+/// A measured prototype showed <b>−91% on the entity transaction and −21% on the whole turn</b>.
+/// </para>
+/// <para>
+/// <b>That prototype was reverted because an unconditional projection is unsafe here.</b> The TCK
+/// conformance bridge serialises embeddings on three search endpoints — <c>/search_messages</c>,
+/// <c>/search_entities</c>, <c>/search_preferences</c> — and would silently start emitting null,
+/// which is why the original plan demanded validation against the full 178-case run.
+/// </para>
+/// <para>
+/// Making it opt-in removes the need for that run: a consumer that re-uses recalled vectors simply
+/// does not enable it, so it is unaffected <b>by construction</b> rather than by a test that passed
+/// once. These tests pin both halves — the projection when asked for, and its complete absence when
+/// not.
+/// </para>
+/// </remarks>
+public sealed class RecallPayloadProjectionTests
+{
+    public static TheoryData<string, Func<bool, string>> Searches => new()
+    {
+        { "Entity", omit => EntityQueries.SearchByVector(true, true, 100, false, omit) },
+        { "Preference", omit => PreferenceQueries.SearchByVector(true, true, 100, false, omit) },
+        { "Fact", omit => FactQueries.SearchByVector(true, true, 100, false, false, omit) },
+    };
+
+    [Theory]
+    [MemberData(nameof(Searches))]
+    public void OffByDefaultTheQueryIsByteIdentical(string name, Func<bool, string> build)
+    {
+        // The off state, and it is the default. Every sealed measurement and the TCK bridge both run
+        // on this exact Cypher; a projection that leaked into the default would change what the
+        // conformance suite receives without anything saying so.
+        _ = name;
+
+        build(false).Should().NotContain("embedding: NULL");
+        build(false).Should().Contain("RETURN node, score");
+    }
+
+    [Theory]
+    [MemberData(nameof(Searches))]
+    public void WhenOmittedTheEmbeddingIsProjectedAway(string name, Func<bool, string> build)
+    {
+        _ = name;
+
+        build(true).Should().Contain("node {.*, embedding: NULL} AS node");
+    }
+
+    [Theory]
+    [MemberData(nameof(Searches))]
+    public void EverythingElseIsStillReturned(string name, Func<bool, string> build)
+    {
+        // `.*` keeps every other property. Projecting an explicit allow-list instead would silently
+        // drop any property added later -- a mapper reading a missing key is a failure that shows up
+        // as a null field rather than as an error.
+        _ = name;
+
+        build(true).Should().Contain(".*");
+    }
+
+    [Fact]
+    public void TheRecencyRerankerStillReadsTheNodeItNeeds()
+    {
+        // The projection happens at the FINAL return only. The recency branch reads
+        // node.last_accessed_at and node.created_at in its WITH clauses, so stripping earlier would
+        // disable the re-ranker rather than shrink the payload -- and the ordering would quietly
+        // revert to semantic-only.
+        var cypher = EntityQueries.SearchByVector(true, true, 100, recencyRerank: true, omitEmbedding: true);
+
+        cypher.Should().Contain("last_accessed_at");
+        cypher.Should().Contain("node {.*, embedding: NULL} AS node");
+    }
+
+    [Fact]
+    public void TheOptionIsOffByDefault()
+    {
+        // A consumer that re-uses recalled vectors -- the TCK bridge among them -- keeps working
+        // without knowing this exists.
+        new MemoryOptions().OmitEmbeddingsFromRecall.Should().BeFalse();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Queries/ScopedVectorSearchQueryTests.cs
@@ -25,8 +25,20 @@ public sealed class ScopedVectorSearchQueryTests
                 FactQueries.SearchByVector(owner, shared, topK, rerank)),
             "fact_embedding_idx",
         };
-        yield return new object[] { "Entity", (Func<bool, bool, int, bool, string>)EntityQueries.SearchByVector, "entity_embedding_idx" };
-        yield return new object[] { "Preference", (Func<bool, bool, int, bool, string>)PreferenceQueries.SearchByVector, "preference_embedding_idx" };
+        yield return new object[]
+        {
+            "Entity",
+            (Func<bool, bool, int, bool, string>)((owner, shared, topK, rerank) =>
+                EntityQueries.SearchByVector(owner, shared, topK, rerank)),
+            "entity_embedding_idx",
+        };
+        yield return new object[]
+        {
+            "Preference",
+            (Func<bool, bool, int, bool, string>)((owner, shared, topK, rerank) =>
+                PreferenceQueries.SearchByVector(owner, shared, topK, rerank)),
+            "preference_embedding_idx",
+        };
     }
 
     [Theory]


### PR DESCRIPTION
Every entity, fact and preference vector search returned the whole node including its 384-dim embedding — ~3 KB/item, ~130 KB/turn moved, deserialized and discarded. Nothing on the recall path reads it. Measured prototype: **−91% entity transaction, −21% whole turn**, quality guards flat.

**Why the prototype was reverted, and why this one isn't.** Confirmed the trap by inspection: the TCK bridge serialises embeddings on `/search_messages`, `/search_entities`, `/search_preferences`, so an unconditional projection emits null there — hence the original demand for a 178-case TCK run. Making it **opt-in removes that requirement rather than deferring it**: the bridge simply never enables it, so it's unaffected *by construction*.

`MemoryOptions.OmitEmbeddingsFromRecall`, default **false**, honoured by the three searches sharing `VectorRerank.Finish` — no partially-respected setting.

Three details that would each have failed silently:

- **Final return only.** The recency re-ranker reads `node.last_accessed_at` in its WITH clauses; stripping earlier would have disabled D1 and reverted ordering to semantic-only rather than shrinking anything.
- **`.*`, not an allow-list.** An explicit list silently drops properties added later, and a mapper reading a missing key yields a null field, not an error.
- **Shared mapper body.** `node {.*, embedding: NULL}` is a MAP, not a Node — the documented trap. Two mapper bodies would eventually map the same row differently depending on which query fetched it.

Verified against live Neo4j, not just the Cypher text: field-for-field equivalence, unchanged scores, and **owner isolation intact** — widening visibility would be the worst possible way to save 3 KB.

4,370 unit (+11) and 357 integration (+5) green. Release 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE