### PR TITLE
Measurement instruments: store probes, judge-only re-grade, a render gate, and the guards that came from getting it wrong

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.102"
+    "version": "10.0.400",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/MemoryOptions.cs
@@ -112,6 +112,15 @@ public sealed record MemoryOptions
     /// Off by default: it changes recall ordering, costs two bounded queries per fact section, and
     /// every recorded measurement was taken without it.
     /// </para>
+    /// <para>
+    /// <b>Its traversal names <c>:ABOUT</c>, but pipeline-built stores contain none.</b> The path
+    /// walks <c>[:RELATED_TO|ABOUT*..4]</c>, and while <c>ABOUT</c> is documented there as one of the
+    /// two edges carrying meaning between an entity and a fact, nothing in this library ever writes
+    /// one — the public <c>CreateAboutRelationshipAsync</c> verbs exist but no ingestion path calls
+    /// them. So on any store this library built, this re-ranker effectively traverses
+    /// <c>RELATED_TO</c> alone, and is weaker than its own query describes. <c>ABOUT</c> participates
+    /// only if a consumer created those links manually.
+    /// </para>
     /// </remarks>
     public bool NodeDistanceReranking { get; set; }
 

--- a/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IFactRepository.cs
@@ -79,6 +79,15 @@ public interface IFactRepository
     Task CreateExtractedFromRelationshipAsync(string factId, string messageId, CancellationToken cancellationToken = default);
 
     /// <summary>Creates an ABOUT relationship from a fact to an entity.</summary>
+    /// <remarks>
+    /// <b>Written links are traversed only by <c>MemoryOptions.NodeDistanceReranking</c>, and the
+    /// ingestion pipeline never writes them.</b> Nothing in this library calls this method, so a
+    /// store built by the pipeline alone contains no <c>:ABOUT</c> edges at all (verified: 26,887 of
+    /// 26,887 facts unlinked in a prepared store). Calling it is therefore only useful in combination
+    /// with that re-ranker, which is itself off by default. Documented rather than removed because
+    /// the method is public API under SemVer, and a consumer who does create links has them honoured
+    /// by that traversal today.
+    /// </remarks>
     Task CreateAboutRelationshipAsync(string factId, string entityId, CancellationToken cancellationToken = default);
 
     /// <summary>Creates a HAS_FACT relationship from a conversation to this fact.</summary>

--- a/src/AgentMemory.Abstractions/Repositories/IPreferenceRepository.cs
+++ b/src/AgentMemory.Abstractions/Repositories/IPreferenceRepository.cs
@@ -73,6 +73,15 @@ public interface IPreferenceRepository
     Task CreateExtractedFromRelationshipAsync(string preferenceId, string messageId, CancellationToken cancellationToken = default);
 
     /// <summary>Creates an ABOUT relationship from a preference to an entity.</summary>
+    /// <remarks>
+    /// <b>Written links are traversed only by <c>MemoryOptions.NodeDistanceReranking</c>, and the
+    /// ingestion pipeline never writes them.</b> Nothing in this library calls this method, so a
+    /// store built by the pipeline alone contains no <c>:ABOUT</c> edges at all (verified: 26,887 of
+    /// 26,887 facts unlinked in a prepared store). Calling it is therefore only useful in combination
+    /// with that re-ranker, which is itself off by default. Documented rather than removed because
+    /// the method is public API under SemVer, and a consumer who does create links has them honoured
+    /// by that traversal today.
+    /// </remarks>
     Task CreateAboutRelationshipAsync(string preferenceId, string entityId, CancellationToken cancellationToken = default);
 
     /// <summary>Creates a HAS_PREFERENCE relationship from a conversation to this preference.</summary>

--- a/src/AgentMemory.Neo4j/Queries/NodeDistanceQueries.cs
+++ b/src/AgentMemory.Neo4j/Queries/NodeDistanceQueries.cs
@@ -62,7 +62,13 @@ internal static class NodeDistanceQueries
     internal static string DistanceToCandidates => @"
             MATCH (centroid:Entity {id: $centroidId})
             MATCH (f:Fact) WHERE f.id IN $candidateIds
-            MATCH path = shortestPath((centroid)-[:RELATED_TO|ABOUT*..4]-(f))
+                    // NOTE: `ABOUT` is named here and NO ingestion path in this library writes one -- the
+            // public CreateAboutRelationshipAsync verbs exist and nothing calls them, so a
+            // pipeline-built store traverses RELATED_TO alone (verified: 26,887 of 26,887 facts
+            // unlinked). Left in the pattern deliberately rather than removed: the writer is public
+            // API, so a consumer who created links manually has them honoured today, and dropping the
+            // edge would silently change their results.
+    MATCH path = shortestPath((centroid)-[:RELATED_TO|ABOUT*..4]-(f))
             WHERE length(path) <= $maxHops
             RETURN f.id AS candidateId, length(path) AS hops";
 }

--- a/tests/AgentMemory.Tests.Integration/Services/SupersessionRenderingPathIntegrationTests.cs
+++ b/tests/AgentMemory.Tests.Integration/Services/SupersessionRenderingPathIntegrationTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using FluentAssertions;
+using AgentMemory;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
+using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Stubs;
+using AgentMemory.Tests.Integration.Fixtures;
+
+namespace AgentMemory.Tests.Integration.Services;
+
+/// <summary>
+/// Localises why the 30.9d render arm produced <b>zero</b> supersession notes in 60 of 60 prompts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The arm ran both levers on. Its store-state gate PASSED — facts placed per question fell to 7.65
+/// against the off-state's 8.25, so supersession demonstrably invalidated facts and removed them from
+/// recall. Its render-state gate FAILED absolutely: <c>0/60</c> prompts carried a chain. An absolute
+/// zero is a disconnected wire, not a weak effect, so this walks the chain one link at a time and
+/// asserts each link separately. Whichever stage fails names the break.
+/// </para>
+/// <para>
+/// <b>Everything here is deterministic.</b> Supersession is invoked through the repository rather than
+/// through extraction, so no model decides whether a contradiction occurred — a diagnostic whose setup
+/// depends on an LLM agreeing to contradict itself can fail for reasons that have nothing to do with
+/// the thing under test.
+/// </para>
+/// <para>
+/// <b>The suspected link is the last one.</b> Bitemporal questions are timestamped, so the benchmark
+/// calls <c>RecallAsOfAsync</c> for every question, while the renderer's own docstring reasons about
+/// the live path's <c>invalidated_at IS NULL</c> filter. No test anywhere covers supersession
+/// projection on the as-of path — which is exactly the shape that has now cost this arc three dark
+/// mechanisms.
+/// </para>
+/// </remarks>
+[Collection("Neo4j Integration")]
+[Trait("Category", "Integration")]
+public sealed class SupersessionRenderingPathIntegrationTests : IAsyncLifetime
+{
+    private const string Owner = "supersession-render-probe";
+    private const string Session = "supersession-render-session";
+
+    private readonly Neo4jIntegrationFixture _fixture;
+    private ServiceProvider _provider = null!;
+    private string _winnerId = null!;
+    private string _loserId = null!;
+
+    public SupersessionRenderingPathIntegrationTests(Neo4jIntegrationFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.CleanDatabaseAsync();
+        _provider = BuildProvider();
+
+        var scope = _provider.CreateScope();
+        var facts = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+        var embedder = _provider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+        var now = DateTimeOffset.UtcNow;
+
+        // Facts are retrieved by VECTOR search, so a fact stored without an embedding is invisible to
+        // recall no matter how correct everything downstream is. Embedding them here is what makes
+        // this a test of the render path rather than a test of an empty context.
+        async Task<float[]> Embed(string text) =>
+            (await embedder.GenerateAsync([text], cancellationToken: CancellationToken.None))
+            [0].Vector.ToArray();
+
+        // The corpus shape this arc has been chasing all week, reduced to two rows: a value that was
+        // recorded, and the correction that replaced it.
+        var loser = await facts.UpsertAsync(
+            new Fact
+            {
+                FactId = Guid.NewGuid().ToString("n"),
+                Subject = "Colm Whitaker",
+                Predicate = "works_at",
+                Object = "Marchmont",
+                Confidence = 0.9,
+                CreatedAtUtc = now.AddMinutes(-10),
+                OwnerId = Owner,
+                Embedding = await Embed("Colm Whitaker works_at Marchmont"),
+            },
+            CancellationToken.None);
+
+        var winner = await facts.UpsertAsync(
+            new Fact
+            {
+                FactId = Guid.NewGuid().ToString("n"),
+                Subject = "Colm Whitaker",
+                Predicate = "works_at",
+                Object = "Lowick",
+                Confidence = 0.9,
+                CreatedAtUtc = now,
+                OwnerId = Owner,
+                Embedding = await Embed("Colm Whitaker works_at Lowick"),
+            },
+            CancellationToken.None);
+
+        _loserId = loser.FactId;
+        _winnerId = winner.FactId;
+
+        await facts.SupersedeAsync(
+            _loserId, _winnerId, MemoryScope.For(Owner, includeShared: false), CancellationToken.None);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null) await _provider.DisposeAsync();
+    }
+
+    /// <summary>LINK 1 — the write half: the edge and the stamp both exist.</summary>
+    [Fact]
+    public async Task Stage1_SupersedeWritesTheEdgeAndInvalidatesTheLoser()
+    {
+        using var scope = _provider.CreateScope();
+        var facts = scope.ServiceProvider.GetRequiredService<IFactRepository>();
+
+        var loser = await facts.GetByIdAsync(_loserId, CancellationToken.None);
+        loser.Should().NotBeNull();
+        loser!.InvalidatedAtUtc.Should().NotBeNull("Supersede stamps invalidated_at on the loser");
+
+        var predecessors = await facts.GetSupersessionPredecessorsAsync(
+            [_winnerId], 3, CancellationToken.None);
+
+        predecessors.Should().ContainKey(_winnerId,
+            "the renderer walks (prev)-[:SUPERSEDED_BY]->(cur) and the winner is `cur`");
+        predecessors[_winnerId].Should().NotBeEmpty();
+        predecessors[_winnerId][0].Object.Should().Be("Marchmont");
+    }
+
+    /// <summary>LINK 2 — the LIVE path renders the note the arm expected to see.</summary>
+    [Fact]
+    public async Task Stage2_LiveRecallRendersTheSupersessionNote()
+    {
+        var context = await RecallAsync(asOf: null);
+
+        context.RelevantFacts.Items.Should().Contain(f => f.FactId == _winnerId,
+            "live recall keeps the winner; the loser is filtered by invalidated_at IS NULL");
+        Note(context).Should().NotBeNullOrWhiteSpace(
+            "this is the path SupersessionProjectionFeature was written against");
+    }
+
+    /// <summary>
+    /// LINK 3 — the AS-OF path, which is the ONLY path the bitemporal benchmark uses.
+    /// </summary>
+    /// <remarks>
+    /// Every bitemporal question carries a QueryTime, so the harness calls <c>RecallAsOfAsync</c> 60
+    /// times out of 60 and <c>RecallAsync</c> zero times. If this fails while Stage 2 passes, the
+    /// render arm's absolute zero is explained and the defect is in the as-of assembly path.
+    /// </remarks>
+    [Fact]
+    public async Task Stage3_AsOfRecallRendersTheSupersessionNote()
+    {
+        var context = await RecallAsync(asOf: DateTimeOffset.UtcNow);
+
+        context.RelevantFacts.Items.Should().Contain(f => f.FactId == _winnerId,
+            "the as-of clocks admit the winner: it is uninvalidated and its window is open");
+        Note(context).Should().NotBeNullOrWhiteSpace(
+            "the benchmark reaches the renderer ONLY through this path");
+    }
+
+    private static string? Note(MemoryContext context) =>
+        context.Projection?.Annotations.Values
+            .Select(annotation => annotation.SupersessionNote)
+            .FirstOrDefault(note => !string.IsNullOrWhiteSpace(note));
+
+    private async Task<MemoryContext> RecallAsync(DateTimeOffset? asOf)
+    {
+        // IMemoryService is SCOPED, and the projection features are scoped alongside it. Resolving
+        // through an explicit scope is what a hosted caller does; the provider is built with
+        // validateScopes so a root resolve fails loudly here instead of quietly handing back a
+        // root-scoped graph whose feature set may differ from production's.
+        using var scope = _provider.CreateScope();
+        var memory = scope.ServiceProvider.GetRequiredService<IMemoryService>();
+        var request = new RecallRequest
+        {
+            SessionId = Session,
+            UserId = Owner,
+            Query = "Which department was Colm Whitaker at?",
+            Options = new RecallOptions
+            {
+                MaxRecentMessages = 0,
+                MaxRelevantMessages = 0,
+                MaxEntities = 0,
+                MaxPreferences = 0,
+                MaxFacts = 10,
+                MaxTraces = 0,
+                // Zero floor: the stub embedder's vectors carry no semantics, and a similarity gate
+                // would make this test measure the embedder rather than the render path.
+                MinSimilarityScore = 0,
+            },
+        };
+
+        var result = asOf is { } instant
+            ? await memory.RecallAsOfAsync(request, instant, DateTimeOffset.UtcNow, CancellationToken.None)
+            : await memory.RecallAsync(request, CancellationToken.None);
+        return result.Context;
+    }
+
+    private ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddNeo4jAgentMemory(
+            new MemoryOptions
+            {
+                // The lever the render arm set, wired the same way the eval profile wires it.
+                Projection = MemoryProjectionOptions.Default with { ResolveSupersessions = true },
+                Extraction = { SupersedeReplacedFacts = true },
+            },
+            configureNeo4j: o =>
+            {
+                o.Uri = _fixture.ConnectionString;
+                o.Username = _fixture.User;
+                o.Password = _fixture.Password;
+                o.Database = "neo4j";
+                o.EmbeddingDimensions = Neo4jIntegrationFixture.TestEmbeddingDimensions;
+            });
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            new StubEmbeddingGenerator(
+                sp.GetRequiredService<ILogger<StubEmbeddingGenerator>>(),
+                Neo4jIntegrationFixture.TestEmbeddingDimensions));
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/GraphRagWiringTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/GraphRagWiringTests.cs
@@ -1,4 +1,5 @@
 ﻿using AgentMemory.Abstractions.Options;
+using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
 using AgentMemory.Extraction.Llm;
 using AgentMemory.LongMemEval;
@@ -185,6 +186,30 @@ public sealed class GraphRagWiringTests
 
         provider.GetRequiredService<IOptions<MemoryOptions>>()
             .Value.Projection.Should().BeSameAs(MemoryProjectionOptions.Default);
+    }
+
+    /// <summary>
+    /// The renderer's OPTIONAL dependency must actually be satisfiable in the harness's own graph.
+    /// </summary>
+    /// <remarks>
+    /// <c>SupersessionProjectionFeature</c> takes <c>IFactRepository?</c> and reports itself
+    /// <b>disabled</b> when it is absent — deliberately, so a container without repositories stays
+    /// resolvable. The consequence is that the flag can be true, the option can reach
+    /// <c>MemoryOptions</c>, and the feature can still never run, reporting exactly what a corpus
+    /// with no supersessions reports. That is the same indistinguishable-zero this whole wave exists
+    /// to eliminate, so the dependency is asserted rather than assumed.
+    /// </remarks>
+    [Fact]
+    public async Task TheRenderersOptionalFactRepositoryIsActuallyRegistered()
+    {
+        // `await using`, unlike every sibling test here: resolving the repository constructs
+        // Neo4jDriverFactory, which implements IAsyncDisposable ONLY, and a synchronous Dispose on a
+        // provider holding one throws. The sibling tests never resolve deep enough to reach it.
+        await using var provider = Resolve(graphRagIndexName: null, resolveSupersessions: true);
+
+        provider.GetService<IFactRepository>().Should().NotBeNull(
+            "the supersession renderer silently disables itself without it, which is "
+            + "indistinguishable from a corpus that had nothing to supersede");
     }
 
     /// <summary>

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/GraphRagWiringTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/GraphRagWiringTests.cs
@@ -86,6 +86,7 @@ public sealed class GraphRagWiringTests
         bool resolveTemporalQueries = false,
         bool rescueShortOwnerResults = false,
         bool supersedeReplacedFacts = false,
+        bool resolveSupersessions = false,
         int? extractionSeed = null,
         PhaseThirtyFeatures? phase30 = null) =>
         LongMemEvalMemoryProfile.ConfigureServices(
@@ -104,6 +105,7 @@ public sealed class GraphRagWiringTests
                 resolveTemporalQueries: resolveTemporalQueries,
                 rescueShortOwnerResults: rescueShortOwnerResults,
                 supersedeReplacedFacts: supersedeReplacedFacts,
+                resolveSupersessions: resolveSupersessions,
                 phase30: phase30 ?? PhaseThirtyFeatures.AllOff,
                 graphRagIndexName: graphRagIndexName,
                 extractionSeed: extractionSeed)
@@ -143,6 +145,59 @@ public sealed class GraphRagWiringTests
 
         provider.GetRequiredService<IOptions<MemoryOptions>>()
             .Value.WorkingMemory.Enabled.Should().Be(enabled);
+    }
+
+    /// <summary>
+    /// 30.9d: the renderer flag must reach <c>MemoryOptions.Projection</c>, not merely parse.
+    /// </summary>
+    /// <remarks>
+    /// The SECOND reachable-but-never-fed lever inside one intervention.
+    /// <c>SupersessionProjectionFeature</c> was fully built and gated on
+    /// <c>ResolveSupersessions</c>, which defaults false and which no harness ever set — so every
+    /// scored run rendered supersession chains dark, including the ablation that existed to measure
+    /// supersession. Same shape as the arithmetic flag above, one wave later.
+    /// </remarks>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TheResolveSupersessionsFlagReachesMemoryOptions(bool enabled)
+    {
+        using var provider = Resolve(graphRagIndexName: null, resolveSupersessions: enabled);
+
+        provider.GetRequiredService<IOptions<MemoryOptions>>()
+            .Value.Projection.ResolveSupersessions.Should().Be(enabled);
+    }
+
+    /// <summary>
+    /// Off must leave <c>Projection</c> REFERENCE-identical to the shared default.
+    /// </summary>
+    /// <remarks>
+    /// <c>MemoryProjectionOptions.Default</c> is reference-compared to tell "unset" from "set to the
+    /// defaults" (<c>MemoryContextAssembler.ResolveProjectionOptions</c>), so assigning a
+    /// <c>with</c>-copy unconditionally would change identity for every sealed measurement while
+    /// leaving all property values equal — a behavioural change that property assertions cannot see.
+    /// This is the test that fails if the conditional assignment is ever "simplified" away.
+    /// </remarks>
+    [Fact]
+    public void TheOffStateKeepsTheSharedProjectionDefaultInstance()
+    {
+        using var provider = Resolve(graphRagIndexName: null, resolveSupersessions: false);
+
+        provider.GetRequiredService<IOptions<MemoryOptions>>()
+            .Value.Projection.Should().BeSameAs(MemoryProjectionOptions.Default);
+    }
+
+    /// <summary>
+    /// Turning rendering on must not silently retune the chain depth the arm did not ask about.
+    /// </summary>
+    [Fact]
+    public void TurningRenderingOnLeavesTheChainDepthAtItsDefault()
+    {
+        using var provider = Resolve(graphRagIndexName: null, resolveSupersessions: true);
+
+        provider.GetRequiredService<IOptions<MemoryOptions>>()
+            .Value.Projection.MaxSupersessionChain.Should()
+            .Be(MemoryProjectionOptions.Default.MaxSupersessionChain);
     }
 
     /// <summary>

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/LongMemEvalDiagnosticCliTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/LongMemEvalDiagnosticCliTests.cs
@@ -144,4 +144,52 @@ public sealed class LongMemEvalDiagnosticCliTests
                 Directory.Delete(directory);
         }
     }
+
+    [Fact]
+    public async Task CellProbeDryRunReportsBrokenPairingWhenWindowLengthsDiffer()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"agentmemory-lme-cell-probe-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var cell = Path.Combine(directory, "cell.json");
+        var pair = Path.Combine(directory, "pair.json");
+        await File.WriteAllTextAsync(
+            cell,
+            """
+            [
+              { "question_id": "q1", "haystack_sessions": [[{ "content": "Payment logged against job: $10 for cable." }]] },
+              { "question_id": "q2", "haystack_sessions": [[{ "content": "Payment logged against job: $11 for tape." }]] }
+            ]
+            """);
+        await File.WriteAllTextAsync(
+            pair,
+            """
+            [
+              { "question_id": "q1", "haystack_sessions": [[{ "content": "Payment logged against job: $10 for cable." }]] }
+            ]
+            """);
+
+        var originalOut = Console.Out;
+        using var output = new StringWriter();
+        Console.SetOut(output);
+        try
+        {
+            await CellProbeProgram.RunAsync(
+            [
+                "--cell-probe", cell,
+                "--dry-run",
+                "--pair-with", pair
+            ]);
+
+            output.ToString().Should().Contain("PAIRING BROKEN")
+                .And.NotContain("PAIRING OK");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
 }

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/SupersessionRenderProbeTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/SupersessionRenderProbeTests.cs
@@ -1,0 +1,121 @@
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The 30.9d render-state gate must fail closed (validity requirement, 2026-08-28).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The defect this guards.</b> Twice inside one intervention a lever was believed live because it
+/// was reachable — <c>SupersedeReplacedFacts</c>, then <c>ResolveSupersessions</c> — and in both
+/// cases a config echo would have confirmed the wrong thing, because the flag that was set was not
+/// the flag that mattered. The ruling on this arm therefore requires POSITIVE evidence drawn from the
+/// run's own output before any score may be read.
+/// </para>
+/// <para>
+/// So these tests apply the counter-check to the check itself: <i>would this gate still pass if the
+/// thing it guards were deleted?</i> A gate that answers "yes" is decoration.
+/// </para>
+/// </remarks>
+public class SupersessionRenderProbeTests
+{
+    private const string Note = "(since 2023-05-12; previously Globex)";
+
+    private static MemoryContext ContextWith(params string?[] notes) => new()
+    {
+        SessionId = "s1",
+        AssembledAtUtc = DateTimeOffset.UnixEpoch,
+        Projection = new ProjectedContext
+        {
+            Annotations = notes
+                .Select((note, index) => (Id: $"fact-{index}", Note: note))
+                .ToDictionary(
+                    pair => pair.Id,
+                    pair => new ProjectedItemAnnotation { SupersessionNote = pair.Note },
+                    StringComparer.Ordinal)
+        }
+    };
+
+    [Fact]
+    public void ARunThatRenderedNothingIsNotConfirmed()
+    {
+        // The dark-arm case: this is precisely the state every scored run was in before 30.9d, and
+        // the state whose scores must NOT be read.
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe("q1", ContextWith(), "Retrieved memory:\n[fact] acme employs colm\n");
+
+        var summary = LongMemEvalSupersessionRenderSummary.From(probe.Samples);
+
+        summary.PromptsInspected.Should().Be(1);
+        summary.NotesAnnotated.Should().Be(0);
+        summary.RenderConfirmed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ANoteThatNeverReachedThePromptIsNotConfirmed()
+    {
+        // The render-surface bug the two counts exist to separate. Projection did its job; the
+        // harness's own prompt builder dropped the note. One count would have called this success.
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe("q1", ContextWith(Note), "Retrieved memory:\n[fact] acme employs colm\n");
+
+        var summary = LongMemEvalSupersessionRenderSummary.From(probe.Samples);
+
+        summary.NotesAnnotated.Should().Be(1);
+        summary.NotesInPrompt.Should().Be(0);
+        summary.RenderConfirmed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ANoteCarriedIntoThePromptIsConfirmedAndKeepsASample()
+    {
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe("q1", ContextWith(Note), $"Retrieved memory:\n[fact] acme employs colm {Note}\n");
+
+        var summary = LongMemEvalSupersessionRenderSummary.From(probe.Samples);
+
+        summary.NotesInPrompt.Should().Be(1);
+        summary.RenderConfirmed.Should().BeTrue();
+        // A retained sample, not merely a positive counter: the gate must be eyeballable, because a
+        // number is exactly what the previous two dark runs also produced.
+        summary.Sample.Should().Be(Note);
+    }
+
+    [Fact]
+    public void QuestionsWithoutSupersessionStillCountTowardTheDenominator()
+    {
+        // Most questions in any corpus have nothing superseded. Dropping those rows would leave
+        // PromptsInspected silently meaning "prompts that had notes", which reads as full coverage.
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe("q1", ContextWith(), "Retrieved memory:\n");
+        probe.Observe("q2", ContextWith(Note), $"Retrieved memory:\n[fact] x {Note}\n");
+
+        var summary = LongMemEvalSupersessionRenderSummary.From(probe.Samples);
+
+        summary.PromptsInspected.Should().Be(2);
+        summary.PromptsWithNoteInPrompt.Should().Be(1);
+        summary.RenderConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnAbsentProjectionIsRecordedAsNotMeasuredRatherThanAsZeroRendered()
+    {
+        // A context with no Projection at all is the off-state, and it must be indistinguishable from
+        // "the feature is off" rather than being reported as a rendering failure.
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe(
+            "q1",
+            new MemoryContext { SessionId = "s1", AssembledAtUtc = DateTimeOffset.UnixEpoch },
+            "Retrieved memory:\n");
+
+        var summary = LongMemEvalSupersessionRenderSummary.From(probe.Samples);
+
+        summary.NotesAnnotated.Should().Be(0);
+        summary.Sample.Should().BeNull();
+        summary.RenderConfirmed.Should().BeFalse();
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/SupersessionRenderProbeTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/SupersessionRenderProbeTests.cs
@@ -101,6 +101,54 @@ public class SupersessionRenderProbeTests
         summary.RenderConfirmed.Should().BeTrue();
     }
 
+    /// <summary>
+    /// The last untested link: a projected note must survive the HARNESS's own prompt builder.
+    /// </summary>
+    /// <remarks>
+    /// The engine renders through <c>ProjectionRenderer</c>, but this harness assembles its answer
+    /// prompt itself, so "projection produced a note" and "the model saw a note" are separate claims
+    /// with separate ways to fail. Everything else in this chain is now asserted — the flag reaches
+    /// <c>MemoryOptions.Projection</c>, the renderer's optional <c>IFactRepository</c> resolves, and
+    /// the probe reports honestly — which leaves exactly one link that a live run would otherwise be
+    /// the first thing to test. It is deterministic, so it does not need to be bought.
+    /// </remarks>
+    [Fact]
+    public void AProjectedNoteSurvivesTheHarnessPromptBuilder()
+    {
+        var fact = new Fact
+        {
+            FactId = "fact-0",
+            Subject = "Colm Whitaker",
+            Predicate = "works_at",
+            Object = "Marchmont",
+            Confidence = 1,
+            CreatedAtUtc = DateTimeOffset.UnixEpoch,
+        };
+        var context = new MemoryContext
+        {
+            SessionId = "s1",
+            AssembledAtUtc = DateTimeOffset.UnixEpoch,
+            RelevantFacts = new MemoryContextSection<Fact> { Items = [fact] },
+            Projection = new ProjectedContext
+            {
+                Annotations = new Dictionary<string, ProjectedItemAnnotation>(StringComparer.Ordinal)
+                {
+                    ["fact-0"] = new() { SupersessionNote = Note }
+                }
+            }
+        };
+
+        var prompt = AgentMemoryLongMemEvalAdapter.BuildAnswerPrompt(context, "Where does Colm work?");
+
+        prompt.Should().Contain(Note, "the cue is the whole intervention; a dropped note is silent");
+
+        // And the probe must agree, on the real prompt rather than a fixture string — this is the
+        // end-to-end form of the gate the run will report.
+        var probe = new LongMemEvalSupersessionRenderProbe();
+        probe.Observe("q1", context, prompt);
+        LongMemEvalSupersessionRenderSummary.From(probe.Samples).RenderConfirmed.Should().BeTrue();
+    }
+
     [Fact]
     public void AnAbsentProjectionIsRecordedAsNotMeasuredRatherThanAsZeroRendered()
     {

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalArmProvenanceTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalArmProvenanceTests.cs
@@ -97,7 +97,10 @@ public sealed class TypedMemEvalArmProvenanceTests
         foreach (var arm in new[]
         {
             TypedMemEvalArm.Default,
-            new TypedMemEvalArm(new PhaseThirtyFeatures(true, true), true, true),
+            new TypedMemEvalArm(
+                new PhaseThirtyFeatures(true, true),
+                RescueShortOwnerResults: true,
+                SupersedeReplacedFacts: true),
         })
         {
             arm.FileToken().IndexOfAny(invalid).Should().Be(-1,
@@ -116,6 +119,46 @@ public sealed class TypedMemEvalArmProvenanceTests
         describe.Should().Contain("rescue-short-owner-results=False");
         describe.Should().Contain("fact-weighted-budget=False");
         describe.Should().Contain("phase30:none");
+    }
+
+    /// <summary>
+    /// 30.9d: the two supersession levers must be distinguishable, alone and together.
+    /// </summary>
+    /// <remarks>
+    /// They are only informative together — one writes the <c>:SUPERSEDED_BY</c> edges, the other
+    /// renders them — so an artifact that cannot say which of the two was on cannot be read at all.
+    /// The write-only arm is the 0.767 ON ablation; the both-on arm is what this wave measures.
+    /// </remarks>
+    [Fact]
+    public void TheSupersessionLeversAreDistinguishableAloneAndTogether()
+    {
+        var writeOnly = new TypedMemEvalArm(
+            PhaseThirtyFeatures.AllOff, SupersedeReplacedFacts: true);
+        var renderOnly = new TypedMemEvalArm(
+            PhaseThirtyFeatures.AllOff, ResolveSupersessions: true);
+        var both = new TypedMemEvalArm(
+            PhaseThirtyFeatures.AllOff, SupersedeReplacedFacts: true, ResolveSupersessions: true);
+
+        writeOnly.FileToken().Should().Be("supersede");
+        renderOnly.FileToken().Should().Be("render");
+        both.FileToken().Should().Be("supersede-render");
+
+        new[] { writeOnly.FileToken(), renderOnly.FileToken(), both.FileToken() }
+            .Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void RenderingAloneIsNotTheDefaultArm()
+    {
+        new TypedMemEvalArm(PhaseThirtyFeatures.AllOff, ResolveSupersessions: true)
+            .IsDefault.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheDescriptionNamesTheRendererSoASidecarCanBeReadWithoutTheToken()
+    {
+        new TypedMemEvalArm(PhaseThirtyFeatures.AllOff, ResolveSupersessions: true)
+            .Describe().Should().Contain("resolve-supersessions=True");
     }
 
     [Fact]
@@ -138,7 +181,8 @@ public sealed class TypedMemEvalArmProvenanceTests
             new PhaseThirtyFeatures(false, true), RescueShortOwnerResults: true,
             SupersedeReplacedFacts: false,
             EvidenceDetail: LongMemEvalEvidenceDetail.Identifiers,
-            FactWeightedBudget: true);
+            FactWeightedBudget: true,
+            ResolveSupersessions: false);
 
         var arm = options.Arm;
 

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalCommandLineTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalCommandLineTests.cs
@@ -182,6 +182,10 @@ public sealed class TypedMemEvalCommandLineTests
             ["--rescue-short-owner-results"] = "RescueShortOwnerResults",
             ["--evidence-detail"] = "EvidenceDetail",
             ["--supersede-replaced-facts"] = "SupersedeReplacedFacts",
+            // 30.9d. The renderer half of the same mechanism: --supersede-replaced-facts writes the
+            // :SUPERSEDED_BY edges and this one renders them, so an arm carrying only one of the two
+            // measures an off-state. Both must be nameable, or the pair is indistinguishable again.
+            ["--resolve-supersessions"] = "ResolveSupersessions",
             ["--fact-weighted-budget"] = "FactWeightedBudget",
         };
 

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
@@ -115,6 +115,22 @@ public class TypedMemEvalReplayAdapterTests
     }
 
     [Fact]
+    public async Task TheAccountingListsCannotBeMutatedThroughTheirPublicProperties()
+    {
+        // Copilot review, PR #209: these returned the backing lists, so a caller could downcast and
+        // mutate the accounting the re-grade gate depends on -- and that gate's whole job is to abort
+        // a run whose baseline would otherwise be silently understated.
+        var adapter = Adapter(("q", "a"));
+        await adapter.InvokeAsync("unexpected question");
+
+        var mismatches = adapter.OrderingMismatches;
+        (mismatches as List<string>)?.Clear();
+
+        adapter.OrderingMismatches.Should().ContainSingle(
+            "the property must hand out a snapshot, not the list the adapter counts with");
+    }
+
+    [Fact]
     public async Task TheHistoryHooksAreInertAndDoNotDisturbReplay()
     {
         // Implemented only so the runner takes the same branches it takes for the real adapter. If

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
@@ -99,6 +99,22 @@ public class TypedMemEvalReplayAdapterTests
     }
 
     [Fact]
+    public async Task AReplayIsUnaffectedByAStoredRowWhoseVerdictWasNull()
+    {
+        // The ON re-grade crashed on a question the new judge returned NO verdict for, and the crash
+        // sat in the AGREEMENT diagnostic -- which ran before the artifact was persisted, so a full
+        // judge pass was destroyed by a statistic. The replay itself must be indifferent to verdicts;
+        // it only ever hands back answer text.
+        var adapter = Adapter(("q", "a"));
+
+        var response = await adapter.InvokeAsync("q");
+
+        response.Text.Should().Be("a");
+        adapter.Matched.Should().Be(1);
+        adapter.OrderingMismatches.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task TheHistoryHooksAreInertAndDoNotDisturbReplay()
     {
         // Implemented only so the runner takes the same branches it takes for the real adapter. If

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
@@ -1,0 +1,84 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The re-grade replay must not be able to understate a baseline (2026-08-28).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The judge-only re-grade exists because AgentEval's bitemporal judge had no body, so every stored
+/// bitemporal verdict is suspect while the answers behind them are sound. The re-graded numbers will
+/// become the baselines a pre-registered arm is adjudicated against, which puts an unusual burden on
+/// this adapter: a silent miss here does not crash, it lowers a baseline.
+/// </para>
+/// <para>
+/// A question with no stored answer is replayed as empty text, and an empty answer grades as WRONG
+/// rather than as MISSING. That is indistinguishable, in the final score, from the model having
+/// genuinely failed — so the miss must be counted and surfaced rather than absorbed.
+/// </para>
+/// </remarks>
+public class TypedMemEvalReplayAdapterTests
+{
+    private static TypedMemEvalReplayAdapter Adapter(params (string Question, string Answer)[] rows) =>
+        new(rows.ToDictionary(row => row.Question, row => row.Answer, StringComparer.Ordinal), "m");
+
+    [Fact]
+    public async Task AStoredAnswerIsReplayedVerbatim()
+    {
+        // Verbatim matters more than it looks: the judge grades this text, so any normalisation here
+        // would be a silent edit to the thing under measurement.
+        var adapter = Adapter(("Where does Colm work?", "Marchmont, since February."));
+
+        var response = await adapter.InvokeAsync("Where does Colm work?");
+
+        response.Text.Should().Be("Marchmont, since February.");
+        adapter.Matched.Should().Be(1);
+        adapter.UnmatchedQuestions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AQuestionWithNoStoredAnswerIsRecordedAsUnmatchedRatherThanScoredAsWrong()
+    {
+        var adapter = Adapter(("Known question", "answer"));
+
+        var response = await adapter.InvokeAsync("A question the artifact never contained");
+
+        response.Text.Should().BeEmpty();
+        adapter.Matched.Should().Be(0);
+        // The whole safety property: the caller can see the miss and abort, instead of publishing a
+        // baseline quietly reduced by one wrong answer that was never actually wrong.
+        adapter.UnmatchedQuestions.Should().ContainSingle()
+            .Which.Should().Be("A question the artifact never contained");
+    }
+
+    [Fact]
+    public async Task MatchingIsExactSoANearMissIsAMissRatherThanAWrongPairing()
+    {
+        // Trailing whitespace, casing, punctuation: pairing a question with a DIFFERENT question's
+        // answer would be worse than not pairing it at all, because it would be graded and scored.
+        var adapter = Adapter(("Where does Colm work?", "Marchmont"));
+
+        await adapter.InvokeAsync("where does colm work?");
+
+        adapter.Matched.Should().Be(0);
+        adapter.UnmatchedQuestions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task TheHistoryHooksAreInertAndDoNotDisturbReplay()
+    {
+        // Implemented only so the runner takes the same branches it takes for the real adapter. If
+        // they ever stop being inert, a re-grade stops being a pure judge pass.
+        var adapter = Adapter(("q", "a"));
+
+        adapter.InjectConversationHistory([("user", "assistant")]);
+        await adapter.ResetSessionAsync();
+        var response = await adapter.InvokeAsync("q");
+
+        response.Text.Should().Be("a");
+        adapter.Matched.Should().Be(1);
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
@@ -23,7 +23,7 @@ namespace AgentMemory.Tests.Unit.LongMemEval;
 public class TypedMemEvalReplayAdapterTests
 {
     private static TypedMemEvalReplayAdapter Adapter(params (string Question, string Answer)[] rows) =>
-        new(rows.ToDictionary(row => row.Question, row => row.Answer, StringComparer.Ordinal), "m");
+        new(rows, "m");
 
     [Fact]
     public async Task AStoredAnswerIsReplayedVerbatim()
@@ -40,7 +40,7 @@ public class TypedMemEvalReplayAdapterTests
     }
 
     [Fact]
-    public async Task AQuestionWithNoStoredAnswerIsRecordedAsUnmatchedRatherThanScoredAsWrong()
+    public async Task AnUnexpectedQuestionIsRefusedRatherThanScoredAsWrong()
     {
         var adapter = Adapter(("Known question", "answer"));
 
@@ -48,22 +48,53 @@ public class TypedMemEvalReplayAdapterTests
 
         response.Text.Should().BeEmpty();
         adapter.Matched.Should().Be(0);
-        // The whole safety property: the caller can see the miss and abort, instead of publishing a
-        // baseline quietly reduced by one wrong answer that was never actually wrong.
-        adapter.UnmatchedQuestions.Should().ContainSingle()
+        // The safety property: the caller sees it and aborts, instead of publishing a baseline
+        // quietly reduced by one wrong answer that was never actually wrong.
+        adapter.OrderingMismatches.Should().ContainSingle()
             .Which.Should().Be("A question the artifact never contained");
     }
 
     [Fact]
-    public async Task MatchingIsExactSoANearMissIsAMissRatherThanAWrongPairing()
+    public async Task AQuestionOutOfOrderIsRefusedRatherThanPairedWithTheWrongAnswer()
     {
-        // Trailing whitespace, casing, punctuation: pairing a question with a DIFFERENT question's
-        // answer would be worse than not pairing it at all, because it would be graded and scored.
-        var adapter = Adapter(("Where does Colm work?", "Marchmont"));
+        // The failure this class exists to prevent. Pairing answers with the wrong questions yields
+        // a complete, plausible, entirely meaningless score -- far worse than an obvious blank.
+        var adapter = Adapter(("First question", "first answer"), ("Second question", "second answer"));
 
-        await adapter.InvokeAsync("where does colm work?");
+        await adapter.InvokeAsync("Second question");
 
         adapter.Matched.Should().Be(0);
+        adapter.OrderingMismatches.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DuplicateQuestionTextsAreReplayedDistinctlyByPosition()
+    {
+        // Twelve of the sixty bitemporal questions share text with a question whose gold answer
+        // DIFFERS -- tme-bit-007 and tme-bit-037 both ask about Colm Whitaker in February and answer
+        // Lowick and Marchmont. Text keying silently mispaired 12 of 60; position keying does not.
+        var adapter = Adapter(
+            ("Which department was Colm Whitaker at in February?", "Lowick"),
+            ("Which department was Colm Whitaker at in February?", "Marchmont"));
+
+        var first = await adapter.InvokeAsync("Which department was Colm Whitaker at in February?");
+        var second = await adapter.InvokeAsync("Which department was Colm Whitaker at in February?");
+
+        first.Text.Should().Be("Lowick");
+        second.Text.Should().Be("Marchmont");
+        adapter.Matched.Should().Be(2);
+        adapter.OrderingMismatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MoreQuestionsThanStoredAnswersIsRecordedAsUnmatched()
+    {
+        var adapter = Adapter(("only question", "only answer"));
+
+        await adapter.InvokeAsync("only question");
+        await adapter.InvokeAsync("a question past the end of the artifact");
+
+        adapter.Matched.Should().Be(1);
         adapter.UnmatchedQuestions.Should().ContainSingle();
     }
 

--- a/tests/AgentMemory.Tests.Unit/Services/SupersessionPredicateGateTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Services/SupersessionPredicateGateTests.cs
@@ -1,0 +1,72 @@
+using AgentMemory.Core.Memory;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.Services;
+
+/// <summary>
+/// The gate that decides whether write-time supersession runs at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> The 30.9d render arm produced zero supersession notes in 60 of 60 prompts,
+/// and a live-Neo4j walk of the chain showed every downstream link working: the edge is written, the
+/// predecessor lookup finds it, and BOTH live and as-of recall render the note. The one link that
+/// walk bypassed was this gate — it superseded through the repository directly, so it never asked
+/// whether extraction would have been *allowed* to supersede.
+/// </para>
+/// <para>
+/// <c>PersistenceStage.SupersedeReplacedFactsAsync</c> returns immediately unless
+/// <c>WriteTimeFactResolution.CanSupersede</c> says the predicate is single-valued, and that is
+/// decided by a vocabulary of exactly six relations with the <c>single</c> cardinality —
+/// <c>belongs to, costs, expires, lives in, weighs, works at</c> — with the documented behaviour
+/// "false for anything unrecognised".
+/// </para>
+/// <para>
+/// This matters far beyond one arm: a corpus whose predicates fall outside those six cannot produce a
+/// single <c>:SUPERSEDED_BY</c> edge, so <c>SupersedeReplacedFacts=true</c> is indistinguishable from
+/// <c>false</c> on it — a lever that reports as ON while doing nothing.
+/// </para>
+/// </remarks>
+public class SupersessionPredicateGateTests
+{
+    [Theory]
+    [InlineData("works at")]
+    [InlineData("lives in")]
+    [InlineData("belongs to")]
+    public void TheDeclaredFunctionalRelationsCanSupersede(string predicate) =>
+        MemoryRelationCardinality.IsSingleValued(predicate).Should().BeTrue();
+
+    /// <summary>
+    /// The phrasings a free-form extractor produces for "which department / site / branch was X at".
+    /// </summary>
+    /// <remarks>
+    /// The evaluation profile leaves <c>usePredicateVocabulary</c> off, so the extractor is not
+    /// constrained to the canonical set and writes whatever the sentence suggests. Each of these is a
+    /// perfectly reasonable extraction of a corrected-location statement, and each one silently
+    /// disables supersession for the fact it belongs to.
+    /// </remarks>
+    [Theory]
+    [InlineData("was at")]
+    [InlineData("is at")]
+    [InlineData("assigned to")]
+    [InlineData("located in")]
+    [InlineData("department")]
+    [InlineData("branch")]
+    [InlineData("region")]
+    [InlineData("office")]
+    [InlineData("site")]
+    [InlineData("recorded at")]
+    public void TheCorpusShapedPhrasingsCannotSupersede(string predicate) =>
+        MemoryRelationCardinality.IsSingleValued(predicate).Should().BeFalse(
+            "an unrecognised predicate silently makes SupersedeReplacedFacts a no-op");
+
+    /// <summary>The gate's reach is six relations, and that number is the finding.</summary>
+    [Fact]
+    public void OnlySixRelationsInTheEntireVocabularyAreSingleValued()
+    {
+        MemoryRelationCardinality.SingleValuedPredicates.Should().HaveCount(6);
+        MemoryRelationCardinality.SingleValuedPredicates.Should().BeEquivalentTo(
+            ["belongs to", "costs", "expires", "lives in", "weighs", "works at"]);
+    }
+}

--- a/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
+++ b/tools/AgentMemory.LongMemEval/AgentMemory.LongMemEval.csproj
@@ -36,7 +36,7 @@
       hard-codes a corpus SHA-256 or question count — counts and identifiers are read from
       TypedMemEvalCorpus/TypedMemEvalVerticals at run time, which is what made this a one-line bump.
     -->
-    <PackageReference Include="AgentEval" Version="0.28.0-beta" />
+    <PackageReference Include="AgentEval" Version="0.29.0-beta" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />

--- a/tools/AgentMemory.LongMemEval/AgentMemoryLongMemEvalAdapter.cs
+++ b/tools/AgentMemory.LongMemEval/AgentMemoryLongMemEvalAdapter.cs
@@ -876,6 +876,13 @@ public sealed partial class AgentMemoryLongMemEvalAdapter :
             prompt,
             queryTime is { } answerNow ? FormatQueryTime(answerNow) : evidenceQuestion?.QuestionDate,
             originsByMessageId);
+
+        // 30.9d render-state evidence, taken HERE rather than from the config, and taken from the
+        // prompt string itself rather than from the projection alone. Two levers in this intervention
+        // were already believed live because they were reachable; a third assumption is not affordable.
+        // Null probe => not observed, which the prereg reads as a failure, never as a pass.
+        _options.SupersessionRenderProbe?.Observe(
+            evidenceQuestion?.QuestionId ?? "(unidentified)", recall.Context, answerPrompt);
         LongMemEvalRetrievalEvidence? retrievalEvidence = null;
         AgentEval.Memory.External.Models.QuestionEvidenceEnvelope? normalizedEvidence = null;
         if (evidenceQuestion is not null)
@@ -1979,6 +1986,12 @@ public sealed record LongMemEvalAdapterOptions
     internal bool RequireGraphReadBack { get; init; }
 
     internal ILongMemEvalGraphProbe? GraphProbe { get; init; }
+
+    /// <summary>
+    /// Collects positive evidence that supersession chains reached the answer prompt, or null to not
+    /// observe. Absence is "not measured" — a gate that reads it must fail closed on null.
+    /// </summary>
+    internal LongMemEvalSupersessionRenderProbe? SupersessionRenderProbe { get; init; }
 }
 
 public sealed record LongMemEvalQuestionTelemetry(

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -98,14 +98,18 @@ internal static partial class CellProbeProgram
                 // The comparison is only controlled if entry i of one cell is entry i of the other.
                 using var pair = JsonDocument.Parse(File.ReadAllText(Path.GetFullPath(pairPath)));
                 var paired = pair.RootElement.EnumerateArray().Skip(skip).Take(maxEntries).ToArray();
-                var mismatch = entries.Length != paired.Length ? -1 : Enumerable
+                var lengthsMatch = entries.Length == paired.Length;
+                var mismatch = lengthsMatch ? Enumerable
                     .Range(0, entries.Length)
                     .FirstOrDefault(i => entries[i].GetProperty("question_id").GetString()
-                        != paired[i].GetProperty("question_id").GetString(), -1);
-                Console.WriteLine(mismatch == -1
+                        != paired[i].GetProperty("question_id").GetString(), -1) : -1;
+                Console.WriteLine(lengthsMatch && mismatch == -1
                     ? $"cell-probe:   PAIRING OK — {entries.Length} entries share question ids with " +
                       Path.GetFileName(pairPath)
-                    : $"cell-probe:   PAIRING BROKEN at index {mismatch} — the cells are not aligned.");
+                    : lengthsMatch
+                        ? $"cell-probe:   PAIRING BROKEN at index {mismatch} — the cells are not aligned."
+                        : $"cell-probe:   PAIRING BROKEN — window length mismatch " +
+                          $"{entries.Length} vs {paired.Length}.");
                 var pairedAmounts = paired.Sum(entry =>
                     entry.GetProperty("haystack_sessions").EnumerateArray()
                         .Sum(sess => sess.EnumerateArray()

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -36,7 +36,7 @@ namespace AgentMemory.LongMemEval;
 internal static partial class CellProbeProgram
 {
     internal static readonly string[] KnownOptions =
-        ["--cell-probe", "--max-entries", "--skip-entries"];
+        ["--cell-probe", "--max-entries", "--skip-entries", "--dry-run", "--pair-with"];
 
     [System.Text.RegularExpressions.GeneratedRegex(@"\$\s?\d|\d+\.\d{2}")]
     private static partial System.Text.RegularExpressions.Regex AmountPattern();
@@ -72,6 +72,51 @@ internal static partial class CellProbeProgram
             return 2;
         }
         Console.WriteLine($"cell-probe: window holds {amountSentences} amount-bearing sentence(s).");
+
+        // DRY RUN. Everything the real run does EXCEPT the paid part: the corpus loads, the window
+        // contains the phenomenon, the paired cell lines up entry-for-entry, the amount pattern
+        // actually matches this corpus's sentences, and the store queries execute. Added because the
+        // first cell run spent ~2,224 calls and two hours on a window that contained none of what it
+        // measured -- a fact one free read of the corpus would have shown before ignition.
+        if (args.Contains("--dry-run", StringComparer.Ordinal))
+        {
+            Console.WriteLine("cell-probe: DRY RUN — no LLM calls, no extraction.");
+            var sessions = entries.Sum(e => e.GetProperty("haystack_sessions").GetArrayLength());
+            Console.WriteLine(
+                $"cell-probe:   entries {entries.Length} (skip {skip}), sessions {sessions}, " +
+                $"amount sentences {amountSentences}");
+
+            var sample = entries
+                .SelectMany(e => e.GetProperty("haystack_sessions").EnumerateArray())
+                .SelectMany(sess => sess.EnumerateArray())
+                .Select(t => t.TryGetProperty("content", out var c) ? c.GetString() ?? "" : "")
+                .FirstOrDefault(text => AmountPattern().IsMatch(text));
+            Console.WriteLine($"cell-probe:   pattern matches, e.g. \"{Trim(sample ?? "(none)")}\"");
+
+            if (Value(args, "--pair-with") is { } pairPath)
+            {
+                // The comparison is only controlled if entry i of one cell is entry i of the other.
+                using var pair = JsonDocument.Parse(File.ReadAllText(Path.GetFullPath(pairPath)));
+                var paired = pair.RootElement.EnumerateArray().Skip(skip).Take(maxEntries).ToArray();
+                var mismatch = entries.Length != paired.Length ? -1 : Enumerable
+                    .Range(0, entries.Length)
+                    .FirstOrDefault(i => entries[i].GetProperty("question_id").GetString()
+                        != paired[i].GetProperty("question_id").GetString(), -1);
+                Console.WriteLine(mismatch == -1
+                    ? $"cell-probe:   PAIRING OK — {entries.Length} entries share question ids with " +
+                      Path.GetFileName(pairPath)
+                    : $"cell-probe:   PAIRING BROKEN at index {mismatch} — the cells are not aligned.");
+                var pairedAmounts = paired.Sum(entry =>
+                    entry.GetProperty("haystack_sessions").EnumerateArray()
+                        .Sum(sess => sess.EnumerateArray()
+                            .Sum(t => AmountPattern().Matches(
+                                t.TryGetProperty("content", out var c) ? c.GetString() ?? "" : "").Count)));
+                Console.WriteLine($"cell-probe:   paired window holds {pairedAmounts} amount sentence(s).");
+            }
+
+            Console.WriteLine("cell-probe: DRY RUN COMPLETE — nothing spent.");
+            return 0;
+        }
         Console.WriteLine(
             $"cell-probe: {Path.GetFileName(path)} — {entries.Length} entr(ies), extraction only.");
 
@@ -153,6 +198,9 @@ internal static partial class CellProbeProgram
         var index = Array.IndexOf(args, name);
         return index < 0 || index + 1 >= args.Length ? null : args[index + 1];
     }
+
+    private static string Trim(string value) =>
+        value.Length <= 90 ? value : value[..90] + "…";
 
     private static string RequiredEnvironment(string name) =>
         Environment.GetEnvironmentVariable(name) is { Length: > 0 } value

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -43,6 +43,29 @@ internal static partial class CellProbeProgram
 
     public static async Task<int> RunAsync(string[] args)
     {
+        try
+        {
+            return await RunCoreAsync(args).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ArgumentException or FileNotFoundException)
+        {
+            // Presented as a refusal, not a crash. The validator's message already names the typo and
+            // suggests the correction; a stack trace on top of it only obscures that the run was
+            // stopped deliberately -- and this particular guard is what stands between a mistyped
+            // --dry-run and an unintended paid extraction.
+            Console.Error.WriteLine($"cell-probe: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunCoreAsync(string[] args)
+    {
+        // Validate FIRST, and the reason is specific to this verb: a mistyped `--dry-runn` is
+        // silently ignored, the dry-run branch never fires, and the operator who asked for the free
+        // check gets a paid extraction instead. Unknown-option tolerance is a spending hazard here,
+        // not a usability nicety.
+        LongMemEvalArgumentValidator.Validate(args, KnownOptions);
+
         var path = Value(args, "--cell-probe")
             ?? throw new ArgumentException("--cell-probe requires a path to a cell .json.");
         var maxEntries = int.TryParse(Value(args, "--max-entries"), out var n) ? n : int.MaxValue;

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using System.Text.Json;
+using AgentMemory.Abstractions.Domain;
+using AgentMemory.Abstractions.Services;
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Extracts an EXTERNAL corpus cell and reports whether amount subjects collide in the store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The question this exists to settle.</b> Our probe found several distinct amounts under the bare
+/// subject <c>Payment</c> and I scoped that as an extraction defect of ours. AgentEval showed it is
+/// not: every amount-bearing sentence in their arithmetic corpus is
+/// <c>"Payment logged against {job}: ${amount} for {item}."</c> — 248 of 248 — so the grammatical
+/// subject really is the bare common noun, and our extractor reported what the sentence said.
+/// </para>
+/// <para>
+/// Two explanations survive that, and they imply opposite work. Either their bare subject is the
+/// cause (fixable by wording), or an amount is a <b>four-place fact</b> — payer, job, amount, line
+/// item — that a triple store must reify or lose the join however it is worded, in which case no
+/// rewording helps and the defect is ours in a different place. Cells B and C differ in exactly one
+/// thing, the payment sentence's subject, so the pair separates them.
+/// </para>
+/// <para>
+/// <b>No judge, no questions, no scoring.</b> This ingests and measures the store. That makes it
+/// materially cheaper than an arm and keeps it incapable of producing an accuracy number that could
+/// later be read as a result it was never designed to support.
+/// </para>
+/// </remarks>
+internal static class CellProbeProgram
+{
+    internal static readonly string[] KnownOptions = ["--cell-probe", "--max-entries"];
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var path = Value(args, "--cell-probe")
+            ?? throw new ArgumentException("--cell-probe requires a path to a cell .json.");
+        var maxEntries = int.TryParse(Value(args, "--max-entries"), out var n) ? n : int.MaxValue;
+        path = Path.GetFullPath(path);
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        var entries = document.RootElement.EnumerateArray().Take(maxEntries).ToArray();
+        Console.WriteLine(
+            $"cell-probe: {Path.GetFileName(path)} — {entries.Length} entr(ies), extraction only.");
+
+        var endpoint = RequiredEnvironment("AZURE_OPENAI_ENDPOINT");
+        var apiKey = RequiredEnvironment("AZURE_OPENAI_API_KEY");
+        var deployment = RequiredEnvironment("AZURE_OPENAI_DEPLOYMENT");
+        var embeddingDeployment = RequiredEnvironment("AZURE_OPENAI_EMBEDDING_DEPLOYMENT");
+        var azure = new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+        using var extractionChat = new LongMemEvalChatCallMeter(
+            new ProviderCompatibleExtractionChatClient(azure.GetChatClient(deployment).AsIChatClient()));
+        var embeddings = azure.GetEmbeddingClient(embeddingDeployment).AsIEmbeddingGenerator();
+        var dimensions = await LongMemEvalRuntime
+            .ProbeEmbeddingDimensionsAsync(embeddings).ConfigureAwait(false);
+
+        await using var profile = await LongMemEvalMemoryProfile.StartAsync(
+            embeddings, extractionChat, LongMemEvalMemoryMode.Structured, deployment, dimensions,
+            Console.Out, CancellationToken.None).ConfigureAwait(false);
+
+        var memory = profile.Services.GetRequiredService<IMemoryService>();
+        var unit = 0;
+        for (var i = 0; i < entries.Length; i++)
+        {
+            // One owner per entry, mirroring the benchmark harness's isolation exactly: pooling them
+            // would let two entries' payments collide for a reason that has nothing to do with the
+            // cell under test.
+            var owner = $"cell-owner-{i:D4}";
+            var sessions = entries[i].GetProperty("haystack_sessions").EnumerateArray().ToArray();
+            for (var s = 0; s < sessions.Length; s++)
+            {
+                var sessionId = $"cell-session-{i:D4}-{s:D3}";
+                var messages = sessions[s].EnumerateArray()
+                    .Select(turn => new Message
+                    {
+                        MessageId = Guid.NewGuid().ToString("n"),
+                        ConversationId = sessionId,
+                        SessionId = sessionId,
+                        Role = turn.TryGetProperty("role", out var r) ? r.GetString() ?? "user" : "user",
+                        Content = turn.TryGetProperty("content", out var c) ? c.GetString() ?? "" : "",
+                        TimestampUtc = DateTimeOffset.UtcNow,
+                    })
+                    .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+                    .ToArray();
+                if (messages.Length == 0) continue;
+
+                await memory.AddMessagesAsync(messages, CancellationToken.None).ConfigureAwait(false);
+                await memory.ExtractAndPersistAsync(
+                    new ExtractionRequest { Messages = messages, SessionId = sessionId, UserId = owner },
+                    CancellationToken.None).ConfigureAwait(false);
+                if (++unit % 10 == 0) Console.WriteLine($"cell-probe: extraction units {unit}.");
+            }
+        }
+
+        var probe = new Neo4jLongMemEvalGraphProbe(
+            profile.Services.GetRequiredService<global::Neo4j.Driver.IDriver>());
+        var objects = await probe.ReadFactObjectShapeAsync(CancellationToken.None).ConfigureAwait(false);
+        var ambiguity = await probe.ReadSubjectAmbiguityAsync(CancellationToken.None).ConfigureAwait(false);
+        var amountGroups = await probe.ReadAmountGroupCollisionAsync(CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Console.WriteLine(
+            $"cell-probe: objects — {objects.AmountBearing} amount-bearing of {objects.Facts} facts.");
+        Console.WriteLine(
+            $"cell-probe: AMOUNT-SUBJECT COLLISION — {amountGroups.CollidingGroups} of " +
+            $"{amountGroups.AmountGroups} amount-bearing subject/predicate groups hold >1 distinct " +
+            $"amount = {(amountGroups.AmountGroups == 0 ? 0 : 100.0 * amountGroups.CollidingGroups / amountGroups.AmountGroups):F1}%");
+        foreach (var sample in amountGroups.Samples) Console.WriteLine($"cell-probe:   {sample}");
+        Console.WriteLine($"cell-probe: (subject-ambiguity groups overall: {ambiguity.Pairs.Count})");
+        Console.WriteLine($"cell-probe: extraction LLM calls {extractionChat.Snapshot()}");
+        return 0;
+    }
+
+    private static string? Value(string[] args, string name)
+    {
+        var index = Array.IndexOf(args, name);
+        return index < 0 || index + 1 >= args.Length ? null : args[index + 1];
+    }
+
+    private static string RequiredEnvironment(string name) =>
+        Environment.GetEnvironmentVariable(name) is { Length: > 0 } value
+            ? value
+            : throw new ArgumentException($"{name} must be set.");
+}

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -184,9 +184,12 @@ internal static partial class CellProbeProgram
         Console.WriteLine(amountGroups.AmountGroups == 0
             ? "cell-probe: AMOUNT-SUBJECT COLLISION — NOT MEASURED (zero amount-bearing groups in " +
               "the store; the metric has no denominator). This is not 0%."
-            : $"cell-probe: AMOUNT-SUBJECT COLLISION — {amountGroups.CollidingGroups} of " +
-              $"{amountGroups.AmountGroups} amount-bearing subject/predicate groups hold >1 distinct " +
-              $"amount = {100.0 * amountGroups.CollidingGroups / amountGroups.AmountGroups:F1}%");
+            : $"cell-probe: AMOUNT-SUBJECT COLLISION — groups {amountGroups.CollidingGroups}/" +
+              $"{amountGroups.AmountGroups} = {100.0 * amountGroups.CollidingGroups / amountGroups.AmountGroups:F1}%" +
+              $"  |  AMOUNTS UNDER AN OVERLOADED SUBJECT {amountGroups.CollidingFacts}/" +
+              $"{amountGroups.AmountFacts} = " +
+              $"{(amountGroups.AmountFacts == 0 ? 0 : 100.0 * amountGroups.CollidingFacts / amountGroups.AmountFacts):F1}%" +
+              "  (the second is the one comparable to their 48/48 per-payment calibration)");
         foreach (var sample in amountGroups.Samples) Console.WriteLine($"cell-probe:   {sample}");
         Console.WriteLine($"cell-probe: (subject-ambiguity groups overall: {ambiguity.Pairs.Count})");
         Console.WriteLine($"cell-probe: extraction LLM calls {extractionChat.Snapshot()}");

--- a/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/CellProbeProgram.cs
@@ -33,9 +33,13 @@ namespace AgentMemory.LongMemEval;
 /// later be read as a result it was never designed to support.
 /// </para>
 /// </remarks>
-internal static class CellProbeProgram
+internal static partial class CellProbeProgram
 {
-    internal static readonly string[] KnownOptions = ["--cell-probe", "--max-entries"];
+    internal static readonly string[] KnownOptions =
+        ["--cell-probe", "--max-entries", "--skip-entries"];
+
+    [System.Text.RegularExpressions.GeneratedRegex(@"\$\s?\d|\d+\.\d{2}")]
+    private static partial System.Text.RegularExpressions.Regex AmountPattern();
 
     public static async Task<int> RunAsync(string[] args)
     {
@@ -44,8 +48,30 @@ internal static class CellProbeProgram
         var maxEntries = int.TryParse(Value(args, "--max-entries"), out var n) ? n : int.MaxValue;
         path = Path.GetFullPath(path);
 
+        var skip = int.TryParse(Value(args, "--skip-entries"), out var k) ? k : 0;
         using var document = JsonDocument.Parse(File.ReadAllText(path));
-        var entries = document.RootElement.EnumerateArray().Take(maxEntries).ToArray();
+        var entries = document.RootElement.EnumerateArray().Skip(skip).Take(maxEntries).ToArray();
+
+        // PRECONDITION, checked before a single LLM call. The first registered window was "the first
+        // 12 entries", and payment sentences in this corpus start at entry 14 -- so the window held
+        // ZERO of the phenomenon, the metric measured 0 of 0, and it printed "0.0%" as though that
+        // were a reading. Two hours and ~2,200 calls bought a constant. A sampling rule that cannot
+        // contain the thing being measured is a defect in the rule, and it is free to detect.
+        var amountSentences = entries.Sum(entry =>
+            entry.GetProperty("haystack_sessions").EnumerateArray()
+                .Sum(session => session.EnumerateArray()
+                    .Sum(turn => AmountPattern().Matches(
+                        turn.TryGetProperty("content", out var c) ? c.GetString() ?? "" : "").Count)));
+        if (amountSentences == 0)
+        {
+            Console.Error.WriteLine(
+                $"cell-probe: ABORT — the selected window (skip {skip}, take {maxEntries}) contains " +
+                "NO amount-bearing sentences, so the amount-collision metric would divide by zero and " +
+                "report 0.0% as if it were a measurement. Choose a window that contains the " +
+                "phenomenon.");
+            return 2;
+        }
+        Console.WriteLine($"cell-probe: window holds {amountSentences} amount-bearing sentence(s).");
         Console.WriteLine(
             $"cell-probe: {Path.GetFileName(path)} — {entries.Length} entr(ies), extraction only.");
 
@@ -107,10 +133,15 @@ internal static class CellProbeProgram
 
         Console.WriteLine(
             $"cell-probe: objects — {objects.AmountBearing} amount-bearing of {objects.Facts} facts.");
-        Console.WriteLine(
-            $"cell-probe: AMOUNT-SUBJECT COLLISION — {amountGroups.CollidingGroups} of " +
-            $"{amountGroups.AmountGroups} amount-bearing subject/predicate groups hold >1 distinct " +
-            $"amount = {(amountGroups.AmountGroups == 0 ? 0 : 100.0 * amountGroups.CollidingGroups / amountGroups.AmountGroups):F1}%");
+        // A share over an empty denominator is NOT MEASURED, and must never be rendered as 0.0% --
+        // that is the constant column this project has now been bitten by three times, and once by
+        // this very program.
+        Console.WriteLine(amountGroups.AmountGroups == 0
+            ? "cell-probe: AMOUNT-SUBJECT COLLISION — NOT MEASURED (zero amount-bearing groups in " +
+              "the store; the metric has no denominator). This is not 0%."
+            : $"cell-probe: AMOUNT-SUBJECT COLLISION — {amountGroups.CollidingGroups} of " +
+              $"{amountGroups.AmountGroups} amount-bearing subject/predicate groups hold >1 distinct " +
+              $"amount = {100.0 * amountGroups.CollidingGroups / amountGroups.AmountGroups:F1}%");
         foreach (var sample in amountGroups.Samples) Console.WriteLine($"cell-probe:   {sample}");
         Console.WriteLine($"cell-probe: (subject-ambiguity groups overall: {ambiguity.Pairs.Count})");
         Console.WriteLine($"cell-probe: extraction LLM calls {extractionChat.Snapshot()}");

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -4,6 +4,26 @@ namespace AgentMemory.LongMemEval;
 
 internal interface ILongMemEvalGraphProbe
 {
+    /// <summary>
+    /// Counts the supersession the run actually wrote: <c>:SUPERSEDED_BY</c> edges, invalidated
+    /// facts, and the predicates extraction produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This replaces an inference that was wrong.</b> The store-state gate used to argue from
+    /// facts-placed-per-question falling (8.25 → 7.92) that supersession had fired. Three arms later
+    /// the same lever produced 7.65 with no lever change in between, so that signal was extraction
+    /// variance and the gate had been certifying an off-state run as "verified ON" — the exact error
+    /// the gate existed to prevent, in the gate itself.
+    /// </para>
+    /// <para>
+    /// A count of edges cannot be confused with noise: zero means the mechanism did not run, and the
+    /// predicate histogram says why, because write-time supersession is refused outright for any
+    /// predicate outside the six the vocabulary declares single-valued.
+    /// </para>
+    /// </remarks>
+    Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(CancellationToken cancellationToken);
+
     Task<LongMemEvalGraphSnapshot> ReadAsync(
         string ownerId,
         CancellationToken cancellationToken = default);
@@ -100,6 +120,60 @@ internal sealed class Neo4jLongMemEvalGraphProbe(IDriver driver) : ILongMemEvalG
           AND (f.owner_id = $ownerId OR f.owner_id IS NULL)
         RETURN f.predicate_key AS predicateKey, count(f) AS factCount
         """;
+
+    // Deliberately three statements rather than one joined query. A single MATCH over facts AND
+    // edges returns NO ROW at all when the graph holds zero edges, and zero edges is the single most
+    // important thing this can report -- it must arrive as a number, never as an absent row.
+    private const string SupersessionEdgeCountQuery =
+        """
+        MATCH ()-[r:SUPERSEDED_BY]->() RETURN count(r) AS edges
+        """;
+
+    private const string FactShapeQuery =
+        """
+        MATCH (f:Fact)
+        RETURN count(f) AS facts,
+               count(CASE WHEN f.invalidated_at IS NOT NULL THEN 1 END) AS invalidated
+        """;
+
+    private const string PredicateHistogramQuery =
+        """
+        MATCH (f:Fact)
+        RETURN coalesce(f.predicate_key, toLower(f.predicate)) AS predicate, count(f) AS n
+        ORDER BY n DESC LIMIT 15
+        """;
+
+    public async Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(
+        CancellationToken cancellationToken)
+    {
+        await using var session = driver.AsyncSession();
+
+        var edges = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(SupersessionEdgeCountQuery).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
+            return record["edges"].As<int>();
+        }).ConfigureAwait(false);
+
+        var (facts, invalidated) = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(FactShapeQuery).ConfigureAwait(false);
+            var record = await cursor.SingleAsync().ConfigureAwait(false);
+            return (record["facts"].As<int>(), record["invalidated"].As<int>());
+        }).ConfigureAwait(false);
+
+        var predicates = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(PredicateHistogramQuery).ConfigureAwait(false);
+            var rows = await cursor.ToListAsync().ConfigureAwait(false);
+            return rows
+                .Where(row => row["predicate"] is not null)
+                .Select(row => (Predicate: row["predicate"].As<string>(), Count: row["n"].As<int>()))
+                .ToArray();
+        }).ConfigureAwait(false);
+
+        return new LongMemEvalSupersessionStore(edges, facts, invalidated, predicates);
+    }
 
     public async Task<IReadOnlyDictionary<string, int>?> ReadRelationFactCountsAsync(
         string ownerId,
@@ -395,3 +469,22 @@ public sealed record LongMemEvalGraphSnapshot(
         LearnedItemsWithProvenance == LearnedItems &&
         RelationshipsWithProvenance == Relationships;
 }
+
+/// <summary>What the store actually holds after a run, on the supersession axis.</summary>
+/// <param name="SupersededByEdges">
+/// The number that decides whether an arm measured anything. Zero means write-time supersession
+/// never ran, and every score from that arm is an off-state score however the flag was set.
+/// </param>
+/// <param name="Facts">Total facts stored.</param>
+/// <param name="InvalidatedFacts">Facts carrying <c>invalidated_at</c>.</param>
+/// <param name="TopPredicates">
+/// The most common predicates extraction produced. Present because a zero edge count is a symptom
+/// and this is the diagnosis: supersession is refused for any predicate outside the six the relation
+/// vocabulary declares single-valued, so the histogram shows immediately whether a corpus can
+/// exercise the mechanism at all.
+/// </param>
+internal sealed record LongMemEvalSupersessionStore(
+    int SupersededByEdges,
+    int Facts,
+    int InvalidatedFacts,
+    IReadOnlyList<(string Predicate, int Count)> TopPredicates);

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -80,7 +80,7 @@ internal interface ILongMemEvalGraphProbe
     /// hand-classified predicate list, which is what the general metric needed and could not have.
     /// </remarks>
     Task<LongMemEvalAmountCollision> ReadAmountGroupCollisionAsync(CancellationToken cancellationToken)
-        => Task.FromResult(new LongMemEvalAmountCollision(0, 0, []));
+        => Task.FromResult(new LongMemEvalAmountCollision(0, 0, 0, 0, []));
 
     Task<LongMemEvalGraphSnapshot> ReadAsync(
         string ownerId,
@@ -250,11 +250,20 @@ internal sealed class Neo4jLongMemEvalGraphProbe(IDriver driver) : ILongMemEvalG
         }).ConfigureAwait(false);
 
         var colliding = rows.Where(r => r.Distinct > 1).ToArray();
+        // Two denominators, both reported, neither chosen after the fact. GROUPS answers "how many
+        // subjects are overloaded"; FACTS answers "how many amounts sit under an overloaded subject"
+        // and is the one comparable to AgentEval's per-payment calibration (48/48). The group rate is
+        // unstable at small denominators -- a wiring smoke showed 1 of 3 groups holding 8 of 10
+        // amounts -- so reporting only the group rate would understate the collapse it exists to
+        // measure. Both are registered before the paired run so neither can be selected afterwards.
+        var amountFacts = rows.Sum(r => r.Distinct);
+        var collidingFacts = colliding.Sum(r => r.Distinct);
         var samples = colliding.Take(5)
             .Select(r => $"\"{Trim(r.Subject)}\" | {r.Predicate} | {r.Distinct} amounts: " +
                          string.Join(" / ", r.Amounts.Take(4)))
             .ToArray();
-        return new LongMemEvalAmountCollision(rows.Length, colliding.Length, samples);
+        return new LongMemEvalAmountCollision(
+            rows.Length, colliding.Length, amountFacts, collidingFacts, samples);
     }
 
     public async Task<LongMemEvalSubjectAmbiguity> ReadSubjectAmbiguityAsync(
@@ -690,4 +699,8 @@ internal sealed record LongMemEvalSubjectAmbiguity(IReadOnlyList<LongMemEvalAmbi
 
 /// <summary>Whether amounts collide under a shared subject — the Cell B vs Cell C measure.</summary>
 internal sealed record LongMemEvalAmountCollision(
-    int AmountGroups, int CollidingGroups, IReadOnlyList<string> Samples);
+    int AmountGroups,
+    int CollidingGroups,
+    int AmountFacts,
+    int CollidingFacts,
+    IReadOnlyList<string> Samples);

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -23,10 +23,22 @@ internal interface ILongMemEvalGraphProbe
     /// </para>
     /// </remarks>
     /// <remarks>
+    /// <para>
     /// Defaulted to empty because these three are OPTIONAL DIAGNOSTICS, not part of what a probe must
     /// be able to do. Making them required broke six unrelated test fakes that have no graph to
     /// report on, which is a signal about the contract rather than about the fakes: a store-shape
     /// reading is something a probe MAY offer, and empty is the honest answer when it cannot.
+    /// </para>
+    /// <para>
+    /// <b>EMPTY MEANS "NO STORE TO READ", NOT "MEASURED ZERO", and a reader must not collapse the
+    /// two.</b> A default that silently satisfies every caller is how a constant column is born — a
+    /// value that could not have come out any other way, read as though it were evidence. That has
+    /// already cost this project once: "12 of 12 pairs with zero entity links" was reported as a
+    /// finding when every fact in every store had zero, because nothing writes those links. A caller
+    /// that needs to distinguish "the mechanism wrote nothing" from "nobody looked" must check
+    /// whether a real probe was supplied, exactly as the render gate treats a null block as a
+    /// failure rather than a pass.
+    /// </para>
     /// </remarks>
     Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(CancellationToken cancellationToken)
         => Task.FromResult(new LongMemEvalSupersessionStore(0, 0, 0, []));

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -70,6 +70,18 @@ internal interface ILongMemEvalGraphProbe
     Task<LongMemEvalSubjectAmbiguity> ReadSubjectAmbiguityAsync(CancellationToken cancellationToken)
         => Task.FromResult(new LongMemEvalSubjectAmbiguity([]));
 
+    /// <summary>
+    /// Of the subject/predicate groups whose objects are amounts, how many hold more than one.
+    /// </summary>
+    /// <remarks>
+    /// The B-vs-C metric, and deliberately narrower than general subject ambiguity: a multi-object
+    /// group is only a defect for a FUNCTIONAL relation, and "this payment's amount" is functional by
+    /// construction. Restricting to amount-valued groups makes the measure functional-only without a
+    /// hand-classified predicate list, which is what the general metric needed and could not have.
+    /// </remarks>
+    Task<LongMemEvalAmountCollision> ReadAmountGroupCollisionAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new LongMemEvalAmountCollision(0, 0, []));
+
     Task<LongMemEvalGraphSnapshot> ReadAsync(
         string ownerId,
         CancellationToken cancellationToken = default);
@@ -211,6 +223,39 @@ internal sealed class Neo4jLongMemEvalGraphProbe(IDriver driver) : ILongMemEvalG
         RETURN subject, subjectKey, predicateKey, objects, entities
         ORDER BY size(objects) DESC LIMIT 12
         """;
+
+    private const string AmountCollisionQuery =
+        """
+        MATCH (f:Fact)
+        WHERE f.object =~ '.*(\$\s?\d|\d+\.\d{2}).*'
+        WITH f.subject_key AS s, f.predicate_key AS p, f.owner_key AS ow,
+             collect(DISTINCT f.object) AS amounts, head(collect(f.subject)) AS subject
+        RETURN subject, p AS predicate, amounts, size(amounts) AS distinctAmounts
+        ORDER BY distinctAmounts DESC
+        """;
+
+    public async Task<LongMemEvalAmountCollision> ReadAmountGroupCollisionAsync(
+        CancellationToken cancellationToken)
+    {
+        await using var session = driver.AsyncSession();
+        var rows = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(AmountCollisionQuery).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            return records.Select(r => (
+                Subject: r["subject"].As<string>() ?? string.Empty,
+                Predicate: r["predicate"].As<string>() ?? string.Empty,
+                Amounts: r["amounts"].As<List<object>>().Select(a => a?.ToString() ?? "").ToArray(),
+                Distinct: r["distinctAmounts"].As<int>())).ToArray();
+        }).ConfigureAwait(false);
+
+        var colliding = rows.Where(r => r.Distinct > 1).ToArray();
+        var samples = colliding.Take(5)
+            .Select(r => $"\"{Trim(r.Subject)}\" | {r.Predicate} | {r.Distinct} amounts: " +
+                         string.Join(" / ", r.Amounts.Take(4)))
+            .ToArray();
+        return new LongMemEvalAmountCollision(rows.Length, colliding.Length, samples);
+    }
 
     public async Task<LongMemEvalSubjectAmbiguity> ReadSubjectAmbiguityAsync(
         CancellationToken cancellationToken)
@@ -642,3 +687,7 @@ internal sealed record LongMemEvalAmbiguousSubject(
 
 /// <summary>Whether a retrieved value can be attributed to the thing it belongs to.</summary>
 internal sealed record LongMemEvalSubjectAmbiguity(IReadOnlyList<LongMemEvalAmbiguousSubject> Pairs);
+
+/// <summary>Whether amounts collide under a shared subject — the Cell B vs Cell C measure.</summary>
+internal sealed record LongMemEvalAmountCollision(
+    int AmountGroups, int CollidingGroups, IReadOnlyList<string> Samples);

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -24,6 +24,19 @@ internal interface ILongMemEvalGraphProbe
     /// </remarks>
     Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Classifies what actually sits in fact OBJECTS, to tell "stored at the wrong grain" from
+    /// "never captured".
+    /// </summary>
+    /// <remarks>
+    /// The predicate histogram showed extraction writing speech acts across three unrelated corpora.
+    /// It could not say whether the content survived inside those triples — an amount attached to
+    /// <c>said as much about</c> is a grain problem, an amount nowhere in the store is a capture
+    /// problem, and the two need different fixes. Objects are returned verbatim in samples so the
+    /// classification is eyeballable rather than trusted.
+    /// </remarks>
+    Task<LongMemEvalFactObjectShape> ReadFactObjectShapeAsync(CancellationToken cancellationToken);
+
     Task<LongMemEvalGraphSnapshot> ReadAsync(
         string ownerId,
         CancellationToken cancellationToken = default);
@@ -142,6 +155,52 @@ internal sealed class Neo4jLongMemEvalGraphProbe(IDriver driver) : ILongMemEvalG
         RETURN coalesce(f.predicate_key, toLower(f.predicate)) AS predicate, count(f) AS n
         ORDER BY n DESC LIMIT 15
         """;
+
+    private const string FactObjectQuery =
+        """
+        MATCH (f:Fact)
+        RETURN f.subject AS subject, f.predicate AS predicate, f.object AS object
+        """;
+
+    public async Task<LongMemEvalFactObjectShape> ReadFactObjectShapeAsync(
+        CancellationToken cancellationToken)
+    {
+        await using var session = driver.AsyncSession();
+        var rows = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(FactObjectQuery).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            return records
+                .Select(r => (
+                    Subject: r["subject"].As<string>() ?? string.Empty,
+                    Predicate: r["predicate"].As<string>() ?? string.Empty,
+                    Object: r["object"].As<string>() ?? string.Empty))
+                .ToArray();
+        }).ConfigureAwait(false);
+
+        // The arithmetic corpus answers in the shape `319.97`, so that is what "amount" means here --
+        // registered before this was written, and deliberately NOT widened to "any digit", which
+        // would count dates and session numbers as money.
+        var amount = new System.Text.RegularExpressions.Regex(
+            @"(\$\s?\d|\d+\.\d{2})", System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+        var digit = new System.Text.RegularExpressions.Regex(@"\d");
+
+        var amounts = rows.Where(r => amount.IsMatch(r.Object)).ToArray();
+        var numeric = rows.Where(r => !amount.IsMatch(r.Object) && digit.IsMatch(r.Object)).ToArray();
+        var plain = rows.Where(r => !digit.IsMatch(r.Object)).ToArray();
+
+        static IReadOnlyList<string> Sample((string Subject, string Predicate, string Object)[] rows) =>
+            rows.Take(6)
+                .Select(r => $"{Trim(r.Subject)} | {Trim(r.Predicate)} | {Trim(r.Object)}")
+                .ToArray();
+
+        return new LongMemEvalFactObjectShape(
+            rows.Length, amounts.Length, numeric.Length, plain.Length,
+            Sample(amounts), Sample(numeric), Sample(plain));
+    }
+
+    private static string Trim(string value) =>
+        value.Length <= 60 ? value : value[..60] + "…";
 
     public async Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(
         CancellationToken cancellationToken)
@@ -488,3 +547,18 @@ internal sealed record LongMemEvalSupersessionStore(
     int Facts,
     int InvalidatedFacts,
     IReadOnlyList<(string Predicate, int Count)> TopPredicates);
+
+/// <summary>What kind of content reaches fact objects.</summary>
+/// <param name="AmountBearing">
+/// Objects carrying a value in the arithmetic corpus's own answer shape. <b>Presence, not
+/// dominance, is the test</b>: one confirmed amount settles "stored at the wrong grain" against
+/// "never captured", which is why no threshold was registered and none may be invented afterwards.
+/// </param>
+internal sealed record LongMemEvalFactObjectShape(
+    int Facts,
+    int AmountBearing,
+    int OtherNumeric,
+    int NonNumeric,
+    IReadOnlyList<string> AmountSamples,
+    IReadOnlyList<string> NumericSamples,
+    IReadOnlyList<string> NonNumericSamples);

--- a/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalGraphProbe.cs
@@ -22,7 +22,14 @@ internal interface ILongMemEvalGraphProbe
     /// predicate outside the six the vocabulary declares single-valued.
     /// </para>
     /// </remarks>
-    Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(CancellationToken cancellationToken);
+    /// <remarks>
+    /// Defaulted to empty because these three are OPTIONAL DIAGNOSTICS, not part of what a probe must
+    /// be able to do. Making them required broke six unrelated test fakes that have no graph to
+    /// report on, which is a signal about the contract rather than about the fakes: a store-shape
+    /// reading is something a probe MAY offer, and empty is the honest answer when it cannot.
+    /// </remarks>
+    Task<LongMemEvalSupersessionStore> ReadSupersessionStoreAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new LongMemEvalSupersessionStore(0, 0, 0, []));
 
     /// <summary>
     /// Classifies what actually sits in fact OBJECTS, to tell "stored at the wrong grain" from
@@ -35,7 +42,21 @@ internal interface ILongMemEvalGraphProbe
     /// problem, and the two need different fixes. Objects are returned verbatim in samples so the
     /// classification is eyeballable rather than trusted.
     /// </remarks>
-    Task<LongMemEvalFactObjectShape> ReadFactObjectShapeAsync(CancellationToken cancellationToken);
+    Task<LongMemEvalFactObjectShape> ReadFactObjectShapeAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new LongMemEvalFactObjectShape(0, 0, 0, 0, [], [], []));
+
+    /// <summary>
+    /// Finds subject-predicate pairs carrying more than one distinct object, and reports how those
+    /// facts resolve to entities.
+    /// </summary>
+    /// <remarks>
+    /// The condition under which a retrieved amount cannot be attributed: if
+    /// <c>payment | has_amount</c> holds three different values, "what did the payment cost" has no
+    /// single answer however well retrieval performs. Whether those facts reach distinct entities,
+    /// one merged entity, or none separates three different defects with three different fixes.
+    /// </remarks>
+    Task<LongMemEvalSubjectAmbiguity> ReadSubjectAmbiguityAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new LongMemEvalSubjectAmbiguity([]));
 
     Task<LongMemEvalGraphSnapshot> ReadAsync(
         string ownerId,
@@ -161,6 +182,41 @@ internal sealed class Neo4jLongMemEvalGraphProbe(IDriver driver) : ILongMemEvalG
         MATCH (f:Fact)
         RETURN f.subject AS subject, f.predicate AS predicate, f.object AS object
         """;
+
+    // Grouped on the KEYS the store merges on, not on the display strings: two facts differing only
+    // by whitespace or case are one fact to the store, and counting them as two would invent
+    // ambiguity that retrieval never sees.
+    private const string SubjectAmbiguityQuery =
+        """
+        MATCH (f:Fact)
+        WITH f.subject_key AS subjectKey, f.predicate_key AS predicateKey,
+             collect(DISTINCT f.object) AS objects, collect(f) AS facts
+        WHERE size(objects) > 1
+        UNWIND facts AS fact
+        OPTIONAL MATCH (fact)-[:ABOUT]->(e:Entity)
+        WITH subjectKey, predicateKey, objects, head(collect(fact.subject)) AS subject,
+             count(DISTINCT e) AS entities
+        RETURN subject, subjectKey, predicateKey, objects, entities
+        ORDER BY size(objects) DESC LIMIT 12
+        """;
+
+    public async Task<LongMemEvalSubjectAmbiguity> ReadSubjectAmbiguityAsync(
+        CancellationToken cancellationToken)
+    {
+        await using var session = driver.AsyncSession();
+        var rows = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(SubjectAmbiguityQuery).ConfigureAwait(false);
+            var records = await cursor.ToListAsync().ConfigureAwait(false);
+            return records.Select(r => new LongMemEvalAmbiguousSubject(
+                r["subject"].As<string>() ?? string.Empty,
+                r["predicateKey"].As<string>() ?? string.Empty,
+                r["objects"].As<List<object>>().Select(o => o?.ToString() ?? string.Empty).ToArray(),
+                r["entities"].As<int>())).ToArray();
+        }).ConfigureAwait(false);
+
+        return new LongMemEvalSubjectAmbiguity(rows);
+    }
 
     public async Task<LongMemEvalFactObjectShape> ReadFactObjectShapeAsync(
         CancellationToken cancellationToken)
@@ -562,3 +618,15 @@ internal sealed record LongMemEvalFactObjectShape(
     IReadOnlyList<string> AmountSamples,
     IReadOnlyList<string> NumericSamples,
     IReadOnlyList<string> NonNumericSamples);
+
+/// <summary>One subject-predicate pair holding more than one distinct object.</summary>
+/// <param name="DistinctEntities">
+/// How many <c>:Entity</c> nodes the facts reach through <c>ABOUT</c>. Several means the entities
+/// were separated and only the subject STRING is under-specified; one means resolution merged
+/// things that differ; zero means the triples are about nobody. Three defects, three fixes.
+/// </param>
+internal sealed record LongMemEvalAmbiguousSubject(
+    string Subject, string PredicateKey, IReadOnlyList<string> Objects, int DistinctEntities);
+
+/// <summary>Whether a retrieved value can be attributed to the thing it belongs to.</summary>
+internal sealed record LongMemEvalSubjectAmbiguity(IReadOnlyList<LongMemEvalAmbiguousSubject> Pairs);

--- a/tools/AgentMemory.LongMemEval/LongMemEvalMemoryProfile.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalMemoryProfile.cs
@@ -44,6 +44,7 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
         bool resolveTemporalQueries = false,
         bool rescueShortOwnerResults = false,
         bool supersedeReplacedFacts = false,
+        bool resolveSupersessions = false,
         string? graphRagIndexName = null,
         int? extractionSeed = null,
         // 30.9c gap: every Phase-30 Wave-C capability ships dark AND had no way in from the harness,
@@ -82,6 +83,7 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
                     resolveTemporalQueries,
                     rescueShortOwnerResults,
                     supersedeReplacedFacts,
+                    resolveSupersessions,
                     phase30 ?? PhaseThirtyFeatures.AllOff,
                     graphRagIndexName,
                     extractionSeed,
@@ -113,6 +115,7 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
         bool resolveTemporalQueries,
         bool rescueShortOwnerResults,
         bool supersedeReplacedFacts,
+        bool resolveSupersessions,
         PhaseThirtyFeatures phase30,
         string? graphRagIndexName,
         int? extractionSeed,
@@ -142,6 +145,7 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
             resolveTemporalQueries,
             rescueShortOwnerResults,
             supersedeReplacedFacts,
+            resolveSupersessions,
             phase30,
             graphRagIndexName,
             multiSessionBatch,
@@ -182,6 +186,7 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
         bool resolveTemporalQueries,
         bool rescueShortOwnerResults,
         bool supersedeReplacedFacts,
+        bool resolveSupersessions,
         PhaseThirtyFeatures phase30,
         string? graphRagIndexName,
         bool multiSessionBatch = true,
@@ -250,6 +255,27 @@ internal sealed class LongMemEvalMemoryProfile : IAsyncDisposable
                     // unless asked for, so every sealed measurement keeps its path.
                     SupersedeReplacedFacts = supersedeReplacedFacts,
                 },
+                // 30.9d. The SECOND reachable-but-never-fed lever inside one intervention, and the
+                // one the ON ablation's own result points at. `SupersessionProjectionFeature` is
+                // fully built and renders "(since D; previously Y)" -- its docstring names the loss
+                // verbatim ("a superseded fact is not 'shown as old' -- it is absent") -- but it is
+                // gated on ResolveSupersessions, which defaults false, and NO harness ever set it.
+                //
+                // That explains the 0.767 null exactly: with writes on and rendering off, the
+                // superseded value is filtered out of recall and the surviving value arrives with no
+                // cue it ever replaced anything, so misses moved from "value absent" to "had it and
+                // chose the wrong side". This is the lever that makes currency legible.
+                //
+                // Assigned CONDITIONALLY, and that is not stylistic. MemoryProjectionOptions.Default
+                // is reference-compared to distinguish "unset" from "set to the defaults"
+                // (MemoryContextAssembler.cs:119), so handing back a `with`-copy even in the off case
+                // would change identity for every sealed measurement. Off must stay byte-identical.
+                //
+                // `Default with` also preserves MaxSupersessionChain = 3, which this arm deliberately
+                // does NOT tune: chain depth is its own ablation with its own pre-registration.
+                Projection = resolveSupersessions
+                    ? MemoryProjectionOptions.Default with { ResolveSupersessions = true }
+                    : MemoryProjectionOptions.Default,
             },
             neo4j =>
             {

--- a/tools/AgentMemory.LongMemEval/LongMemEvalSupersessionRenderProbe.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalSupersessionRenderProbe.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using AgentMemory.Abstractions.Domain;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Positive evidence that supersession chains actually reached the answer prompt during a run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a config echo is not acceptable here.</b> Twice inside one intervention a lever was
+/// believed live because it was reachable: <c>SupersedeReplacedFacts</c> (the Bitemporal vertical ran
+/// against an append-only store) and then <c>ResolveSupersessions</c> (the renderer was dark in every
+/// run ever scored). Re-printing the flag we set would have detected neither, because in both cases
+/// the flag we set was not the flag that mattered. So this probe reads the OUTPUT: what the
+/// projection annotated, and whether that text is present in the prompt string the model was handed.
+/// </para>
+/// <para>
+/// <b>Two counts, deliberately, because they fail differently.</b> <c>NotesAnnotated</c> comes from
+/// <see cref="ProjectedContext.Annotations"/> and is authoritative about the feature having run.
+/// <c>NotesInPrompt</c> checks the annotation text against the assembled prompt and is authoritative
+/// about it having reached the model. Annotated &gt; 0 with InPrompt = 0 is a render-surface defect
+/// that a single count would have reported as success -- the harness builds its own prompt text, so
+/// "projection produced a note" and "the note was rendered" are genuinely separable claims.
+/// </para>
+/// <para>
+/// <b>The check must not be passable by absence.</b> A zero here means the arm was dark and its
+/// scores must not be read; a NULL summary means the probe never ran, which is likewise a failure and
+/// never a pass. <see cref="LongMemEvalSupersessionRenderSummary.RenderConfirmed"/> is the only
+/// affirmative form, and it requires a retained sample string rather than a nonzero counter, so the
+/// claim can be eyeballed rather than trusted.
+/// </para>
+/// </remarks>
+internal sealed class LongMemEvalSupersessionRenderProbe
+{
+    /// <summary>Bounded so a sidecar cannot inherit a whole prompt; long enough to read the chain.</summary>
+    private const int MaxSampleLength = 240;
+
+    private readonly ConcurrentBag<SupersessionRenderSample> _samples = [];
+
+    public IReadOnlyList<SupersessionRenderSample> Samples => _samples.ToArray();
+
+    /// <summary>Records what one question's projection annotated, and how much of it reached the prompt.</summary>
+    public void Observe(string questionId, MemoryContext? context, string prompt)
+    {
+        var notes = context?.Projection?.Annotations.Values
+            .Select(annotation => annotation.SupersessionNote)
+            .Where(note => !string.IsNullOrWhiteSpace(note))
+            .ToArray() ?? [];
+
+        // Recorded even when empty. A question that produced no note is data -- most questions in any
+        // corpus have nothing superseded -- and dropping those rows would leave PromptsInspected
+        // measuring "prompts with notes", which is the denominator the pass rule needs.
+        var inPrompt = notes.Count(note => prompt.Contains(note!, StringComparison.Ordinal));
+
+        _samples.Add(new SupersessionRenderSample(
+            questionId,
+            notes.Length,
+            inPrompt,
+            notes.Length == 0 ? null : Truncate(notes[0]!)));
+    }
+
+    private static string Truncate(string note) =>
+        note.Length <= MaxSampleLength ? note : note[..MaxSampleLength] + "…";
+}
+
+/// <summary>One question's supersession-render observation.</summary>
+internal sealed record SupersessionRenderSample(
+    string QuestionId,
+    int NotesAnnotated,
+    int NotesInPrompt,
+    string? FirstNote);
+
+/// <summary>Run-level supersession-render evidence, written to the provenance sidecar.</summary>
+internal sealed record LongMemEvalSupersessionRenderSummary(
+    int PromptsInspected,
+    int PromptsWithAnnotation,
+    int PromptsWithNoteInPrompt,
+    int NotesAnnotated,
+    int NotesInPrompt,
+    string? Sample)
+{
+    /// <summary>
+    /// The pre-registered render-state gate: the arm rendered supersession chains into real prompts.
+    /// </summary>
+    /// <remarks>
+    /// Requires a retained <see cref="Sample"/>, not merely a positive count, so the gate cannot be
+    /// satisfied by an arithmetic artifact. A caller that cannot obtain this summary at all must treat
+    /// the absence as a failure -- <c>false</c> and "not measured" are the same verdict for a gate,
+    /// and only this property may be read as a pass.
+    /// </remarks>
+    public bool RenderConfirmed => NotesInPrompt > 0 && !string.IsNullOrWhiteSpace(Sample);
+
+    public static LongMemEvalSupersessionRenderSummary From(IReadOnlyList<SupersessionRenderSample> samples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        return new LongMemEvalSupersessionRenderSummary(
+            samples.Count,
+            samples.Count(sample => sample.NotesAnnotated > 0),
+            samples.Count(sample => sample.NotesInPrompt > 0),
+            samples.Sum(sample => sample.NotesAnnotated),
+            samples.Sum(sample => sample.NotesInPrompt),
+            samples.FirstOrDefault(sample => sample.NotesInPrompt > 0)?.FirstNote);
+    }
+}

--- a/tools/AgentMemory.LongMemEval/Program.cs
+++ b/tools/AgentMemory.LongMemEval/Program.cs
@@ -488,7 +488,7 @@ internal static class LongMemEvalProgram
     private static readonly string[] KnownOptions =
     [
         "--reference-arm", "--surface-probe", "--predicate-distribution", "--prepared-pair",
-        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade", "--cell-probe", "--max-entries",
+        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade", "--cell-probe", "--max-entries", "--skip-entries",
         "--oracle-decomposition", "--max-sub-questions", "--question-ids", "--no-content",
         "--oracle-precision", "--distractor-sessions", "--gold-fraction", "--oracle-representation",
         "--capture-headroom", "--artifacts",

--- a/tools/AgentMemory.LongMemEval/Program.cs
+++ b/tools/AgentMemory.LongMemEval/Program.cs
@@ -145,6 +145,15 @@ internal static class LongMemEvalProgram
                 .ConfigureAwait(false);
         }
 
+        if (args.Contains("--regrade", StringComparer.Ordinal))
+        {
+            // Judge-only re-grade of a stored artifact. Checked BEFORE --typedmemeval because a
+            // re-grade names its vertical through the source sidecar, never on the command line:
+            // re-specifying sampling by hand is how a re-grade quietly compares two different
+            // question sets and reports the difference as a judge effect.
+            return await TypedMemEvalRegradeProgram.RunAsync(args).ConfigureAwait(false);
+        }
+
         if (args.Contains("--typedmemeval", StringComparer.Ordinal))
         {
             // 30.9c. TypedMemEval verticals (embedded AgentEval corpora): typed-outcome runs,
@@ -472,7 +481,7 @@ internal static class LongMemEvalProgram
     private static readonly string[] KnownOptions =
     [
         "--reference-arm", "--surface-probe", "--predicate-distribution", "--prepared-pair",
-        "--procedural-benefit", "--typedmemeval", "--attempts",
+        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade",
         "--oracle-decomposition", "--max-sub-questions", "--question-ids", "--no-content",
         "--oracle-precision", "--distractor-sessions", "--gold-fraction", "--oracle-representation",
         "--capture-headroom", "--artifacts",

--- a/tools/AgentMemory.LongMemEval/Program.cs
+++ b/tools/AgentMemory.LongMemEval/Program.cs
@@ -488,7 +488,7 @@ internal static class LongMemEvalProgram
     private static readonly string[] KnownOptions =
     [
         "--reference-arm", "--surface-probe", "--predicate-distribution", "--prepared-pair",
-        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade", "--cell-probe", "--max-entries", "--skip-entries",
+        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade", "--cell-probe", "--max-entries", "--skip-entries", "--dry-run", "--pair-with",
         "--oracle-decomposition", "--max-sub-questions", "--question-ids", "--no-content",
         "--oracle-precision", "--distractor-sessions", "--gold-fraction", "--oracle-representation",
         "--capture-headroom", "--artifacts",

--- a/tools/AgentMemory.LongMemEval/Program.cs
+++ b/tools/AgentMemory.LongMemEval/Program.cs
@@ -145,6 +145,13 @@ internal static class LongMemEvalProgram
                 .ConfigureAwait(false);
         }
 
+        if (args.Contains("--cell-probe", StringComparer.Ordinal))
+        {
+            // Extraction-only probe of an EXTERNAL corpus file. Checked before the verbs that read
+            // embedded corpora: a diagnostic cell is deliberately not a shipped vertical.
+            return await CellProbeProgram.RunAsync(args).ConfigureAwait(false);
+        }
+
         if (args.Contains("--regrade", StringComparer.Ordinal))
         {
             // Judge-only re-grade of a stored artifact. Checked BEFORE --typedmemeval because a
@@ -481,7 +488,7 @@ internal static class LongMemEvalProgram
     private static readonly string[] KnownOptions =
     [
         "--reference-arm", "--surface-probe", "--predicate-distribution", "--prepared-pair",
-        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade",
+        "--procedural-benefit", "--typedmemeval", "--attempts", "--regrade", "--cell-probe", "--max-entries",
         "--oracle-decomposition", "--max-sub-questions", "--question-ids", "--no-content",
         "--oracle-precision", "--distractor-sessions", "--gold-fraction", "--oracle-representation",
         "--capture-headroom", "--artifacts",

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalArm.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalArm.cs
@@ -36,11 +36,25 @@ namespace AgentMemory.LongMemEval;
 /// once again indistinguishable from each other.
 /// </param>
 /// <param name="FactWeightedBudget">Whether the recall budget was reallocated toward facts.</param>
+/// <param name="ResolveSupersessions">
+/// Whether the supersession CHAIN was rendered into the prompt. Deliberately appended LAST rather
+/// than grouped beside <paramref name="SupersedeReplacedFacts"/>, which is where it belongs by
+/// meaning: inserting a positional parameter mid-record silently re-slots every positional call
+/// site, and that exact mistake turned a `factwt` arm into a `supersede` arm once already. Meaning
+/// loses to safety here, and the pairing is documented instead.
+/// <para>
+/// The two levers are only informative TOGETHER. <see cref="SupersedeReplacedFacts"/> writes the
+/// <c>:SUPERSEDED_BY</c> edges; this renders them. Rendering alone has nothing to read, and writing
+/// alone filters the superseded value out of recall while giving the model no cue that the surviving
+/// value ever replaced anything -- which is the off-state the 0.767 ON ablation actually measured.
+/// </para>
+/// </param>
 public sealed record TypedMemEvalArm(
     PhaseThirtyFeatures Phase30,
     bool RescueShortOwnerResults = false,
     bool SupersedeReplacedFacts = false,
-    bool FactWeightedBudget = false)
+    bool FactWeightedBudget = false,
+    bool ResolveSupersessions = false)
 {
     /// <summary>The shipped default: every lever off, which is how the sealed measurements were taken.</summary>
     public static TypedMemEvalArm Default { get; } = new(PhaseThirtyFeatures.AllOff);
@@ -48,7 +62,7 @@ public sealed record TypedMemEvalArm(
     /// <summary>True when nothing is enabled, so a run can assert it took the default path.</summary>
     public bool IsDefault =>
         Phase30.IsDefault && !RescueShortOwnerResults && !FactWeightedBudget
-        && !SupersedeReplacedFacts;
+        && !SupersedeReplacedFacts && !ResolveSupersessions;
 
     /// <summary>
     /// A filename-safe token naming every enabled lever, or <c>"default"</c> when none is.
@@ -67,6 +81,7 @@ public sealed record TypedMemEvalArm(
         if (Phase30.ArithmeticMemory) parts.Add("arith");
         if (RescueShortOwnerResults) parts.Add("rescue");
         if (SupersedeReplacedFacts) parts.Add("supersede");
+        if (ResolveSupersessions) parts.Add("render");
         if (FactWeightedBudget) parts.Add("factwt");
         return string.Join("-", parts);
     }
@@ -76,5 +91,6 @@ public sealed record TypedMemEvalArm(
         CultureInfo.InvariantCulture,
         $"{Phase30.Describe()} rescue-short-owner-results={RescueShortOwnerResults} " +
         $"supersede-replaced-facts={SupersedeReplacedFacts} " +
+        $"resolve-supersessions={ResolveSupersessions} " +
         $"fact-weighted-budget={FactWeightedBudget}");
 }

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -227,6 +227,7 @@ internal static class TypedMemEvalProgram
             // prevent occurring inside the gate itself.
             LongMemEvalSupersessionStore? supersessionStore = null;
             LongMemEvalFactObjectShape? objectShape = null;
+            LongMemEvalSubjectAmbiguity? subjectAmbiguity = null;
             if (profile is not null && !options.Oracle)
             {
                 try
@@ -237,6 +238,8 @@ internal static class TypedMemEvalProgram
                         .ReadSupersessionStoreAsync(CancellationToken.None).ConfigureAwait(false);
                     objectShape = await storeProbe
                         .ReadFactObjectShapeAsync(CancellationToken.None).ConfigureAwait(false);
+                    subjectAmbiguity = await storeProbe
+                        .ReadSubjectAmbiguityAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -255,6 +258,7 @@ internal static class TypedMemEvalProgram
                 renderSummary, supersessionStore);
             PrintSupersessionStore(supersessionStore);
             PrintObjectShape(objectShape);
+            PrintSubjectAmbiguity(subjectAmbiguity);
             PrintRenderState(options, renderSummary);
             PrintRun(result, destination);
             results.Add(result);
@@ -519,6 +523,31 @@ internal static class TypedMemEvalProgram
             Console.WriteLine($"typedmemeval:   [numeric] {sample}");
         foreach (var sample in shape.NonNumericSamples)
             Console.WriteLine($"typedmemeval:   [plain]   {sample}");
+    }
+
+    /// <summary>Reports subject-predicate pairs whose value cannot be attributed.</summary>
+    private static void PrintSubjectAmbiguity(LongMemEvalSubjectAmbiguity? ambiguity)
+    {
+        if (ambiguity is null) return;
+
+        if (ambiguity.Pairs.Count == 0)
+        {
+            // Registered in advance as informative: zero means the sample-line concern was an
+            // artifact of reading three rows, and the retraction is the finding.
+            Console.WriteLine(
+                "typedmemeval: subject ambiguity — NONE. No subject/predicate pair carries more " +
+                "than one distinct object; the C1b genericity flag does not reproduce.");
+            return;
+        }
+
+        Console.WriteLine($"typedmemeval: subject ambiguity — {ambiguity.Pairs.Count} pair(s):");
+        foreach (var pair in ambiguity.Pairs)
+        {
+            Console.WriteLine(
+                $"typedmemeval:   \"{pair.Subject}\" | {pair.PredicateKey} | " +
+                $"{pair.Objects.Count} distinct objects | {pair.DistinctEntities} entity(ies) " +
+                $"→ {string.Join(" / ", pair.Objects.Take(4))}");
+        }
     }
 
     private static void PrintRenderState(

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -58,6 +58,8 @@ internal static class TypedMemEvalProgram
         "--evidence-detail",
         // 30.9c ON arm for Bitemporal — see PREREG-BITEMPORAL-ON-2026-08-23.md.
         "--supersede-replaced-facts",
+        // 30.9d. Renders the chains --supersede-replaced-facts writes. Only informative together.
+        "--resolve-supersessions",
     ];
 
     public static async Task<int> RunAsync(string[] args)
@@ -115,7 +117,8 @@ internal static class TypedMemEvalProgram
                             CancellationToken.None,
                             phase30: options.Phase30,
                             rescueShortOwnerResults: options.RescueShortOwnerResults,
-                            supersedeReplacedFacts: options.SupersedeReplacedFacts)
+                            supersedeReplacedFacts: options.SupersedeReplacedFacts,
+                            resolveSupersessions: options.ResolveSupersessions)
                         .ConfigureAwait(false);
                 }
 
@@ -172,6 +175,12 @@ internal static class TypedMemEvalProgram
                 $"seed {options.RandomSeed?.ToString(CultureInfo.InvariantCulture) ?? "unseeded"}, " +
                 $"max questions {options.MaxQuestions?.ToString(CultureInfo.InvariantCulture) ?? "all"}.");
 
+            // Per-run, unlike the vector-yield listener above: this summary is written into ONE
+            // artifact's sidecar and must describe that run alone. Null on the oracle arm, which
+            // assembles no memory context to project -- "not measured", not "measured zero".
+            LongMemEvalSupersessionRenderProbe? renderProbe = null;
+            if (!options.Oracle) renderProbe = new LongMemEvalSupersessionRenderProbe();
+
             ExternalBenchmarkResult result;
             if (options.Oracle)
             {
@@ -201,6 +210,7 @@ internal static class TypedMemEvalProgram
                         ModelId = deployment,
                         EvidenceIndex = LongMemEvalEvidenceIndex.CreateTypedMemEval(vertical, facade),
                         EvidenceDetail = options.EvidenceDetail,
+                        SupersessionRenderProbe = renderProbe,
                         RequireGraphReadBack = true,
                         GraphProbe = new Neo4jLongMemEvalGraphProbe(
                             profile.Services.GetRequiredService<global::Neo4j.Driver.IDriver>()),
@@ -210,9 +220,14 @@ internal static class TypedMemEvalProgram
                 result = await runner.RunAsync(adapter, vertical, facade).ConfigureAwait(false);
             }
 
+            var renderSummary = renderProbe is null
+                ? null
+                : LongMemEvalSupersessionRenderSummary.From(renderProbe.Samples);
             var destination = Persist(
                 result, descriptor, options, runIndex, startedUtc,
-                vectorYield is null ? null : LongMemEvalVectorYieldSummary.From(vectorYield.Samples));
+                vectorYield is null ? null : LongMemEvalVectorYieldSummary.From(vectorYield.Samples),
+                renderSummary);
+            PrintRenderState(options, renderSummary);
             PrintRun(result, destination);
             results.Add(result);
         }
@@ -245,7 +260,8 @@ internal static class TypedMemEvalProgram
         TypedMemEvalRunOptions options,
         int runIndex,
         DateTimeOffset startedUtc,
-        LongMemEvalVectorYieldSummary? vectorYield)
+        LongMemEvalVectorYieldSummary? vectorYield,
+        LongMemEvalSupersessionRenderSummary? renderSummary)
     {
         // The arm is stamped into the FILENAME, not into the report body. The serialized type is
         // AgentEval's ExternalBenchmarkResult and its Options is their fixed record with no extension
@@ -268,7 +284,8 @@ internal static class TypedMemEvalProgram
             JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }) +
             Environment.NewLine);
 
-        WriteProvenance(destination, arm, descriptor, options, runIndex, startedUtc, vectorYield);
+        WriteProvenance(
+            destination, arm, descriptor, options, runIndex, startedUtc, vectorYield, renderSummary);
         return destination;
     }
 
@@ -295,7 +312,8 @@ internal static class TypedMemEvalProgram
         TypedMemEvalRunOptions options,
         int runIndex,
         DateTimeOffset startedUtc,
-        LongMemEvalVectorYieldSummary? vectorYield)
+        LongMemEvalVectorYieldSummary? vectorYield,
+        LongMemEvalSupersessionRenderSummary? renderSummary)
     {
         // Built before the object rather than inline: an anonymous type inside a conditional has no
         // natural type to infer, so `condition ? null : new { ... }` does not compile. Hoisting it
@@ -316,6 +334,21 @@ internal static class TypedMemEvalProgram
             };
         }
 
+        object? renderBlock = null;
+        if (renderSummary is not null)
+        {
+            renderBlock = new
+            {
+                promptsInspected = renderSummary.PromptsInspected,
+                promptsWithAnnotation = renderSummary.PromptsWithAnnotation,
+                promptsWithNoteInPrompt = renderSummary.PromptsWithNoteInPrompt,
+                notesAnnotated = renderSummary.NotesAnnotated,
+                notesInPrompt = renderSummary.NotesInPrompt,
+                sample = renderSummary.Sample,
+                renderConfirmed = renderSummary.RenderConfirmed,
+            };
+        }
+
         var provenance = new
         {
             schema = "typedmemeval-provenance/1",
@@ -332,6 +365,7 @@ internal static class TypedMemEvalProgram
                 arithmeticMemory = arm.Phase30.ArithmeticMemory,
                 rescueShortOwnerResults = arm.RescueShortOwnerResults,
                 supersedeReplacedFacts = arm.SupersedeReplacedFacts,
+                resolveSupersessions = arm.ResolveSupersessions,
                 factWeightedBudget = arm.FactWeightedBudget,
                 schemaExtensions = arm.Phase30.Extensions,
             },
@@ -354,6 +388,12 @@ internal static class TypedMemEvalProgram
             // NULL means NOT MEASURED, and that distinction is the point: a zeroed block would read
             // as "no starvation observed", which is a claim this listener never made.
             vectorYield = yieldBlock,
+            // 30.9d render-state gate. `renderConfirmed` is the ONLY affirmative form, and it needs a
+            // retained sample rather than a nonzero counter so the claim can be eyeballed. A null
+            // block means the probe never ran, which the prereg reads as a FAILURE, not a pass:
+            // scores from an unconfirmed arm may not be read, because a dark renderer is exactly the
+            // defect this arm exists to rule out.
+            supersessionRender = renderBlock,
         };
 
         File.WriteAllText(
@@ -388,6 +428,48 @@ internal static class TypedMemEvalProgram
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Announces the render-state gate at the console, loudly when it fails.
+    /// </summary>
+    /// <remarks>
+    /// Printed only for the arm that asked for rendering. Elsewhere a zero is the correct and
+    /// expected state, and a warning there would train the reader to ignore this line -- which is how
+    /// a gate stops being read at all.
+    /// </remarks>
+    private static void PrintRenderState(
+        TypedMemEvalRunOptions options, LongMemEvalSupersessionRenderSummary? renderSummary)
+    {
+        if (!options.ResolveSupersessions) return;
+
+        if (renderSummary is null)
+        {
+            Console.WriteLine(
+                "typedmemeval: WARNING render-state NOT MEASURED (--resolve-supersessions was set). " +
+                "Treat this run's scores as unreadable.");
+            return;
+        }
+
+        Console.WriteLine(
+            $"typedmemeval: supersession render — prompts {renderSummary.PromptsWithNoteInPrompt}" +
+            $"/{renderSummary.PromptsInspected} carried a chain, notes {renderSummary.NotesInPrompt}" +
+            $"/{renderSummary.NotesAnnotated} reached the prompt.");
+
+        if (renderSummary.RenderConfirmed)
+        {
+            Console.WriteLine($"typedmemeval: render CONFIRMED — sample {renderSummary.Sample}");
+            return;
+        }
+
+        // The two failures say different things and must not be collapsed: nothing annotated means
+        // the feature or its edges are dark, while annotated-but-absent means the harness's own
+        // prompt builder dropped the note. Only the second is a render-surface bug.
+        Console.WriteLine(renderSummary.NotesAnnotated == 0
+            ? "typedmemeval: WARNING render NOT confirmed — projection annotated NOTHING. Either the " +
+              "renderer is off or no :SUPERSEDED_BY edges exist. Do not read this run's scores."
+            : "typedmemeval: WARNING render NOT confirmed — projection annotated " +
+              $"{renderSummary.NotesAnnotated} note(s) and NONE reached the prompt. Render-surface bug.");
     }
 
     private static void PrintRun(ExternalBenchmarkResult result, string destination)
@@ -476,7 +558,8 @@ internal static class TypedMemEvalProgram
             Array.IndexOf(args, "--rescue-short-owner-results") >= 0,
             Array.IndexOf(args, "--supersede-replaced-facts") >= 0,
             ParseEvidenceDetail(Value("--evidence-detail")),
-            Array.IndexOf(args, "--fact-weighted-budget") >= 0);
+            Array.IndexOf(args, "--fact-weighted-budget") >= 0,
+            Array.IndexOf(args, "--resolve-supersessions") >= 0);
 
         // Validated at parse time, before any container, client, or provider call exists: a run
         // set that cannot be banded, or a control arm with no pair to control, must stop here.
@@ -603,7 +686,12 @@ internal static class TypedMemEvalProgram
         // Arm A finding (2026-08-21): the structured budget splits three ways, so an arithmetic
         // question spends two thirds of its context on entities and preferences -- kinds that cannot
         // carry a value. This reallocates the SAME total toward facts.
-        bool FactWeightedBudget)
+        bool FactWeightedBudget,
+        // 30.9d. The renderer (`SupersessionProjectionFeature`) was built, gated on
+        // MemoryProjectionOptions.ResolveSupersessions = false, and never set by any harness -- so
+        // every scored run rendered supersession chains DARK. Appended last for the positional-safety
+        // reason documented on TypedMemEvalArm.ResolveSupersessions.
+        bool ResolveSupersessions)
     {
         /// <summary>
         /// Every lever this run had on, composed into one identity for the filename and the sidecar.
@@ -613,6 +701,7 @@ internal static class TypedMemEvalProgram
         /// that disagreed with the options that produced it would be worse than no token at all.
         /// </remarks>
         internal TypedMemEvalArm Arm =>
-            new(Phase30, RescueShortOwnerResults, SupersedeReplacedFacts, FactWeightedBudget);
+            new(Phase30, RescueShortOwnerResults, SupersedeReplacedFacts, FactWeightedBudget,
+                ResolveSupersessions);
     }
 }

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -483,14 +483,6 @@ internal static class TypedMemEvalProgram
         }
     }
 
-    /// <summary>
-    /// Announces the render-state gate at the console, loudly when it fails.
-    /// </summary>
-    /// <remarks>
-    /// Printed only for the arm that asked for rendering. Elsewhere a zero is the correct and
-    /// expected state, and a warning there would train the reader to ignore this line -- which is how
-    /// a gate stops being read at all.
-    /// </remarks>
     /// <summary>Announces what supersession actually wrote, loudly when it wrote nothing.</summary>
     private static void PrintSupersessionStore(LongMemEvalSupersessionStore? store)
     {
@@ -550,6 +542,14 @@ internal static class TypedMemEvalProgram
         }
     }
 
+    /// <summary>
+    /// Announces the render-state gate at the console, loudly when it fails.
+    /// </summary>
+    /// <remarks>
+    /// Printed only for the arm that asked for rendering. Elsewhere a zero is the correct and
+    /// expected state, and a warning there would train the reader to ignore this line -- which is how
+    /// a gate stops being read at all.
+    /// </remarks>
     private static void PrintRenderState(
         TypedMemEvalRunOptions options, LongMemEvalSupersessionRenderSummary? renderSummary)
     {

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -220,13 +220,37 @@ internal static class TypedMemEvalProgram
                 result = await runner.RunAsync(adapter, vertical, facade).ConfigureAwait(false);
             }
 
+            // Read BEFORE Persist and before teardown: the container is reaped when the run ends, so
+            // a store fact not captured here can never be recovered. This is the store-state gate as
+            // a COUNT rather than the facts-per-question inference it replaces -- that inference
+            // certified an off-state arm as verified-ON, which is the failure the gate existed to
+            // prevent occurring inside the gate itself.
+            LongMemEvalSupersessionStore? supersessionStore = null;
+            if (profile is not null && !options.Oracle)
+            {
+                try
+                {
+                    supersessionStore = await new Neo4jLongMemEvalGraphProbe(
+                            profile.Services.GetRequiredService<global::Neo4j.Driver.IDriver>())
+                        .ReadSupersessionStoreAsync(CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Diagnostic only: it must never cost a completed run. Null reads as NOT
+                    // MEASURED, which is the honest value and is distinct from a measured zero.
+                    Console.WriteLine($"typedmemeval: supersession store probe failed — {ex.Message}");
+                }
+            }
+
             var renderSummary = renderProbe is null
                 ? null
                 : LongMemEvalSupersessionRenderSummary.From(renderProbe.Samples);
             var destination = Persist(
                 result, descriptor, options, runIndex, startedUtc,
                 vectorYield is null ? null : LongMemEvalVectorYieldSummary.From(vectorYield.Samples),
-                renderSummary);
+                renderSummary, supersessionStore);
+            PrintSupersessionStore(supersessionStore);
             PrintRenderState(options, renderSummary);
             PrintRun(result, destination);
             results.Add(result);
@@ -261,7 +285,8 @@ internal static class TypedMemEvalProgram
         int runIndex,
         DateTimeOffset startedUtc,
         LongMemEvalVectorYieldSummary? vectorYield,
-        LongMemEvalSupersessionRenderSummary? renderSummary)
+        LongMemEvalSupersessionRenderSummary? renderSummary,
+        LongMemEvalSupersessionStore? supersessionStore)
     {
         // The arm is stamped into the FILENAME, not into the report body. The serialized type is
         // AgentEval's ExternalBenchmarkResult and its Options is their fixed record with no extension
@@ -285,7 +310,8 @@ internal static class TypedMemEvalProgram
             Environment.NewLine);
 
         WriteProvenance(
-            destination, arm, descriptor, options, runIndex, startedUtc, vectorYield, renderSummary);
+            destination, arm, descriptor, options, runIndex, startedUtc, vectorYield, renderSummary,
+            supersessionStore);
         return destination;
     }
 
@@ -313,7 +339,8 @@ internal static class TypedMemEvalProgram
         int runIndex,
         DateTimeOffset startedUtc,
         LongMemEvalVectorYieldSummary? vectorYield,
-        LongMemEvalSupersessionRenderSummary? renderSummary)
+        LongMemEvalSupersessionRenderSummary? renderSummary,
+        LongMemEvalSupersessionStore? supersessionStore)
     {
         // Built before the object rather than inline: an anonymous type inside a conditional has no
         // natural type to infer, so `condition ? null : new { ... }` does not compile. Hoisting it
@@ -346,6 +373,19 @@ internal static class TypedMemEvalProgram
                 notesInPrompt = renderSummary.NotesInPrompt,
                 sample = renderSummary.Sample,
                 renderConfirmed = renderSummary.RenderConfirmed,
+            };
+        }
+
+        object? storeBlock = null;
+        if (supersessionStore is not null)
+        {
+            storeBlock = new
+            {
+                supersededByEdges = supersessionStore.SupersededByEdges,
+                facts = supersessionStore.Facts,
+                invalidatedFacts = supersessionStore.InvalidatedFacts,
+                topPredicates = supersessionStore.TopPredicates
+                    .Select(p => new { predicate = p.Predicate, count = p.Count }).ToArray(),
             };
         }
 
@@ -394,6 +434,11 @@ internal static class TypedMemEvalProgram
             // scores from an unconfirmed arm may not be read, because a dark renderer is exactly the
             // defect this arm exists to rule out.
             supersessionRender = renderBlock,
+            // The store-state gate, as a count. `supersededByEdges: 0` means write-time supersession
+            // never ran and the arm measured an off-state whatever its flags say; `topPredicates`
+            // explains why, since supersession is refused for any predicate outside the six the
+            // relation vocabulary declares single-valued.
+            supersessionStore = storeBlock,
         };
 
         File.WriteAllText(
@@ -438,6 +483,24 @@ internal static class TypedMemEvalProgram
     /// expected state, and a warning there would train the reader to ignore this line -- which is how
     /// a gate stops being read at all.
     /// </remarks>
+    /// <summary>Announces what supersession actually wrote, loudly when it wrote nothing.</summary>
+    private static void PrintSupersessionStore(LongMemEvalSupersessionStore? store)
+    {
+        if (store is null) return;
+
+        Console.WriteLine(
+            $"typedmemeval: supersession store — {store.SupersededByEdges} :SUPERSEDED_BY edge(s), " +
+            $"{store.InvalidatedFacts}/{store.Facts} facts invalidated.");
+
+        if (store.SupersededByEdges > 0) return;
+
+        Console.WriteLine(
+            "typedmemeval: WARNING supersession wrote NOTHING — this arm measured an OFF-STATE " +
+            "regardless of its flags. Write-time supersession is refused for any predicate outside " +
+            "the six the relation vocabulary declares single-valued. Top predicates extracted: " +
+            string.Join(", ", store.TopPredicates.Take(8).Select(p => $"{p.Predicate}×{p.Count}")));
+    }
+
     private static void PrintRenderState(
         TypedMemEvalRunOptions options, LongMemEvalSupersessionRenderSummary? renderSummary)
     {

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -226,14 +226,17 @@ internal static class TypedMemEvalProgram
             // certified an off-state arm as verified-ON, which is the failure the gate existed to
             // prevent occurring inside the gate itself.
             LongMemEvalSupersessionStore? supersessionStore = null;
+            LongMemEvalFactObjectShape? objectShape = null;
             if (profile is not null && !options.Oracle)
             {
                 try
                 {
-                    supersessionStore = await new Neo4jLongMemEvalGraphProbe(
-                            profile.Services.GetRequiredService<global::Neo4j.Driver.IDriver>())
-                        .ReadSupersessionStoreAsync(CancellationToken.None)
-                        .ConfigureAwait(false);
+                    var storeProbe = new Neo4jLongMemEvalGraphProbe(
+                        profile.Services.GetRequiredService<global::Neo4j.Driver.IDriver>());
+                    supersessionStore = await storeProbe
+                        .ReadSupersessionStoreAsync(CancellationToken.None).ConfigureAwait(false);
+                    objectShape = await storeProbe
+                        .ReadFactObjectShapeAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -251,6 +254,7 @@ internal static class TypedMemEvalProgram
                 vectorYield is null ? null : LongMemEvalVectorYieldSummary.From(vectorYield.Samples),
                 renderSummary, supersessionStore);
             PrintSupersessionStore(supersessionStore);
+            PrintObjectShape(objectShape);
             PrintRenderState(options, renderSummary);
             PrintRun(result, destination);
             results.Add(result);
@@ -499,6 +503,22 @@ internal static class TypedMemEvalProgram
             "regardless of its flags. Write-time supersession is refused for any predicate outside " +
             "the six the relation vocabulary declares single-valued. Top predicates extracted: " +
             string.Join(", ", store.TopPredicates.Take(8).Select(p => $"{p.Predicate}×{p.Count}")));
+    }
+
+    /// <summary>Reports what reaches fact objects: wrong grain, or lost content.</summary>
+    private static void PrintObjectShape(LongMemEvalFactObjectShape? shape)
+    {
+        if (shape is null) return;
+
+        Console.WriteLine(
+            $"typedmemeval: fact objects — {shape.AmountBearing} amount-bearing, " +
+            $"{shape.OtherNumeric} other-numeric, {shape.NonNumeric} non-numeric of {shape.Facts}.");
+        foreach (var sample in shape.AmountSamples)
+            Console.WriteLine($"typedmemeval:   [amount]  {sample}");
+        foreach (var sample in shape.NumericSamples)
+            Console.WriteLine($"typedmemeval:   [numeric] {sample}");
+        foreach (var sample in shape.NonNumericSamples)
+            Console.WriteLine($"typedmemeval:   [plain]   {sample}");
     }
 
     private static void PrintRenderState(

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using AgentEval.Memory.External.Models;
 using AgentEval.Memory.External.TypedMemEval;
 using Azure;
@@ -146,11 +147,19 @@ internal static class TypedMemEvalRegradeProgram
                 return 3;
             }
 
+            // Persisted FIRST, and the ordering is the fix for a real loss: Agreement() used to run
+            // before this and threw on a null verdict, destroying an artifact that had already cost a
+            // full judge pass. A cheap derived metric must never stand between an expensive result and
+            // the disk. Agreement is written into the sidecar afterwards, by amendment.
+            var destination = Persist(result, reportPath, sidecarPath, armToken, agreement: null);
             var agreement = Agreement(report.RootElement, result);
-            var destination = Persist(result, reportPath, sidecarPath, armToken, agreement);
+            AmendSidecarWithAgreement(destination, agreement);
 
             Console.WriteLine(
                 $"regrade: matched {adapter.Matched} answers; " +
+                (agreement.Unscored > 0
+                    ? $"{agreement.Unscored} question(s) returned NO VERDICT (validity issue, not a score); "
+                    : string.Empty) +
                 $"judge agreement with the stored verdicts {agreement.Agreed}/{agreement.Compared} " +
                 $"({(agreement.Compared == 0 ? 0 : (double)agreement.Agreed / agreement.Compared):P1})");
             Console.WriteLine($"regrade: report {destination}");
@@ -173,7 +182,8 @@ internal static class TypedMemEvalRegradeProgram
     /// Compared by <c>QuestionId</c>, not by position: the runner selects questions itself, and a
     /// positional comparison would silently pair different questions if selection ever changed.
     /// </remarks>
-    private static (int Compared, int Agreed) Agreement(JsonElement stored, object regraded)
+    private static (int Compared, int Agreed, int Unscored) Agreement(
+        JsonElement stored, object regraded)
     {
         var storedById = new Dictionary<string, bool>(StringComparer.Ordinal);
         foreach (var row in stored.GetProperty("QuestionResults").EnumerateArray())
@@ -187,15 +197,28 @@ internal static class TypedMemEvalRegradeProgram
         using var fresh = JsonDocument.Parse(JsonSerializer.Serialize(regraded));
         var compared = 0;
         var agreed = 0;
+        var unscored = 0;
         foreach (var row in fresh.RootElement.GetProperty("QuestionResults").EnumerateArray())
         {
             var id = row.GetProperty("QuestionId").GetString();
             if (id is null || !storedById.TryGetValue(id, out var before)) continue;
+
+            // `Correct` is NULL when the judge returned no verdict at all. That is neither agreement
+            // nor disagreement, and folding it into either would move the agreement rate for a reason
+            // that has nothing to do with the judge's opinion. Counted on its own instead, because a
+            // re-grade carrying unscored questions is a validity question before it is a score.
+            var verdict = row.GetProperty("Correct");
+            if (verdict.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            {
+                unscored++;
+                continue;
+            }
+
             compared++;
-            if (before == row.GetProperty("Correct").GetBoolean()) agreed++;
+            if (before == verdict.GetBoolean()) agreed++;
         }
 
-        return (compared, agreed);
+        return (compared, agreed, unscored);
     }
 
     private static string Persist(
@@ -203,7 +226,7 @@ internal static class TypedMemEvalRegradeProgram
         string sourceReportPath,
         string sourceSidecarPath,
         string? armToken,
-        (int Compared, int Agreed) agreement)
+        (int Compared, int Agreed, int Unscored)? agreement)
     {
         var stamp = DateTimeOffset.UtcNow;
         var name =
@@ -231,8 +254,11 @@ internal static class TypedMemEvalRegradeProgram
             judge = new
             {
                 agentEvalVersion = AgentEvalVersion(),
-                agreementWithStored = agreement.Agreed,
-                agreementCompared = agreement.Compared,
+                // Null until amended in: the artifact is written before agreement is computed, so a
+                // crash in the diagnostic cannot cost the judge pass that produced the artifact.
+                agreementWithStored = agreement?.Agreed,
+                agreementCompared = agreement?.Compared,
+                unscoredQuestions = agreement?.Unscored,
             },
             // Stated in the artifact so no later reader has to infer it: answers were REPLAYED. No
             // extraction, retrieval or answering ran, so retrieval-side diagnostics in the body
@@ -244,6 +270,25 @@ internal static class TypedMemEvalRegradeProgram
             JsonSerializer.Serialize(provenance, new JsonSerializerOptions { WriteIndented = true }) +
             Environment.NewLine);
         return destination;
+    }
+
+    /// <summary>Writes the agreement figures into the sidecar after the artifact is safely on disk.</summary>
+    /// <remarks>
+    /// A second small write rather than a delayed first one. The expensive thing is the judge pass;
+    /// once it exists it must reach disk before anything that can throw runs against it.
+    /// </remarks>
+    private static void AmendSidecarWithAgreement(
+        string reportPath, (int Compared, int Agreed, int Unscored) agreement)
+    {
+        var sidecarPath = Path.ChangeExtension(reportPath, null) + ".provenance.json";
+        var node = JsonNode.Parse(File.ReadAllText(sidecarPath))!;
+        var judge = node["judge"]!;
+        judge["agreementWithStored"] = agreement.Agreed;
+        judge["agreementCompared"] = agreement.Compared;
+        judge["unscoredQuestions"] = agreement.Unscored;
+        File.WriteAllText(
+            sidecarPath,
+            node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
     }
 
     private static string AgentEvalVersion() =>

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -50,6 +50,8 @@ internal static class TypedMemEvalRegradeProgram
     {
         try
         {
+            LongMemEvalArgumentValidator.Validate(args, KnownOptions);
+
             var reportPath = Value(args, "--regrade")
                 ?? throw new ArgumentException("--regrade requires a path to a stored report .json.");
             reportPath = Path.GetFullPath(reportPath);

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -69,15 +69,19 @@ internal static class TypedMemEvalRegradeProgram
             using var report = JsonDocument.Parse(File.ReadAllText(reportPath));
             using var sidecar = JsonDocument.Parse(File.ReadAllText(sidecarPath));
 
+            // Kept in artifact ORDER. Twelve of the sixty bitemporal questions share their text with
+            // another question that has a DIFFERENT gold answer (tme-bit-007 / tme-bit-037 both ask
+            // about Colm Whitaker in February and answer Lowick and Marchmont), because each question
+            // is asked against its own injected history. Keying by text would hand 12 of 60 questions
+            // an answer written for a different question -- and grade it.
             var rows = report.RootElement.GetProperty("QuestionResults");
-            var answers = new Dictionary<string, string>(StringComparer.Ordinal);
-            var duplicates = 0;
+            var storedRows = new List<(string Question, string Answer)>();
             string? modelId = null;
             foreach (var row in rows.EnumerateArray())
             {
-                var question = row.GetProperty("Question").GetString() ?? string.Empty;
-                var answer = row.GetProperty("AgentResponse").GetString() ?? string.Empty;
-                if (!answers.TryAdd(question, answer)) duplicates++;
+                storedRows.Add((
+                    row.GetProperty("Question").GetString() ?? string.Empty,
+                    row.GetProperty("AgentResponse").GetString() ?? string.Empty));
             }
 
             var sampling = sidecar.RootElement.GetProperty("sampling");
@@ -93,18 +97,7 @@ internal static class TypedMemEvalRegradeProgram
 
             Console.WriteLine(
                 $"regrade: source {Path.GetFileName(reportPath)} — vertical {verticalSlug}, " +
-                $"arm {armToken}, {answers.Count} distinct answers" +
-                (duplicates > 0 ? $" ({duplicates} duplicate question texts collapsed)" : string.Empty));
-
-            if (duplicates > 0)
-            {
-                // Text is the only key InvokeAsync receives, so identical questions are
-                // indistinguishable to the replay. Rather than grade one answer twice and call the
-                // difference a judge effect, stop.
-                Console.Error.WriteLine(
-                    "regrade: ABORT — duplicate question texts cannot be replayed unambiguously.");
-                return 2;
-            }
+                $"arm {armToken}, {storedRows.Count} stored answers replayed in artifact order");
 
             var facade = new TypedMemEvalOptions
             {
@@ -124,9 +117,22 @@ internal static class TypedMemEvalRegradeProgram
             using var judgeChatClient = new LongMemEvalChatCallMeter(
                 azureClient.GetChatClient(deployment).AsIChatClient());
 
-            var adapter = new TypedMemEvalReplayAdapter(answers, modelId);
+            var adapter = new TypedMemEvalReplayAdapter(storedRows, modelId);
             var runner = new TypedMemEvalRunner(judgeChatClient);
             var result = await runner.RunAsync(adapter, vertical, facade).ConfigureAwait(false);
+
+            if (adapter.OrderingMismatches.Count > 0)
+            {
+                // The runner selected or ordered questions differently from the stored artifact, so
+                // positional replay is pairing answers with the wrong questions. That yields a
+                // complete, plausible, entirely meaningless score -- the worst possible outcome, and
+                // the reason the position assumption is verified rather than trusted.
+                Console.Error.WriteLine(
+                    $"regrade: ABORT — {adapter.OrderingMismatches.Count} position(s) did not match " +
+                    "the stored question order, so answers would be paired with the wrong questions. " +
+                    "First: " + Truncate(adapter.OrderingMismatches[0]));
+                return 4;
+            }
 
             if (adapter.UnmatchedQuestions.Count > 0)
             {

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -1,0 +1,269 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using AgentEval.Memory.External.Models;
+using AgentEval.Memory.External.TypedMemEval;
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.AI;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Re-grades a stored TypedMemEval artifact under the currently referenced judge, without re-running
+/// extraction, retrieval, or answering.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The situation this exists for.</b> The Bitemporal vertical shipped with no judge body, so
+/// every bitemporal number on record was graded by a judge that graded the gold answer's
+/// justification rather than its value. The model answers were not affected — the judge is strictly
+/// downstream of answering, verified in code — so the correct repair is to re-grade the stored
+/// answers, not to re-run four hours of pipeline per arm.
+/// </para>
+/// <para>
+/// <b>It replays through AgentEval's own runner.</b> Question selection, judge body, typed-outcome
+/// derivation and attribution accounting are all their code, reached through
+/// <see cref="TypedMemEvalReplayAdapter"/>. Nothing about grading is reimplemented here, so this
+/// cannot drift from the path that produces every other number we cite, and it inherits whatever the
+/// new package changes.
+/// </para>
+/// <para>
+/// <b>Self-validating, which is why it can be trusted before the fixed judge exists.</b> Re-grading
+/// an artifact under the SAME judge that produced it must reproduce its verdicts. That check costs
+/// one judge pass and no new package. An instrument that cannot reproduce a known result has no
+/// business re-anchoring a baseline, and this prints the agreement rate so the question is answered
+/// rather than assumed.
+/// </para>
+/// <para>
+/// <b>Sampling is read from the artifact's own provenance sidecar</b>, never re-specified by hand: a
+/// re-grade that selected a different question set would silently compare two different corpora
+/// slices and report it as a judge effect.
+/// </para>
+/// </remarks>
+internal static class TypedMemEvalRegradeProgram
+{
+    internal static readonly string[] KnownOptions = ["--regrade"];
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        try
+        {
+            var reportPath = Value(args, "--regrade")
+                ?? throw new ArgumentException("--regrade requires a path to a stored report .json.");
+            reportPath = Path.GetFullPath(reportPath);
+            if (!File.Exists(reportPath))
+                throw new FileNotFoundException($"No such report: {reportPath}");
+
+            var sidecarPath = Path.ChangeExtension(reportPath, null) + ".provenance.json";
+            if (!File.Exists(sidecarPath))
+            {
+                // Refused rather than defaulted. The sidecar carries the seed and question cap; a
+                // guessed sampling would re-grade a DIFFERENT question set and the difference would
+                // present as a judge effect, which is the one conclusion this tool exists to support.
+                throw new FileNotFoundException(
+                    $"No provenance sidecar beside the report ({Path.GetFileName(sidecarPath)}). " +
+                    "Sampling cannot be reconstructed safely without it.");
+            }
+
+            using var report = JsonDocument.Parse(File.ReadAllText(reportPath));
+            using var sidecar = JsonDocument.Parse(File.ReadAllText(sidecarPath));
+
+            var rows = report.RootElement.GetProperty("QuestionResults");
+            var answers = new Dictionary<string, string>(StringComparer.Ordinal);
+            var duplicates = 0;
+            string? modelId = null;
+            foreach (var row in rows.EnumerateArray())
+            {
+                var question = row.GetProperty("Question").GetString() ?? string.Empty;
+                var answer = row.GetProperty("AgentResponse").GetString() ?? string.Empty;
+                if (!answers.TryAdd(question, answer)) duplicates++;
+            }
+
+            var sampling = sidecar.RootElement.GetProperty("sampling");
+            var verticalSlug = sidecar.RootElement.GetProperty("vertical").GetString()!;
+            // Resolved through the descriptor table, the same lookup the run verb uses, so a slug
+            // this build does not know fails here rather than silently grading a different vertical.
+            var vertical = (TypedMemEvalVerticals.All.FirstOrDefault(candidate =>
+                    string.Equals(candidate.Slug, verticalSlug, StringComparison.OrdinalIgnoreCase))
+                ?? throw new ArgumentException(
+                    $"The sidecar names vertical '{verticalSlug}', which this build does not know."))
+                .Vertical;
+            var armToken = sidecar.RootElement.GetProperty("arm").GetProperty("token").GetString();
+
+            Console.WriteLine(
+                $"regrade: source {Path.GetFileName(reportPath)} — vertical {verticalSlug}, " +
+                $"arm {armToken}, {answers.Count} distinct answers" +
+                (duplicates > 0 ? $" ({duplicates} duplicate question texts collapsed)" : string.Empty));
+
+            if (duplicates > 0)
+            {
+                // Text is the only key InvokeAsync receives, so identical questions are
+                // indistinguishable to the replay. Rather than grade one answer twice and call the
+                // difference a judge effect, stop.
+                Console.Error.WriteLine(
+                    "regrade: ABORT — duplicate question texts cannot be replayed unambiguously.");
+                return 2;
+            }
+
+            var facade = new TypedMemEvalOptions
+            {
+                MaxQuestions = Nullable(sampling, "maxQuestions"),
+                RandomSeed = Nullable(sampling, "randomSeed"),
+                AnswerSeed = Nullable(sampling, "answerSeed"),
+                ControlArm = sampling.GetProperty("control").GetBoolean(),
+                TemporalGrounding = sampling.GetProperty("control").GetBoolean()
+                    ? TemporalGroundingMode.TimestampsAndText
+                    : null,
+            };
+
+            var endpoint = RequiredEnvironment("AZURE_OPENAI_ENDPOINT");
+            var apiKey = RequiredEnvironment("AZURE_OPENAI_API_KEY");
+            var deployment = RequiredEnvironment("AZURE_OPENAI_DEPLOYMENT");
+            var azureClient = new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+            using var judgeChatClient = new LongMemEvalChatCallMeter(
+                azureClient.GetChatClient(deployment).AsIChatClient());
+
+            var adapter = new TypedMemEvalReplayAdapter(answers, modelId);
+            var runner = new TypedMemEvalRunner(judgeChatClient);
+            var result = await runner.RunAsync(adapter, vertical, facade).ConfigureAwait(false);
+
+            if (adapter.UnmatchedQuestions.Count > 0)
+            {
+                // An unmatched question is graded as an empty answer, which scores as WRONG rather
+                // than as MISSING and would quietly lower the re-graded baseline -- corrupting the
+                // very number this exists to establish. Fail loudly instead.
+                Console.Error.WriteLine(
+                    $"regrade: ABORT — {adapter.UnmatchedQuestions.Count} question(s) had no stored " +
+                    "answer, so the re-graded score would be understated. First: " +
+                    Truncate(adapter.UnmatchedQuestions[0]));
+                return 3;
+            }
+
+            var agreement = Agreement(report.RootElement, result);
+            var destination = Persist(result, reportPath, sidecarPath, armToken, agreement);
+
+            Console.WriteLine(
+                $"regrade: matched {adapter.Matched} answers; " +
+                $"judge agreement with the stored verdicts {agreement.Agreed}/{agreement.Compared} " +
+                $"({(agreement.Compared == 0 ? 0 : (double)agreement.Agreed / agreement.Compared):P1})");
+            Console.WriteLine($"regrade: report {destination}");
+            Console.WriteLine(
+                "regrade: NOTE — agreement is the instrument check when re-grading under the SAME " +
+                "judge, and the FINDING when re-grading under a different one. Which of the two this " +
+                "run was depends on the AgentEval package referenced at build time: " +
+                AgentEvalVersion());
+            return 0;
+        }
+        catch (Exception ex) when (ex is ArgumentException or FileNotFoundException or JsonException)
+        {
+            Console.Error.WriteLine($"regrade: {ex.Message}");
+            return 1;
+        }
+    }
+
+    /// <summary>Per-question verdict agreement between the stored artifact and the re-grade.</summary>
+    /// <remarks>
+    /// Compared by <c>QuestionId</c>, not by position: the runner selects questions itself, and a
+    /// positional comparison would silently pair different questions if selection ever changed.
+    /// </remarks>
+    private static (int Compared, int Agreed) Agreement(JsonElement stored, object regraded)
+    {
+        var storedById = new Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var row in stored.GetProperty("QuestionResults").EnumerateArray())
+        {
+            var id = row.GetProperty("QuestionId").GetString();
+            if (id is not null) storedById[id] = row.GetProperty("Correct").GetBoolean();
+        }
+
+        // Re-serialized rather than reflected over: the result type is AgentEval's and its shape is
+        // theirs to change, so reading it the same way the artifact is read keeps one parsing story.
+        using var fresh = JsonDocument.Parse(JsonSerializer.Serialize(regraded));
+        var compared = 0;
+        var agreed = 0;
+        foreach (var row in fresh.RootElement.GetProperty("QuestionResults").EnumerateArray())
+        {
+            var id = row.GetProperty("QuestionId").GetString();
+            if (id is null || !storedById.TryGetValue(id, out var before)) continue;
+            compared++;
+            if (before == row.GetProperty("Correct").GetBoolean()) agreed++;
+        }
+
+        return (compared, agreed);
+    }
+
+    private static string Persist(
+        object result,
+        string sourceReportPath,
+        string sourceSidecarPath,
+        string? armToken,
+        (int Compared, int Agreed) agreement)
+    {
+        var stamp = DateTimeOffset.UtcNow;
+        var name =
+            Path.GetFileNameWithoutExtension(sourceReportPath) +
+            $"-regrade-{stamp:yyyyMMddTHHmmssZ}.json";
+        var destination = Path.GetFullPath(Path.Combine("artifacts", "evaluation", name));
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        File.WriteAllText(
+            destination,
+            JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }) +
+            Environment.NewLine);
+
+        var provenance = new
+        {
+            schema = "typedmemeval-regrade-provenance/1",
+            report = Path.GetFileName(destination),
+            regradedAtUtc = stamp.ToString("O", CultureInfo.InvariantCulture),
+            // The whole point of the artifact: which answers were graded, and by which judge.
+            source = new
+            {
+                report = Path.GetFileName(sourceReportPath),
+                sidecar = Path.GetFileName(sourceSidecarPath),
+                arm = armToken,
+            },
+            judge = new
+            {
+                agentEvalVersion = AgentEvalVersion(),
+                agreementWithStored = agreement.Agreed,
+                agreementCompared = agreement.Compared,
+            },
+            // Stated in the artifact so no later reader has to infer it: answers were REPLAYED. No
+            // extraction, retrieval or answering ran, so retrieval-side diagnostics in the body
+            // describe the ORIGINAL run and must not be read as fresh measurements.
+            answersReplayed = true,
+        };
+        File.WriteAllText(
+            Path.ChangeExtension(destination, null) + ".provenance.json",
+            JsonSerializer.Serialize(provenance, new JsonSerializerOptions { WriteIndented = true }) +
+            Environment.NewLine);
+        return destination;
+    }
+
+    private static string AgentEvalVersion() =>
+        typeof(TypedMemEvalRunner).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(TypedMemEvalRunner).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
+
+    private static int? Nullable(JsonElement parent, string name) =>
+        parent.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Number
+            ? value.GetInt32()
+            : null;
+
+    private static string? Value(string[] args, string name)
+    {
+        var index = Array.IndexOf(args, name);
+        if (index < 0) return null;
+        if (index + 1 >= args.Length) throw new ArgumentException($"{name} requires a value.");
+        return args[index + 1];
+    }
+
+    private static string RequiredEnvironment(string name) =>
+        Environment.GetEnvironmentVariable(name) is { Length: > 0 } value
+            ? value
+            : throw new ArgumentException($"{name} must be set.");
+
+    private static string Truncate(string text) =>
+        text.Length <= 120 ? text : text[..120] + "…";
+}

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -189,7 +189,15 @@ internal static class TypedMemEvalRegradeProgram
         foreach (var row in stored.GetProperty("QuestionResults").EnumerateArray())
         {
             var id = row.GetProperty("QuestionId").GetString();
-            if (id is not null) storedById[id] = row.GetProperty("Correct").GetBoolean();
+            if (id is null) continue;
+
+            // The SAME null-verdict case the re-graded side below already handles, and it was missed
+            // here -- an asymmetry that would have thrown AFTER the judge pass was paid for, which is
+            // exactly the cheap-thing-destroys-expensive-result failure the persist-before-diagnostics
+            // ordering exists to prevent. A stored row with no verdict is simply not comparable.
+            var storedVerdict = row.GetProperty("Correct");
+            if (storedVerdict.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) continue;
+            storedById[id] = storedVerdict.GetBoolean();
         }
 
         // Re-serialized rather than reflected over: the result type is AgentEval's and its shape is

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
@@ -69,7 +69,9 @@ internal sealed class TypedMemEvalReplayAdapter(
     /// wrong answer rather than as a missing one, quietly lowering the re-graded baseline. Collected
     /// so the caller can fail the whole re-grade instead.
     /// </remarks>
-    public IReadOnlyList<string> UnmatchedQuestions => _unmatched;
+    // Snapshot, not the backing list: a caller that downcast and mutated this would corrupt
+    // the accounting the whole re-grade gate depends on.
+    public IReadOnlyList<string> UnmatchedQuestions => _unmatched.ToArray();
 
     /// <summary>
     /// Positions where the runner's question did not match the stored row at that position.
@@ -78,7 +80,7 @@ internal sealed class TypedMemEvalReplayAdapter(
     /// Non-empty means the replay is pairing answers with the wrong questions, which produces a
     /// fully-populated, entirely meaningless score. Fatal to the caller, never a warning.
     /// </remarks>
-    public IReadOnlyList<string> OrderingMismatches => _orderingMismatches;
+    public IReadOnlyList<string> OrderingMismatches => _orderingMismatches.ToArray();
 
     public int Matched { get; private set; }
 

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
@@ -1,0 +1,86 @@
+using AgentEval.Core;
+
+namespace AgentMemory.LongMemEval;
+
+/// <summary>
+/// Replays the answers a stored run already produced, so a judge can grade them again.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> AgentEval disclosed that the Bitemporal vertical shipped with no judge
+/// body: it fell through to the standard body, and the shared preamble's "premature" definition made
+/// the judge grade the gold answer's JUSTIFICATION rather than its value. Every bitemporal number we
+/// hold was produced by that judge. The model answers, however, were not — so the fix is to re-grade,
+/// not to re-run.
+/// </para>
+/// <para>
+/// <b>Why replaying through the REAL runner, rather than calling a judge directly.</b> A
+/// hand-rolled grading loop would be a second implementation of scoring, free to drift from the one
+/// that produces every other number we cite, and the drift would look like a finding. This adapter
+/// instead satisfies <see cref="IEvaluableAgent"/> by handing back the stored answer, so the
+/// question selection, the judge body, the typed-outcome derivation and the attribution accounting
+/// are all AgentEval's own code paths, unchanged. Whatever the new package changes, this inherits.
+/// </para>
+/// <para>
+/// <b>What makes it verifiable.</b> Replaying under the SAME judge that produced an artifact must
+/// reproduce that artifact's verdicts. That check needs no new package and is the reason this can be
+/// trusted before the fixed judge exists: an instrument that cannot reproduce a known result has no
+/// business re-anchoring a baseline. Judges are LLMs, so the target is high agreement rather than
+/// bit-identity, and the disagreements are inspected rather than averaged away.
+/// </para>
+/// <para>
+/// <b>The history hooks are deliberately inert.</b> Nothing is retrieved here; the answer already
+/// exists. Implementing them anyway keeps the adapter's shape identical to the real one, so the
+/// runner takes the same branches — a replay that changed the runner's path would be measuring a
+/// different harness.
+/// </para>
+/// </remarks>
+internal sealed class TypedMemEvalReplayAdapter(
+    IReadOnlyDictionary<string, string> answersByQuestion,
+    string? modelId)
+    : IEvaluableAgent, IHistoryInjectableAgent, ITimestampedHistoryInjectableAgent,
+      ISessionResettableAgent
+{
+    private readonly List<string> _unmatched = [];
+
+    public string Name => "AgentMemory.LongMemEval.Replay";
+
+    /// <summary>Questions the runner asked that the stored artifact had no answer for.</summary>
+    /// <remarks>
+    /// A miss is not recoverable by guessing — an empty answer would be graded, and would score as a
+    /// wrong answer rather than as a missing one, quietly lowering the re-graded baseline. Collected
+    /// so the caller can fail the whole re-grade instead.
+    /// </remarks>
+    public IReadOnlyList<string> UnmatchedQuestions => _unmatched;
+
+    public int Matched { get; private set; }
+
+    public void InjectConversationHistory(
+        IEnumerable<(string UserMessage, string AssistantResponse)> conversationTurns) { }
+
+    public void InjectTimestampedConversationHistory(TimestampedConversationHistory history) { }
+
+    public Task ResetSessionAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
+    public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!answersByQuestion.TryGetValue(prompt, out var answer))
+        {
+            _unmatched.Add(prompt);
+            // Still returns empty rather than throwing: one unmatched question should not abort a
+            // 60-question re-grade, because the caller can only judge whether the mismatch is
+            // systematic by seeing how many there are. UnmatchedQuestions is the gate.
+            return Task.FromResult(new AgentResponse { Text = string.Empty, ModelId = modelId });
+        }
+
+        Matched++;
+        return Task.FromResult(new AgentResponse { Text = answer, ModelId = modelId });
+    }
+}

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalReplayAdapter.cs
@@ -29,6 +29,22 @@ namespace AgentMemory.LongMemEval;
 /// bit-identity, and the disagreements are inspected rather than averaged away.
 /// </para>
 /// <para>
+/// <b>Keyed by POSITION, not by question text, and that is a corpus fact rather than a preference.</b>
+/// Twelve of the sixty bitemporal questions share their text with another question and carry a
+/// DIFFERENT gold answer -- <c>tme-bit-007</c> and <c>tme-bit-037</c> ask "which department was Colm
+/// Whitaker at in February?" and answer Lowick and Marchmont respectively. Each question is asked
+/// against its own injected history, so identical words over different memory legitimately have
+/// different right answers. A text-keyed replay would therefore have handed 12 of 60 questions an
+/// answer written for a different question and graded it, which is not a lost row but a WRONG one.
+/// </para>
+/// <para>
+/// <b>The position assumption is asserted, not trusted.</b> <see cref="InvokeAsync"/> receives only
+/// the prompt, so ordering is the only identity available; it is verified by checking that the text
+/// at each position still matches the stored row. If the runner ever selects or orders questions
+/// differently, that check fires instead of silently pairing the wrong answers -- the failure mode
+/// this whole class exists to make impossible.
+/// </para>
+/// <para>
 /// <b>The history hooks are deliberately inert.</b> Nothing is retrieved here; the answer already
 /// exists. Implementing them anyway keeps the adapter's shape identical to the real one, so the
 /// runner takes the same branches — a replay that changed the runner's path would be measuring a
@@ -36,12 +52,14 @@ namespace AgentMemory.LongMemEval;
 /// </para>
 /// </remarks>
 internal sealed class TypedMemEvalReplayAdapter(
-    IReadOnlyDictionary<string, string> answersByQuestion,
+    IReadOnlyList<(string Question, string Answer)> storedRows,
     string? modelId)
     : IEvaluableAgent, IHistoryInjectableAgent, ITimestampedHistoryInjectableAgent,
       ISessionResettableAgent
 {
     private readonly List<string> _unmatched = [];
+    private readonly List<string> _orderingMismatches = [];
+    private int _next;
 
     public string Name => "AgentMemory.LongMemEval.Replay";
 
@@ -52,6 +70,15 @@ internal sealed class TypedMemEvalReplayAdapter(
     /// so the caller can fail the whole re-grade instead.
     /// </remarks>
     public IReadOnlyList<string> UnmatchedQuestions => _unmatched;
+
+    /// <summary>
+    /// Positions where the runner's question did not match the stored row at that position.
+    /// </summary>
+    /// <remarks>
+    /// Non-empty means the replay is pairing answers with the wrong questions, which produces a
+    /// fully-populated, entirely meaningless score. Fatal to the caller, never a warning.
+    /// </remarks>
+    public IReadOnlyList<string> OrderingMismatches => _orderingMismatches;
 
     public int Matched { get; private set; }
 
@@ -71,16 +98,22 @@ internal sealed class TypedMemEvalReplayAdapter(
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!answersByQuestion.TryGetValue(prompt, out var answer))
+        if (_next >= storedRows.Count)
         {
+            // The runner asked more questions than the artifact holds answers for. Recorded rather
+            // than thrown so the caller sees the full extent before aborting.
             _unmatched.Add(prompt);
-            // Still returns empty rather than throwing: one unmatched question should not abort a
-            // 60-question re-grade, because the caller can only judge whether the mismatch is
-            // systematic by seeing how many there are. UnmatchedQuestions is the gate.
+            return Task.FromResult(new AgentResponse { Text = string.Empty, ModelId = modelId });
+        }
+
+        var row = storedRows[_next++];
+        if (!string.Equals(row.Question, prompt, StringComparison.Ordinal))
+        {
+            _orderingMismatches.Add(prompt);
             return Task.FromResult(new AgentResponse { Text = string.Empty, ModelId = modelId });
         }
 
         Matched++;
-        return Task.FromResult(new AgentResponse { Text = answer, ModelId = modelId });
+        return Task.FromResult(new AgentResponse { Text = row.Answer, ModelId = modelId });
     }
 }


### PR DESCRIPTION
The branch is named for a hypothesis that is now closed as a clean negative. What it actually carries
is the instruments built while testing it — and two code facts they uncovered.

## The code facts, both verifiable in this repo

**Write-time supersession cannot fire on free-form predicates.** `PersistenceStage` gates on
`WriteTimeFactResolution.CanSupersede` → `MemoryRelationCardinality.IsSingleValued`, which requires
membership in the relation vocabulary's `single` cardinality set — **exactly six relations**
(`belongs to, costs, expires, lives in, weighs, works at`), no aliases, documented "false for
anything unrecognised". A corpus whose extracted predicates fall outside those six cannot produce a
single `:SUPERSEDED_BY` edge, so `SupersedeReplacedFacts = true` is indistinguishable from `false` on
it. Measured across four separate stores: **0 edges, 0 invalidated facts**. A guard test now pins the
gate's reach.

**`CreateAboutRelationshipAsync` is public API that no ingestion path calls.** Verified against a
prepared store: 26,887 of 26,887 facts carry no `:ABOUT` edge. It is not unread, though —
`NodeDistanceQueries` traverses `[:RELATED_TO|ABOUT*..4]` and its docstring names `ABOUT` as
load-bearing, so anyone enabling `NodeDistanceReranking` today gets a re-ranker walking a graph
missing every `ABOUT` edge it names, weaker than its own query describes, with nothing reporting the
difference.

Documented rather than changed: the writer is public under SemVer, so a consumer who created links
manually has them honoured today and removing the edge from the traversal would change their results
silently. All three surfaces — both verbs, the option, and the traversal — now say what is true.
Wiring a writer or dropping the edge stay open as real options.

## Instruments

- **Store probes** in every run's sidecar: `:SUPERSEDED_BY` count, invalidated-fact count, extracted-
  predicate histogram, fact-object shape, amount-subject collision. A mechanism's firing is verified
  by **counting its artifacts**, never by a downstream statistic moving — the previous check inferred
  supersession from facts-per-question falling, and that band turned out to be extraction variance.
- **`--regrade`**: judge-only re-grade of a stored artifact, replayed through the evaluator's own
  runner rather than a second grading loop, so scoring cannot drift from the path that produces every
  other number. Self-validating — re-grading under the judge that produced an artifact reproduces it
  (60/60 verdicts, identical accuracy). Keyed by **position**, after the duplicate guard caught that
  12 of 60 questions in one corpus share their text with a question having a **different** gold.
- **A render-state gate** that reads the assembled prompt, not the config, and fails closed: a null
  block is a failure, never a pass.
- **`--cell-probe`** for extracting external corpus files, with `--dry-run`.
- **`--resolve-supersessions`** wiring, plus a staged live-Neo4j test proving supersession renders on
  **both** the live and as-of recall paths — neither had any coverage before.

## The guards, and why they exist

Each one is a mistake made in this branch, converted into something that cannot recur:

- **Window containment precondition** — a paid run measured a window containing none of the
  phenomenon (the sampling rule said the first 12 entries; the phenomenon starts at entry 14). The
  probe now counts occurrences and aborts **before the first paid call**.
- **Zero-denominator guard** — `0 of 0` prints `NOT MEASURED … this is not 0%`. A share over nothing
  is not a small share.
- **Persist-before-diagnostics** — an agreement statistic threw and destroyed an artifact that had
  already been paid for. Nothing cheap may stand between an expensive result and durability.
- **Probe-contract note** — the optional probe members default to empty, and the contract now states
  that **empty means "no store to read", not "measured zero"**, because a default that silently
  satisfies every caller is how a constant column is born.

## Verification

Release build **0 warnings**. Unit **5,187 + 728 + 54**. Integration **486 passed / 29 skipped / 0
failed** against live Neo4j; the skips are the NAMS live tests behind their opt-in flag.

Also bumps the SDK pin to 10.0.400 (10.0.102 was uninstalled and unavailable) and the evaluator
package to the release whose judge has a body for the vertical it was grading.