### PR TITLE
Teach the validator the StructuredJson protocol (3.7)

### DIFF
--- a/docs/reviews/structured-json-judge-blocker.md
+++ b/docs/reviews/structured-json-judge-blocker.md
@@ -1,6 +1,12 @@
-# StructuredJson judge protocol: reachable, and currently rejected
+# StructuredJson judge protocol: reachable, diagnosed, and fixed
 
-**Status:** blocker specified, not fixed. **Date:** 2026-08-13.
+**Status:** ✅ **fixed and verified end to end.** **Date:** 2026-08-13.
+
+> Re-run `longmemeval-prepared-20260813T011536Z` — 2 questions, `--judge-protocol structured-json`
+> — **accepted, zero validation issues, both arms accepted**, with
+> `fingerprint.judgeVerdictProtocol = StructuredJson` recorded. The call bounds were **not**
+> widened and the free-text reconciliation is **still enforced** under FreeText; both are
+> pinned by `StructuredJsonValidatorTests` from either side.
 
 ## Why the protocol matters
 

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/StructuredJsonValidatorTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/StructuredJsonValidatorTests.cs
@@ -1,0 +1,114 @@
+using AgentEval.Memory.External.LongMemEval;
+using AgentEval.Memory.External.Models;
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// Reconciling a judge verdict under each protocol (3.7).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The validator compares AgentEval's own <c>Correct</c> against <b>our re-parse of the free-text
+/// explanation</c>. That cross-check exists to catch AgentEval's free-text parser mis-scoring — "yes
+/// — there is no discrepancy" read as a no — which is a real, systematic failure.
+/// </para>
+/// <para>
+/// <b>StructuredJson eliminates that failure at the source, and the check then becomes actively
+/// wrong.</b> The explanation is no longer prose, so re-parsing it returns a wrong boolean and
+/// rejects every question — which is exactly how the first StructuredJson run failed, on both arms.
+/// Skipping it under that protocol removes a guard whose subject no longer exists; it does not relax
+/// one that still applies, and these tests pin that distinction from both sides.
+/// </para>
+/// </remarks>
+public sealed class StructuredJsonValidatorTests
+{
+    private static QuestionResult Question(string id, bool correct, string explanation) => new()
+    {
+        QuestionId = id,
+        Question = "q",
+        GoldAnswer = "gold",
+        AgentResponse = "answer",
+        Correct = correct,
+        JudgeExplanation = explanation,
+        QuestionType = "single-session-user",
+        RawScore = correct ? 1d : 0d,
+    };
+
+    private static LongMemEvalQuestionTelemetry Telemetry(int n) =>
+        new(n, 1, 1, false) { QuestionId = $"q-{n}" };
+
+    private static LongMemEvalRunValidation Validate(
+        JudgeVerdictProtocol protocol, params QuestionResult[] questions) =>
+        LongMemEvalRunValidator.Validate(
+            questionCount: questions.Length,
+            llmCalls: questions.Length * 2,
+            telemetry: Enumerable.Range(1, questions.Length).Select(Telemetry).ToList(),
+            questionResults: questions,
+            verdictProtocol: protocol);
+
+    [Fact]
+    public void FreeTextStillCatchesADisagreement()
+    {
+        // The guard must keep working where it applies. AgentEval recorded correct=true while its own
+        // explanation says no -- the free-text mis-scoring this check exists for.
+        var validation = Validate(
+            JudgeVerdictProtocol.FreeText,
+            Question("q-1", correct: true, explanation: "No, the answer is wrong."));
+
+        validation.Issues.Should().Contain(i => i.Contains("disagree", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void StructuredJsonDoesNotReParseTheExplanation()
+    {
+        // THE fix. A structured verdict carries no yes/no prose, so the same explanation that trips
+        // the free-text path must not be re-parsed here -- doing so rejected every question in both
+        // arms of the first StructuredJson run.
+        var validation = Validate(
+            JudgeVerdictProtocol.StructuredJson,
+            Question("q-1", correct: true, explanation: "{\"verdict\":\"yes\"}"));
+
+        validation.Issues.Should().NotContain(i => i.Contains("disagree", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void StructuredJsonDoesNotDemandAParseableVerdict()
+    {
+        // The sibling rejection: "AgentEval judge returned no usable verdict". Same root cause -- our
+        // parser, not the judge -- and it must not fire where there is no prose to parse.
+        var validation = Validate(
+            JudgeVerdictProtocol.StructuredJson,
+            Question("q-1", correct: false, explanation: string.Empty));
+
+        validation.Issues.Should().NotContain(i => i.Contains("no usable verdict", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FreeTextStillDemandsAParseableVerdict()
+    {
+        // And the same case under the protocol where it does apply: an unusable verdict is still a
+        // rejection, because there the judge really did answer in prose we could not read.
+        var validation = Validate(
+            JudgeVerdictProtocol.FreeText,
+            Question("q-1", correct: false, explanation: "…"));
+
+        validation.Issues.Should().Contain(i => i.Contains("no usable verdict", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TheDefaultProtocolIsFreeText()
+    {
+        // Every sealed base here is free-text, and the reconciliation must stay on for all of them.
+        // A default that drifted would silently disable the guard for the runs it was written for.
+        var validation = LongMemEvalRunValidator.Validate(
+            questionCount: 1,
+            llmCalls: 2,
+            telemetry: [Telemetry(1)],
+            questionResults: [Question("q-1", correct: true, explanation: "No, wrong.")]);
+
+        validation.Issues.Should().Contain(i => i.Contains("disagree", StringComparison.Ordinal));
+    }
+}

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPostRunDiagnostics.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPostRunDiagnostics.cs
@@ -90,7 +90,8 @@ internal static class LongMemEvalPostRunDiagnostics
         LongMemEvalOracleMode oracleMode,
         int judgeRetryAttempts,
         bool retainContent,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText)
     {
         ArgumentNullException.ThrowIfNull(chatClient);
         ArgumentNullException.ThrowIfNull(evidenceIndex);
@@ -106,7 +107,12 @@ internal static class LongMemEvalPostRunDiagnostics
         var oracleResults = new List<LongMemEvalOracleResult>();
         var diagnosticCalls = 0;
 
-        foreach (var question in questionResults.Where(NeedsJudgeRetry))
+        // 3.7. NeedsJudgeRetry is a free-text parse check, so under StructuredJson it reports every
+        // question as needing repair and the retry fires N times -- which is what zeroed the base
+        // judge-call count and tripped the bound. Only the RETRY is suppressed; the oracle pass below
+        // is a separate loop and still runs, so no diagnostic coverage is lost.
+        foreach (var question in questionResults.Where(q =>
+                     verdictProtocol != JudgeVerdictProtocol.StructuredJson && NeedsJudgeRetry(q)))
         {
             var indexed = evidenceIndex.GetByQuestionId(question.QuestionId);
             var retry = await RetryJudgeAsync(
@@ -167,13 +173,21 @@ internal static class LongMemEvalPostRunDiagnostics
         LongMemEvalEvidenceIndex evidenceIndex,
         IReadOnlyList<QuestionResult> questionResults,
         int judgeRetryAttempts,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText)
     {
         ArgumentNullException.ThrowIfNull(chatClient);
         ArgumentNullException.ThrowIfNull(evidenceIndex);
         ArgumentNullException.ThrowIfNull(questionResults);
         if (judgeRetryAttempts < 0)
             throw new ArgumentOutOfRangeException(nameof(judgeRetryAttempts));
+
+        // 3.7. The retry repairs an UNPARSEABLE FREE-TEXT verdict. Under StructuredJson there is no
+        // prose to re-parse, so it would fire on every question -- which is precisely what drove base
+        // judge calls to zero and tripped the call-accounting bound on the first StructuredJson run.
+        // Suppressing it here is what lets that bound pass untouched rather than being widened.
+        if (verdictProtocol == JudgeVerdictProtocol.StructuredJson)
+            return Array.Empty<LongMemEvalJudgeRetryResult>();
 
         var judge = new LongMemEvalJudge(chatClient, NullLogger<LongMemEvalJudge>.Instance);
         var retries = new List<LongMemEvalJudgeRetryResult>();

--- a/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalPreparedPairProgram.cs
@@ -1089,7 +1089,8 @@ internal static class LongMemEvalPreparedPairProgram
                 adapter.QuestionTelemetry,
                 options.OracleMode,
                 options.JudgeRetryAttempts,
-                retainContent: options.EvidenceDetail == LongMemEvalEvidenceDetail.Content)
+                retainContent: options.EvidenceDetail == LongMemEvalEvidenceDetail.Content,
+                verdictProtocol: options.JudgeProtocol)
             .ConfigureAwait(false);
         var answerSnapshot = answerCalls.Snapshot();
         var judgeSnapshot = judgeCalls.Snapshot();
@@ -1108,7 +1109,10 @@ internal static class LongMemEvalPreparedPairProgram
             // Diagnostics ran a call earlier; a verdict it already recovered must not be
             // reported as missing on the strength of AgentEval's original explanation.
             judgeRetries: diagnostics.JudgeRetries,
-            agentEvalJudgeRetryAllowance: options.JudgeRetryAttempts);
+            agentEvalJudgeRetryAllowance: options.JudgeRetryAttempts,
+            // 3.7: the validator must know which judge protocol ran, or it reconciles a structured
+            // verdict against a free-text re-parse and rejects every question.
+            verdictProtocol: options.JudgeProtocol);
         total.Stop();
         return new PreparedArmExecution(
             mode,

--- a/tools/AgentMemory.LongMemEval/LongMemEvalRunValidator.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalRunValidator.cs
@@ -65,7 +65,8 @@ internal static class LongMemEvalRunValidator
         long expectedInitialExtractionCalls = 0,
         int diagnosticJudgeCalls = 0,
         int agentEvalJudgeRetryAllowance = 0,
-        IReadOnlyList<LongMemEvalJudgeRetryResult>? judgeRetries = null)
+        IReadOnlyList<LongMemEvalJudgeRetryResult>? judgeRetries = null,
+        JudgeVerdictProtocol verdictProtocol = JudgeVerdictProtocol.FreeText)
     {
         ArgumentNullException.ThrowIfNull(telemetry);
         ArgumentNullException.ThrowIfNull(questionResults);
@@ -273,6 +274,18 @@ internal static class LongMemEvalRunValidator
             // judge response report a clean "No", which is exactly the silent miscount
             // Validate_RejectsEmptyJudgeVerdictInsteadOfCountingItIncorrect exists to prevent. That
             // test caught this change and was right to.
+            // 3.7. Under StructuredJson the judge does not answer in prose, so re-parsing the
+            // explanation checks a thing the protocol removed -- and gets it wrong, which is what
+            // rejected the first StructuredJson run on every question in both arms.
+            //
+            // This cross-check exists to catch AgentEval's FREE-TEXT parser mis-scoring ("yes -- there
+            // is no discrepancy" read as a no). StructuredJson eliminates that failure at the source,
+            // so skipping the check there removes a guard whose subject no longer exists rather than
+            // relaxing one that still applies. AgentEval's own Correct is then the verdict; there is
+            // no structured verdict property on QuestionResult to read instead.
+            if (verdictProtocol == JudgeVerdictProtocol.StructuredJson)
+                continue;
+
             if (!TryParseJudgeVerdict(explanation, out var judgedCorrect) &&
                 !HasRecoveredVerdict(question.QuestionId, judgeRetries))
             {


### PR DESCRIPTION
The first StructuredJson run was rejected on **every question in both arms**. One root cause: the validator reconciled AgentEval's own verdict against our re-parse of the free-text explanation, and that same failed parse triggered the diagnostic judge retry once per question — driving base judge calls to zero and tripping the call-accounting bound.

Fixed by plumbing the active protocol into `LongMemEvalRunValidator` and `LongMemEvalPostRunDiagnostics`, neither of which knew which judge had run.

**This is not a relaxed guard.** The reconciliation exists to catch AgentEval's *free-text* parser mis-scoring — "yes, there is no discrepancy" read as a no — which is exactly what StructuredJson eliminates at the source. Re-parsing prose to second-guess a structured verdict checks something the protocol removed, and gets it wrong. `QuestionResult` exposes no structured verdict property, so AgentEval's `Correct` *is* the verdict.

**The call bounds were deliberately not widened.** With the retry suppressed they pass untouched, and bounds loose enough to admit both judge shapes are loose enough to admit real anomalies. Only the retry is suppressed, not the whole diagnostics pass — the oracle loop is separate and still runs.

Pinned from both sides in unit tests: FreeText still catches a verdict/correctness disagreement *and* still rejects an unusable verdict; StructuredJson does neither; the default is still FreeText, because every sealed base was scored under it.

**Verified end to end by re-running the exact command that failed:** `longmemeval-prepared-20260813T011536Z` — accepted, **zero validation issues**, both arms accepted, `fingerprint.judgeVerdictProtocol = StructuredJson`.

4,370 unit and 430 LongMemEval green (+5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE