### PR TITLE
Promote successful attempts so 7.6 can measure anything

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/MafAgentTaskRunnerTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/MafAgentTaskRunnerTests.cs
@@ -1,5 +1,9 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.LongMemEval;
 using FluentAssertions;
+using NSubstitute;
 using Microsoft.Extensions.AI;
 using Xunit;
 
@@ -102,5 +106,116 @@ public sealed class MafAgentTaskRunnerTests
 
         strict("I have completed the task successfully!").Should().BeFalse();
         strict("BOOKING-CONFIRMED ref 91821").Should().BeTrue();
+    }
+}
+
+/// <summary>
+/// Promoting a successful attempt to a reusable procedure (7.6).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the benchmark measures nothing. The Agent Framework provider recalls reasoning traces
+/// and <b>never writes one</b> — <c>AgentTraceRecorder</c> is gated off by default and is not called
+/// on a normal run — so the procedural arm would recall procedures while nothing stored any. Both arms
+/// would behave identically and the harness would report "no benefit" while describing a wiring gap.
+/// </para>
+/// <para>
+/// Asserted against the promotion <i>decision</i> rather than through a stub agent: the decision is
+/// what can be quietly wrong, and routing through an agent would test the plumbing around it instead.
+/// </para>
+/// </remarks>
+public sealed class ProcedurePromotionTests
+{
+    /// <summary>Substituted rather than hand-written: only AddAsync is under test.</summary>
+    private static (IReasoningTraceRepository Repo, List<ReasoningTrace> Added) Traces()
+    {
+        var added = new List<ReasoningTrace>();
+        var repo = Substitute.For<IReasoningTraceRepository>();
+        repo.AddAsync(Arg.Any<ReasoningTrace>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var trace = call.Arg<ReasoningTrace>();
+                added.Add(trace);
+                return Task.FromResult(trace);
+            });
+        return (repo, added);
+    }
+
+    private static readonly string[] Chain = ["LookUpTraveller", "PlaceHold", "Book"];
+
+    private static MafAgentTaskRunner Runner(IReasoningTraceRepository? traces) =>
+        new(_ => null!, "book it", _ => true, traces);
+
+    private static Task PromoteAsync(
+        IReasoningTraceRepository traces, bool completed, bool enabled) =>
+        Runner(traces).PromoteIfWorthKeepingAsync(
+            new AgentTaskRun(completed, Steps: 3, ToolCalls: 3), enabled, Chain);
+
+    [Fact]
+    public async Task ASuccessfulProceduralAttemptIsPromoted()
+    {
+        // THE gap this closes. Nothing else in the MAF path writes a trace, so without this the
+        // procedural arm has nothing to recall on attempt two.
+        var (repo, added) = Traces();
+
+        await PromoteAsync(repo, completed: true, enabled: true);
+
+        added.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ThePromotedTraceIsAProcedureNotAnEpisode()
+    {
+        // Owner-scoped procedural recall filters on procedures, so an episode-kinded trace is stored,
+        // recalled by nothing, and presents as exactly the false negative this prevents.
+        var (repo, added) = Traces();
+
+        await PromoteAsync(repo, completed: true, enabled: true);
+
+        added.Single().Kind.Should().Be(TraceKind.Procedure);
+    }
+
+    [Fact]
+    public async Task AFailedAttemptIsNotPromoted()
+    {
+        // Promoting a failure teaches the wrong chain. 7.7's wrong-procedure rate would then correctly
+        // punish it, and the benchmark would be measuring a bug introduced here rather than the feature.
+        var (repo, added) = Traces();
+
+        await PromoteAsync(repo, completed: false, enabled: true);
+
+        added.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TheControlArmNeverPromotes()
+    {
+        // The arm switch. If the control arm promoted too, both arms would share a procedure store and
+        // the comparison would measure nothing at all.
+        var (repo, added) = Traces();
+
+        await PromoteAsync(repo, completed: true, enabled: false);
+
+        added.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TheProcedureRecordsTheToolChain()
+    {
+        // What makes it reusable rather than a note that something worked once.
+        var (repo, added) = Traces();
+
+        await PromoteAsync(repo, completed: true, enabled: true);
+
+        added.Single().Outcome.Should().Be("LookUpTraveller -> PlaceHold -> Book");
+    }
+
+    [Fact]
+    public async Task NoRepositoryMeansNoPromotionAndNoCrash()
+    {
+        var act = async () => await Runner(null).PromoteIfWorthKeepingAsync(
+            new AgentTaskRun(true, 3, 3), procedureMemoryEnabled: true, Chain);
+
+        await act.Should().NotThrowAsync();
     }
 }

--- a/tools/AgentMemory.LongMemEval/MafAgentTaskRunner.cs
+++ b/tools/AgentMemory.LongMemEval/MafAgentTaskRunner.cs
@@ -1,3 +1,5 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Repositories;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
@@ -32,6 +34,8 @@ internal sealed class MafAgentTaskRunner : IAgentTaskRunner
     private readonly Func<bool, AIAgent> _agentFactory;
     private readonly string _taskPrompt;
     private readonly Func<string, bool> _isComplete;
+    private readonly IReasoningTraceRepository? _traces;
+    private readonly string _ownerId;
 
     /// <param name="agentFactory">
     /// Builds an agent with procedural memory on or off. A factory rather than two instances because
@@ -40,14 +44,23 @@ internal sealed class MafAgentTaskRunner : IAgentTaskRunner
     /// </param>
     /// <param name="taskPrompt">The task, issued identically on every attempt.</param>
     /// <param name="isComplete">Decides completion from the final transcript.</param>
+    /// <param name="traces">
+    /// Where a successful attempt is promoted to a procedure. <see langword="null"/> disables
+    /// promotion, which is what the control arm uses.
+    /// </param>
+    /// <param name="ownerId">Owner the procedure is stored under; recall is owner-scoped.</param>
     public MafAgentTaskRunner(
         Func<bool, AIAgent> agentFactory,
         string taskPrompt,
-        Func<string, bool> isComplete)
+        Func<string, bool> isComplete,
+        IReasoningTraceRepository? traces = null,
+        string ownerId = "procedural-benchmark")
     {
         _agentFactory = agentFactory;
         _taskPrompt = taskPrompt;
         _isComplete = isComplete;
+        _traces = traces;
+        _ownerId = ownerId;
     }
 
     /// <inheritdoc/>
@@ -68,10 +81,18 @@ internal sealed class MafAgentTaskRunner : IAgentTaskRunner
             .ConfigureAwait(false);
 
         var messages = response.Messages ?? [];
-        return new AgentTaskRun(
+        var run = new AgentTaskRun(
             Completed: _isComplete(response.Text ?? string.Empty),
             Steps: CountSteps(messages),
             ToolCalls: CountToolCalls(messages));
+
+        await PromoteIfWorthKeepingAsync(
+                run,
+                procedureMemoryEnabled,
+                messages.SelectMany(m => m.Contents.OfType<FunctionCallContent>()).Select(c => c.Name),
+                cancellationToken)
+            .ConfigureAwait(false);
+        return run;
     }
 
     /// <summary>Assistant turns taken — the agent's own reasoning steps.</summary>
@@ -86,4 +107,54 @@ internal sealed class MafAgentTaskRunner : IAgentTaskRunner
     /// <summary>Tool invocations across the whole run.</summary>
     internal static int CountToolCalls(IEnumerable<ChatMessage> messages) =>
         messages.Sum(m => m.Contents.OfType<FunctionCallContent>().Count());
+
+    /// <summary>
+    /// Stores a successful attempt as a reusable procedure (7.6).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Without this the benchmark measures nothing.</b> The Agent Framework provider recalls
+    /// reasoning traces and never writes one — <c>AgentTraceRecorder</c> is gated off by default and
+    /// is not called on a normal run — so the procedural arm would recall procedures while nothing
+    /// stored any, both arms would behave identically, and the harness would report "no benefit"
+    /// while actually describing a wiring gap.
+    /// </para>
+    /// <para>
+    /// <b>Successful attempts only.</b> Promoting a failed one teaches the wrong chain; 7.7's
+    /// wrong-procedure rate would then correctly punish it, and the benchmark would be measuring a
+    /// bug introduced here rather than the feature.
+    /// </para>
+    /// <para>
+    /// <b>Written as <see cref="TraceKind.Procedure"/>, never Episode.</b> Owner-scoped procedural
+    /// recall filters on procedures, so an episode-kinded trace is stored, recalled by nothing, and
+    /// presents as exactly the same false negative this method exists to prevent.
+    /// </para>
+    /// </remarks>
+    internal async Task PromoteIfWorthKeepingAsync(
+        AgentTaskRun run,
+        bool procedureMemoryEnabled,
+        IEnumerable<string> toolNames,
+        CancellationToken cancellationToken = default)
+    {
+        // The arm switch. The control arm passes no repository and therefore never promotes, which is
+        // what makes the two arms differ in the feature rather than in their prompts.
+        if (_traces is null || !procedureMemoryEnabled || !run.Completed) return;
+
+        var chain = string.Join(" -> ", toolNames);
+
+        await _traces.AddAsync(
+            new ReasoningTrace
+            {
+                TraceId = $"proc-{Guid.NewGuid():N}",
+                SessionId = "procedural-benchmark",
+                Task = _taskPrompt,
+                Outcome = chain,
+                Success = true,
+                Kind = TraceKind.Procedure,
+                OwnerId = _ownerId,
+                StartedAtUtc = DateTimeOffset.UtcNow,
+                CompletedAtUtc = DateTimeOffset.UtcNow,
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
The prerequisite found while preparing the run: **the MAF provider recalls reasoning traces and never writes one.** The procedural arm would have recalled procedures while nothing stored any — both arms identical, harness reporting "no benefit" while describing a wiring gap.

`MafAgentTaskRunner` now promotes a completed attempt to a stored procedure. The three ways that could quietly reopen are each pinned by a test:

- **Successful attempts only.** Promoting a failure teaches the wrong chain; 7.7's wrong-procedure rate would correctly punish it, and the benchmark would be measuring a bug introduced here rather than the feature.
- **`TraceKind.Procedure`, never `Episode`.** Owner-scoped procedural recall filters on procedures, so an episode-kinded trace is stored, recalled by nothing, and presents as the same false negative.
- **Promotion is the arm switch.** The control arm is constructed without a repository and never promotes. If both promoted, they'd share a procedure store and the comparison would measure nothing.

Tests assert the promotion **decision** directly rather than driving a stub agent — the decision is what can be quietly wrong, and routing through an agent would test the plumbing around it while dragging Agent Framework types into a test project with no reason to reference them.

4,370 unit and 449 LongMemEval green (+6). What remains for 7.6 is the measured run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE