### PR TITLE
Wire the B3 token breakdown into the runner (12.3)

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/AgentMemoryLongMemEvalAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/AgentMemoryLongMemEvalAdapterTests.cs
@@ -92,10 +92,22 @@ public sealed class AgentMemoryLongMemEvalAdapterTests
                     // J5.1 context cost: a real measurement of this run, not a fixed expectation, so
                     // it is asserted below on its own terms rather than frozen into this shape.
                     .Excluding(info => info.Path == "AnswerPromptCharacters")
-                    .Excluding(info => info.Path == "EstimatedContextTokens"));
+                    .Excluding(info => info.Path == "EstimatedContextTokens")
+                    // B3: a real measurement of this run, asserted below on its own terms.
+                    .Excluding(info => info.Path.StartsWith("TokenBreakdown", StringComparison.Ordinal)));
         // The arm's actual cost must be recorded and non-zero: a prompt was demonstrably built above.
         telemetry.AnswerPromptCharacters.Should().BeGreaterThan(0);
         telemetry.EstimatedContextTokens.Should().BeGreaterThan(0);
+
+        // B3 wiring: the breakdown has to be PRODUCED by a real run, not merely producible. Its own
+        // tests prove the arithmetic; this proves something calls it.
+        telemetry.TokenBreakdown.Should().NotBeNull();
+        telemetry.TokenBreakdown!.ContextTokens.Should().BeGreaterThan(0);
+        telemetry.TokenBreakdown.FullHistoryTokens.Should().BeGreaterThan(0);
+        telemetry.TokenBreakdown.CompressionRatio.Should().NotBeNull();
+        // The counting method travels with the number: this fixture's model resolves no tiktoken
+        // encoding, so the value is an estimate and says so rather than passing as a measurement.
+        telemetry.TokenBreakdown.CountMethod.Should().NotBeNullOrWhiteSpace();
         telemetry.StageTimings.Should().NotBeNull(
             "accepted LongMemEval questions must expose a phase waterfall");
         telemetry.StageTimings!.StorageMs.Should().BeGreaterThan(0);

--- a/tools/AgentMemory.LongMemEval/AgentMemoryLongMemEvalAdapter.cs
+++ b/tools/AgentMemory.LongMemEval/AgentMemoryLongMemEvalAdapter.cs
@@ -27,6 +27,18 @@ public sealed partial class AgentMemoryLongMemEvalAdapter :
     private readonly IChatClient _chatClient;
     private readonly string _runId;
     private readonly LongMemEvalAdapterOptions _options;
+
+    /// <summary>
+    /// Tokenizer for the B3 breakdown, built lazily from the answer model.
+    /// </summary>
+    /// <remarks>
+    /// Lazy because constructing a tiktoken encoding is not free and a run that never reaches a
+    /// successful recall never needs one.
+    /// </remarks>
+    private LongMemEvalTokenCounter? _tokenCounter;
+
+    private LongMemEvalTokenCounter TokenCounter =>
+        _tokenCounter ??= new LongMemEvalTokenCounter(_options.ModelId);
     private readonly object _stateLock = new();
     private readonly List<LongMemEvalQuestionTelemetry> _telemetry = [];
     private IReadOnlyList<(string UserMessage, string AssistantResponse)>? _pendingHistory;
@@ -842,11 +854,14 @@ public sealed partial class AgentMemoryLongMemEvalAdapter :
             retrievalEvidence,
             extractionUnits,
             recall.Context,
-            graphSnapshot,
-            timings.Snapshot(),
-            preparedQuestion?.MessagesPrepared ?? 0,
-            preparedQuestion?.ExtractionUnitsPrepared ?? 0,
-            preparedQuestion is not null,
+            // B3: the transcript this context was distilled from, so the compression ratio has a
+            // denominator. Named from here on -- the positional tail is what a new parameter breaks.
+            fullHistory: messages,
+            graphSnapshot: graphSnapshot,
+            stageTimings: timings.Snapshot(),
+            messagesPrepared: preparedQuestion?.MessagesPrepared ?? 0,
+            extractionUnitsPrepared: preparedQuestion?.ExtractionUnitsPrepared ?? 0,
+            preparedMemory: preparedQuestion is not null,
             goldCoverage: goldCoverage,
             // Computed here rather than inside RecordTelemetry, which has neither the gold message
             // origins nor the evidence question in scope.
@@ -974,6 +989,7 @@ public sealed partial class AgentMemoryLongMemEvalAdapter :
         LongMemEvalRetrievalEvidence? retrievalEvidence = null,
         int extractionUnits = 0,
         MemoryContext? context = null,
+        IReadOnlyList<Message>? fullHistory = null,
         LongMemEvalGraphSnapshot? graphSnapshot = null,
         LongMemEvalStageTimings? stageTimings = null,
         int messagesPrepared = 0,
@@ -994,6 +1010,12 @@ public sealed partial class AgentMemoryLongMemEvalAdapter :
                 questionNumber, messagesStored, itemsRetrieved, recallTruncated, status)
             {
                 QuestionId = questionId,
+                // B3. Measured only when both halves are present: a breakdown against an absent
+                // transcript would report a null ratio, which is an absent measurement rather than a
+                // flattering one -- but emitting the row at all would invite it being read as zero.
+                TokenBreakdown = context is not null && fullHistory is { Count: > 0 }
+                    ? ContextTokenBreakdown.Measure(context, fullHistory, TokenCounter)
+                    : null,
                 RetrievalEvidence = retrievalEvidence,
                 ExtractionUnits = extractionUnits,
                 MessagesPrepared = messagesPrepared,
@@ -1641,6 +1663,17 @@ public sealed record LongMemEvalQuestionTelemetry(
 
     /// <summary>Approximate tokens in that prompt. An estimate, and named one.</summary>
     public int EstimatedContextTokens { get; init; }
+
+    /// <summary>
+    /// B3. The real token cost of the assembled memory context against the full transcript.
+    /// </summary>
+    /// <remarks>
+    /// Sits beside <see cref="EstimatedContextTokens"/> rather than replacing it, so the chars/4
+    /// estimate every earlier run recorded stays comparable with itself. The published claim —
+    /// "answering from memory costs a fraction of sending the conversation" — is read off this one,
+    /// because a compression ratio derived from an estimate is a claim about arithmetic.
+    /// </remarks>
+    public ContextTokenBreakdown? TokenBreakdown { get; init; }
 
     public string? QuestionId { get; init; }
 

--- a/tools/AgentMemory.LongMemEval/ContextTokenBreakdown.cs
+++ b/tools/AgentMemory.LongMemEval/ContextTokenBreakdown.cs
@@ -8,7 +8,7 @@ namespace AgentMemory.LongMemEval;
 /// <param name="Section">Section name, as it appears on <see cref="MemoryContext"/>.</param>
 /// <param name="Items">How many memories the section contributed.</param>
 /// <param name="Tokens">Their cost, counted with the real tokenizer.</param>
-internal sealed record ContextSectionTokens(string Section, int Items, int Tokens);
+public sealed record ContextSectionTokens(string Section, int Items, int Tokens);
 
 /// <summary>
 /// The token cost of answering from memory versus from the whole conversation (B3).
@@ -31,16 +31,16 @@ internal sealed record ContextSectionTokens(string Section, int Items, int Token
 /// result by measuring against a system that has already given up on remembering.
 /// </para>
 /// </remarks>
-internal sealed record ContextTokenBreakdown
+public sealed record ContextTokenBreakdown
 {
     /// <summary>Per-section costs, largest first.</summary>
-    internal required IReadOnlyList<ContextSectionTokens> Sections { get; init; }
+    public required IReadOnlyList<ContextSectionTokens> Sections { get; init; }
 
     /// <summary>Total tokens in the assembled memory context.</summary>
-    internal int ContextTokens => Sections.Sum(s => s.Tokens);
+    public int ContextTokens => Sections.Sum(s => s.Tokens);
 
     /// <summary>Tokens in the full conversation the memory was built from.</summary>
-    internal required int FullHistoryTokens { get; init; }
+    public required int FullHistoryTokens { get; init; }
 
     /// <summary>How the counting was done, so a reader can tell a real count from a fallback.</summary>
     /// <remarks>
@@ -48,10 +48,10 @@ internal sealed record ContextTokenBreakdown
     /// when it cannot resolve an encoding for the model, and a compression ratio computed from an
     /// estimate must not be readable as a measurement.
     /// </remarks>
-    internal required string CountMethod { get; init; }
+    public required string CountMethod { get; init; }
 
     /// <summary>The encoding used, when one was resolved.</summary>
-    internal string? Encoding { get; init; }
+    public string? Encoding { get; init; }
 
     /// <summary>
     /// How many times smaller the memory context is than the full history.
@@ -61,7 +61,7 @@ internal sealed record ContextTokenBreakdown
     /// infinity, it is an absent measurement, and reporting a number there would be the single most
     /// flattering way to be wrong.
     /// </remarks>
-    internal double? CompressionRatio =>
+    public double? CompressionRatio =>
         FullHistoryTokens == 0 ? null : (double)FullHistoryTokens / Math.Max(1, ContextTokens);
 
     /// <summary>


### PR DESCRIPTION
**The instrument existed and nothing called it.** A measured run would have spent money and emitted no breakdown — the dead-instrument shape this track has hit five times, and the one most likely to be discovered *after* paying for the run.

`ContextTokenBreakdown` is now computed in `RecordTelemetry` from the recalled context and the question's full transcript, emitted on every telemetry row. Proving it required the adapter's **end-to-end** test, not the instrument's arithmetic tests — a breakdown nothing invokes passes all of those while every run stays silent.

Placed **beside** `EstimatedContextTokens`, not replacing it: that field is a chars/4 estimate and is named one, and every earlier run recorded it. Swapping a real count under the same name would make this run incomparable with the series it belongs to while looking like a continuation of it.

The end-to-end test also vindicated a design choice — the fixture's model resolves no tiktoken encoding, so the run reports `CharacterHeuristic` and its ratio cannot be mistaken for a measurement.

One positional `RecordTelemetry` call site converted to named arguments; a positional tail is exactly what a new parameter breaks, and binding the wrong argument silently is how it breaks.

4,370 unit and 425 LongMemEval green. Release 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE