### PR TITLE
Add the arbitrary dependency; find the real obstacle is the action space (7.6)

### DIFF
--- a/docs/reviews/procedural-benefit-run-prerequisite.md
+++ b/docs/reviews/procedural-benefit-run-prerequisite.md
@@ -125,3 +125,42 @@ and not a wording problem.
 The harness, runner, promotion path and arm switch are all built, tested, and demonstrated working
 end to end across two runs. **What is missing is a task hard enough to measure them with.** The
 figures from both runs should not be cited as evidence about procedural memory in either direction.
+
+
+---
+
+## Third run: arbitrary dependency added, still no discrimination — and now the reason is structural
+
+Added the dependency the second run's write-up called for: booking requires a `clearanceCode`, and
+the only source is a **service bulletin** lookup — a tool whose name gives no hint. The refusal names
+the missing code and never says where to find it. Unit tests pin both.
+
+Result: **4 tool calls, both arms, zero refusals.** The model simply called *all four tools* before
+booking.
+
+**That is the structural finding, and it survives any amount of dependency-hiding:** with a small
+tool set, exhaustive calling is a cheap and correct strategy. The agent never has to *discover* the
+ordering because it never has to *choose* — it can afford to call everything. A stored procedure
+saves nothing when the unguided policy is already near-optimal.
+
+So the requirement is not "hide the dependency" but **make exploration expensive**:
+
+- **A large action space** — dozens of tools, so calling them all costs more than the task is worth;
+  or
+- **irreversible or penalised wrong steps** — a wrong call that consumes a booking slot, charges a
+  fee, or must be undone, so that exploring has a price the harness can see; or
+- **a long chain**, where the number of orderings grows fast enough that guessing stops working.
+
+All three make the benchmark meaningfully bigger. That is the honest scope of what is left.
+
+### Three designs, one conclusion
+
+| Attempt | Change | Result |
+|---|---|---|
+| 1 | Enforced chain, prerequisites in descriptions | 3 calls, 0 refusals — chain read off the prose |
+| 2 | Prerequisites removed from all descriptions | 3 calls, 0 refusals — chain read off parameter names |
+| 3 | Arbitrary dependency behind an unhinted tool | 4 calls, 0 refusals — agent called every tool |
+
+The harness, runner, promotion path and arm switch are built, tested, and demonstrated working end to
+end across all three. **None of these figures is evidence about procedural memory.** What is missing
+is a task whose action space is large enough that exploration costs something.

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/ProceduralBenchmarkTaskTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/ProceduralBenchmarkTaskTests.cs
@@ -42,7 +42,10 @@ public sealed class ProceduralBenchmarkTaskTests
         var hold = await InvokeAsync(task, "PlaceHold", new { connection = "14:05", tier = "gold" });
         hold.Should().Contain("HOLD-4417");
 
-        var booking = await InvokeAsync(task, "Book", new { holdReference = "HOLD-4417" });
+        var bulletin = await InvokeAsync(task, "CheckServiceBulletin", new { connection = "14:05" });
+        bulletin.Should().Contain("CLR-7731");
+
+        var booking = await InvokeAsync(task, "Book", new { holdReference = "HOLD-4417", clearanceCode = "CLR-7731" });
         booking.Should().Contain(ProceduralBenchmarkTask.ConfirmationMarker);
         task.IsComplete(booking).Should().BeTrue();
     }
@@ -55,7 +58,7 @@ public sealed class ProceduralBenchmarkTaskTests
         // memory does not help" for a reason that is entirely about the task.
         var task = new ProceduralBenchmarkTask();
 
-        var booking = await InvokeAsync(task, "Book", new { holdReference = "whatever" });
+        var booking = await InvokeAsync(task, "Book", new { holdReference = "whatever", clearanceCode = "whatever" });
 
         booking.Should().Contain("refused", Exactly.Once());
         task.IsComplete(booking).Should().BeFalse();
@@ -151,9 +154,38 @@ public sealed class ProceduralBenchmarkTaskTests
         }
     }
 
+
+    [Fact]
+    public async Task AValidHoldWithoutTheClearanceCodeIsRefused()
+    {
+        // THE arbitrary dependency. Two earlier runs failed to discriminate because every prerequisite
+        // was inferable from names; this one is not. Nothing about "book" suggests a service bulletin,
+        // so the step has to be found rather than deduced -- which is what makes it worth remembering.
+        var task = new ProceduralBenchmarkTask();
+
+        var booking = await InvokeAsync(
+            task, "Book", new { holdReference = "HOLD-4417", clearanceCode = "guessed" });
+
+        booking.Should().Contain("clearance code");
+        task.IsComplete(booking).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TheRefusalDoesNotNameWhereTheCodeComesFrom()
+    {
+        // Saying "check the service bulletin" would hand over the arbitrary step and put the benchmark
+        // straight back to being guessable.
+        var task = new ProceduralBenchmarkTask();
+
+        var booking = await InvokeAsync(
+            task, "Book", new { holdReference = "HOLD-4417", clearanceCode = "guessed" });
+
+        booking.Should().NotContain("bulletin");
+    }
+
     [Fact]
     public void ToolsAreExposedInProcedureOrder()
     {
-        new ProceduralBenchmarkTask().CreateTools().Should().HaveCount(3);
+        new ProceduralBenchmarkTask().CreateTools().Should().HaveCount(4);
     }
 }

--- a/tools/AgentMemory.LongMemEval/ProceduralBenchmarkTask.cs
+++ b/tools/AgentMemory.LongMemEval/ProceduralBenchmarkTask.cs
@@ -42,6 +42,18 @@ internal sealed class ProceduralBenchmarkTask
     private const string RequiredTier = "gold";
     private const string HoldReference = "HOLD-4417";
 
+    /// <summary>
+    /// The arbitrary dependency, and the reason this task can be measured at all.
+    /// </summary>
+    /// <remarks>
+    /// Booking needs a clearance code, and the only tool that yields one is a <i>service bulletin</i>
+    /// lookup — a name that does not suggest it. Two earlier runs failed to discriminate because
+    /// every dependency was inferable from tool and parameter names, so a competent model ordered
+    /// the calls cold and no procedure could save anything. A semantic cue the model can follow is
+    /// not a procedure worth remembering; an arbitrary one is.
+    /// </remarks>
+    private const string ClearanceCode = "CLR-7731";
+
     /// <summary>Records what was called, so a test can assert the chain without a model.</summary>
     internal List<string> Calls { get; } = [];
 
@@ -68,8 +80,19 @@ internal sealed class ProceduralBenchmarkTask
     [
         AIFunctionFactory.Create(LookUpTraveller),
         AIFunctionFactory.Create(PlaceHold),
+        AIFunctionFactory.Create(CheckServiceBulletin),
         AIFunctionFactory.Create(Book),
     ];
+
+    [Description("Returns the service bulletin for a connection.")]
+    private string CheckServiceBulletin(
+        [Description("The connection time.")] string connection)
+    {
+        Calls.Add(nameof(CheckServiceBulletin));
+        // The clearance code is buried in an otherwise unremarkable bulletin. Nothing in the tool's
+        // name or signature says it is the source, so it has to be found rather than deduced.
+        return $"bulletin for {connection}: on time; catering normal; clearance={ClearanceCode}";
+    }
 
     // Descriptions state PURPOSE only. Naming a prerequisite here hands the model the chain, and
     // the first run proved it: zero refusals, minimal tool count, both arms identical. The ordering
@@ -100,11 +123,17 @@ internal sealed class ProceduralBenchmarkTask
 
     [Description("Confirms a booking.")]
     private string Book(
-        [Description("The hold reference.")] string holdReference)
+        [Description("The hold reference.")] string holdReference,
+        [Description("The clearance code.")] string clearanceCode)
     {
         Calls.Add(nameof(Book));
-        return string.Equals(holdReference, HoldReference, StringComparison.OrdinalIgnoreCase)
+        if (!string.Equals(holdReference, HoldReference, StringComparison.OrdinalIgnoreCase))
+            return "refused: booking needs a valid hold reference";
+
+        // Names what is missing, never where to get it. Saying "check the service bulletin" would
+        // hand over the arbitrary step and put us back where the first two runs were.
+        return string.Equals(clearanceCode, ClearanceCode, StringComparison.OrdinalIgnoreCase)
             ? string.Create(CultureInfo.InvariantCulture, $"{ConfirmationMarker} ref {HoldReference}")
-            : "refused: booking needs a valid hold reference; place a hold first";
+            : "refused: booking needs a valid clearance code";
     }
 }


### PR DESCRIPTION
Third attempt at making the benchmark discriminate. Booking now needs a `clearanceCode` whose only source is a **service-bulletin** lookup — a tool whose name gives no hint — and the refusal names the missing code without saying where to find it. Both pinned by tests.

**Result: 4 tool calls, both arms, zero refusals.** The model called all four tools before booking.

**That's the structural finding, and it survives any amount of dependency-hiding.** With a small tool set, exhaustive calling is a cheap and correct strategy: the agent never has to *discover* an ordering because it never has to *choose*. A stored procedure can't pay for itself when the unguided policy is already near-optimal.

So the requirement was never "hide the dependency" — it's to **make exploration expensive**: a large action space where calling everything costs more than the task is worth; wrong steps that are irreversible or penalised so exploring has a visible price; or a chain long enough that orderings defeat guessing. All three make the benchmark meaningfully bigger, and that's the honest scope of what remains.

| Attempt | Change | Result |
|---|---|---|
| 1 | Prerequisites in descriptions | 3 calls, 0 refusals — chain read off the prose |
| 2 | Prerequisites removed everywhere | 3 calls, 0 refusals — chain read off parameter names |
| 3 | Arbitrary dependency, unhinted tool | 4 calls, 0 refusals — agent called every tool |

Harness, runner, promotion path and arm switch are built, tested, and demonstrated working end to end across all three runs. **None of these figures is evidence about procedural memory in either direction**, and the note says so.

453 LongMemEval green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE