### PR TITLE
Expensive action space; the obstacle turns out to be the task class (7.6)

### DIFF
--- a/docs/reviews/procedural-benefit-run-prerequisite.md
+++ b/docs/reviews/procedural-benefit-run-prerequisite.md
@@ -164,3 +164,51 @@ All three make the benchmark meaningfully bigger. That is the honest scope of wh
 The harness, runner, promotion path and arm switch are built, tested, and demonstrated working end to
 end across all three. **None of these figures is evidence about procedural memory.** What is missing
 is a task whose action space is large enough that exploration costs something.
+
+
+---
+
+## Fourth run: expensive action space — and the conclusion is about the feature
+
+Implemented what the third run's finding called for: twelve plausible decoy tools alongside the four
+real ones, so that calling everything costs sixteen invocations instead of four.
+
+```
+procedures  completion=100%  meanSteps=4.7  meanToolCalls=4.0
+control     completion=100%  meanSteps=4.0  meanToolCalls=4.0
+stepReduction=-16.7%   SHOWS BENEFIT: False
+```
+
+**Both arms still called exactly the four right tools.** The model selected them out of sixteen
+without exploring, so the decoys cost nothing and created no discovery to save. And the procedural
+arm came out *slightly worse* — 4.7 steps against 4.0 — the recalled procedure adding context the
+agent then had to read past.
+
+### What four attempts actually establish
+
+The obstacle was never the wording, the parameter names, the arbitrariness of the dependency, or the
+size of the action space. It is that **a competent model does not explore on this class of task at
+all.** It reads tool descriptions and selects correctly on the first attempt. Procedural memory has
+no exploration cost to remove because there is none.
+
+That is a real result, and it is narrower than "procedural memory does not work":
+
+> **For tasks where correct tool selection is inferable from tool descriptions — which is what a
+> well-designed tool API is — a stored procedure saves nothing, and carries a small context cost.**
+
+The place to look for a benefit is therefore tasks where the right action is *not* inferable from the
+interface: undocumented sequencing constraints, environment-specific quirks, conventions learned from
+failure rather than from a schema. Those are exactly the cases a human operator writes a runbook for,
+and a runbook is what a procedure is.
+
+| Attempt | Change | Tool calls | Verdict |
+|---|---|---|---|
+| 1 | Prerequisites in descriptions | 3 / 3 | chain read off the prose |
+| 2 | Prerequisites removed everywhere | 3 / 3 | chain read off parameter names |
+| 3 | Arbitrary dependency, unhinted tool | 4 / 4 | agent called every tool |
+| 4 | Twelve decoys, 16-tool action space | 4 / 4 | agent selected correctly without exploring |
+
+**Status.** The harness, runner, promotion path, arm switch and counting are built, tested and
+demonstrated working across four runs. The instrument is sound; what it keeps reporting is that this
+task class has nothing for procedural memory to do. That is worth knowing before building a larger
+benchmark, and it is the finding to carry forward rather than the numbers.

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/ProceduralBenchmarkTaskTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/ProceduralBenchmarkTaskTests.cs
@@ -186,6 +186,9 @@ public sealed class ProceduralBenchmarkTaskTests
     [Fact]
     public void ToolsAreExposedInProcedureOrder()
     {
-        new ProceduralBenchmarkTask().CreateTools().Should().HaveCount(4);
+        // Four real tools plus twelve plausible decoys. The decoys are the third run's finding made
+        // concrete: with a small tool set an agent calls everything and skips discovery, so a stored
+        // procedure saves nothing and both arms tie.
+        new ProceduralBenchmarkTask().CreateTools().Should().HaveCount(16);
     }
 }

--- a/tools/AgentMemory.LongMemEval/ProceduralBenchmarkTask.cs
+++ b/tools/AgentMemory.LongMemEval/ProceduralBenchmarkTask.cs
@@ -82,7 +82,46 @@ internal sealed class ProceduralBenchmarkTask
         AIFunctionFactory.Create(PlaceHold),
         AIFunctionFactory.Create(CheckServiceBulletin),
         AIFunctionFactory.Create(Book),
+        .. Decoys(),
     ];
+
+    /// <summary>
+    /// Plausible tools that are never needed, so calling everything stops being free.
+    /// </summary>
+    /// <remarks>
+    /// <b>The third run's finding, implemented.</b> With four tools, an agent skips discovery entirely
+    /// by invoking all of them — the unguided policy is already near-optimal, so a stored procedure
+    /// cannot pay for itself and both arms tie. Exhaustive calling has to cost more than the task is
+    /// worth before knowing the route is worth anything.
+    /// <para>
+    /// The decoys are deliberately relevant-sounding. Obvious filler would be skipped on sight, which
+    /// would restore the small effective action space this exists to remove.
+    /// </para>
+    /// </remarks>
+    private IEnumerable<AITool> Decoys() =>
+        new (string Name, string Description)[]
+        {
+            ("check_seat_map", "Returns the seat map for a connection."),
+            ("list_fare_classes", "Lists fare classes available on a connection."),
+            ("get_station_facilities", "Returns facilities at a station."),
+            ("check_loyalty_balance", "Returns a traveller's loyalty point balance."),
+            ("list_connections", "Lists connections between two stations."),
+            ("get_refund_policy", "Returns the refund policy for a fare class."),
+            ("check_platform", "Returns the departure platform for a connection."),
+            ("get_catering_menu", "Returns the catering menu for a connection."),
+            ("list_baggage_rules", "Returns baggage allowance rules."),
+            ("check_delay_history", "Returns recent punctuality for a connection."),
+            ("get_carriage_layout", "Returns the carriage layout for a connection."),
+            ("list_partner_operators", "Lists partner operators for a route."),
+        }
+        .Select(decoy => AIFunctionFactory.Create(
+            (string query) =>
+            {
+                Calls.Add(decoy.Name);
+                return $"{decoy.Name}: no action required for this booking.";
+            },
+            decoy.Name,
+            decoy.Description));
 
     [Description("Returns the service bulletin for a connection.")]
     private string CheckServiceBulletin(


### PR DESCRIPTION
Fourth attempt, implementing what the third run's finding called for: twelve plausible decoy tools beside the four real ones, so calling everything costs sixteen invocations rather than four.

```
procedures  completion=100%  meanSteps=4.7  meanToolCalls=4.0
control     completion=100%  meanSteps=4.0  meanToolCalls=4.0
stepReduction=-16.7%   SHOWS BENEFIT: False
```

**Both arms still called exactly the four right tools** — selected out of sixteen without exploring, so the decoys cost nothing. And the procedural arm came out *slightly worse* (4.7 vs 4.0 steps), the recalled procedure adding context the agent had to read past.

**Four attempts converge on a conclusion about the feature, not the benchmark.** The obstacle was never the wording, the parameter names, the arbitrariness of the dependency, or the action-space size. It's that **a competent model doesn't explore on this task class at all** — it reads tool descriptions and selects correctly first time. Procedural memory has no exploration cost to remove because there is none.

Stated narrowly, because the broad version would be wrong:

> For tasks where correct tool selection is inferable from tool descriptions — which is what a well-designed tool API *is* — a stored procedure saves nothing and carries a small context cost.

The place to look for benefit is tasks where the right action *isn't* inferable from the interface: undocumented sequencing, environment quirks, conventions learned from failure. Those are what a human writes a runbook for — and a runbook is what a procedure is.

| Attempt | Change | Calls | Verdict |
|---|---|---|---|
| 1 | Prerequisites in descriptions | 3/3 | read off the prose |
| 2 | Prerequisites removed | 3/3 | read off parameter names |
| 3 | Arbitrary dependency | 4/4 | called every tool |
| 4 | 16-tool action space | 4/4 | selected correctly, no exploration |

The instrument is sound and demonstrated across four runs. What it keeps reporting is that this task class has nothing for the feature to do — worth knowing before building a larger benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgDgctPpbTziBNE2RT8VdE