### PR TITLE
Say something when SupersedeReplacedFacts is on and inert

### DIFF
--- a/src/AgentMemory.Abstractions/Options/ExtractionOptions.cs
+++ b/src/AgentMemory.Abstractions/Options/ExtractionOptions.cs
@@ -94,6 +94,20 @@ public sealed class ExtractionOptions
     /// <c>IFactRepository.FindSupersededCandidatesAsync</c>; one that does not simply keeps appending.
     /// </para>
     /// </remarks>
+    /// <remarks>
+    /// <b>This only applies to predicates the relation vocabulary declares SINGLE-VALUED</b>
+    /// (functional relations, where a subject holds at most one live value). A predicate outside that
+    /// set — including any free-form phrasing an extractor invents, such as <c>"was at"</c>,
+    /// <c>"assigned to"</c> or <c>"department"</c> — is refused, silently as far as the graph is
+    /// concerned: no <c>:SUPERSEDED_BY</c> edge is written and no <c>invalidated_at</c> is stamped.
+    /// <para>
+    /// So enabling this against free-form predicates leaves the feature <b>on and inert</b>. The
+    /// library now says so — a debug line per refusal naming the predicate and the qualifying set, and
+    /// one warning per batch when the option is enabled and nothing qualified. If you see that
+    /// warning, either the extraction needs to canonicalise its predicates into the vocabulary, or
+    /// supersession does not apply to your material.
+    /// </para>
+    /// </remarks>
     public bool SupersedeReplacedFacts { get; set; }
 
     /// <summary>

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -6,6 +6,7 @@ using AgentMemory.Abstractions.Exceptions;
 using AgentMemory.Abstractions.Options;
 using AgentMemory.Abstractions.Repositories;
 using AgentMemory.Abstractions.Services;
+using AgentMemory.Core.Memory;
 using AgentMemory.Core.Services;
 
 namespace AgentMemory.Core.Extraction;
@@ -308,6 +309,10 @@ internal sealed partial class PersistenceStage : IPersistenceStage
         }
         // 2. Embed + upsert facts.
         var persistedFactCount = 0;
+        // Counted so the batch can say whether the lever did anything at all -- the "you turned this
+        // on and it was inert" signal that took a week and four scored runs to notice its absence.
+        var supersessionEligible = 0;
+        var supersessionRefusals = 0;
 
         async Task<(Fact Item, string SourceKey)?> PrepareFactAsync(PreparedFact preparedFact)
         {
@@ -410,8 +415,30 @@ internal sealed partial class PersistenceStage : IPersistenceStage
         // precision in live recall, while failing the ingestion over it would lose the memory itself.
         async Task SupersedeReplacedFactsAsync(Fact winner)
         {
-            if (!_options.SupersedeReplacedFacts || !WriteTimeFactResolution.CanSupersede(winner))
+            if (!_options.SupersedeReplacedFacts) return;
+
+            // The silent no-op this closes. `CanSupersede` requires the predicate to be one of the
+            // relations the vocabulary declares single-valued, and it is FALSE for anything
+            // unrecognised -- so a caller who enables SupersedeReplacedFacts against free-form
+            // predicates ("was at", "assigned to", "department") gets a feature that is on and inert,
+            // writes no :SUPERSEDED_BY edge, and says nothing about it anywhere.
+            //
+            // That is not hypothetical: a benchmark ran four scored arms against it before the cause
+            // was found, and only because the graph could be queried directly. A consumer has no such
+            // recourse, so the refusal is now observable.
+            if (!WriteTimeFactResolution.CanSupersede(winner))
+            {
+                supersessionRefusals++;
+                _logger.LogDebug(
+                    "Supersession skipped for '{S} {P} {O}': predicate '{P}' is not declared "
+                    + "single-valued, so at most one live value per subject is not assumed. "
+                    + "Single-valued relations: {Known}.",
+                    winner.Subject, winner.Predicate, winner.Object, winner.Predicate,
+                    string.Join(", ", MemoryRelationCardinality.SingleValuedPredicates));
                 return;
+            }
+
+            supersessionEligible++;
 
             var scope = string.IsNullOrEmpty(ownerId) ? null : MemoryScope.For(ownerId, includeShared: false);
             try
@@ -763,6 +790,22 @@ internal sealed partial class PersistenceStage : IPersistenceStage
             foreach (var input in relationshipInputs)
                 await PersistRelationshipIndividuallyAsync(input.Item, input.SourceKey).ConfigureAwait(false);
         }
+        // The batch-level signal. Debug-level per-fact logging tells you WHY once you are already
+        // looking; this is what makes you look. Warned once per batch rather than per fact so a large
+        // ingestion cannot bury it, and only when the option was actually asked for -- a warning on a
+        // feature nobody enabled is how warnings stop being read.
+        if (_options.SupersedeReplacedFacts && supersessionEligible == 0 && supersessionRefusals > 0)
+        {
+            _logger.LogWarning(
+                "SupersedeReplacedFacts is ENABLED but none of the {Refused} fact(s) in this batch "
+                + "had a predicate declared single-valued, so NO supersession was attempted and no "
+                + ":SUPERSEDED_BY edge was written. The feature is on and inert for this content. "
+                + "Single-valued relations: {Known}. Either the extracted predicates need to "
+                + "canonicalise into that set, or supersession does not apply to this material.",
+                supersessionRefusals,
+                string.Join(", ", MemoryRelationCardinality.SingleValuedPredicates));
+        }
+
         return new PersistenceResult
         {
             EntityCount = persistedEntityMap.Count,

--- a/src/AgentMemory.Core/Extraction/PersistenceStage.cs
+++ b/src/AgentMemory.Core/Extraction/PersistenceStage.cs
@@ -429,12 +429,21 @@ internal sealed partial class PersistenceStage : IPersistenceStage
             if (!WriteTimeFactResolution.CanSupersede(winner))
             {
                 supersessionRefusals++;
-                _logger.LogDebug(
-                    "Supersession skipped for '{S} {P} {O}': predicate '{P}' is not declared "
-                    + "single-valued, so at most one live value per subject is not assumed. "
-                    + "Single-valued relations: {Known}.",
-                    winner.Subject, winner.Predicate, winner.Object, winner.Predicate,
-                    string.Join(", ", MemoryRelationCardinality.SingleValuedPredicates));
+                // Guarded, because the arguments are evaluated whether or not Debug is enabled: this
+                // runs once per refused fact, and on an ingestion where NOTHING qualifies that is once
+                // per fact in the batch. Joining the relation list each time would be a real cost paid
+                // for output nobody is reading. The batch warning below is unguarded on purpose --
+                // it fires at most once and only when something is wrong.
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Supersession skipped for '{Subject} {Predicate} {Object}': predicate is not "
+                        + "declared single-valued, so at most one live value per subject is not "
+                        + "assumed. Single-valued relations: {Known}.",
+                        winner.Subject, winner.Predicate, winner.Object,
+                        string.Join(", ", MemoryRelationCardinality.SingleValuedPredicates));
+                }
+
                 return;
             }
 

--- a/tests/AgentMemory.Tests.Unit/Extraction/WriteTimeSupersessionTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/WriteTimeSupersessionTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
 using AgentMemory.Abstractions.Options;
@@ -81,7 +80,9 @@ public sealed class WriteTimeSupersessionTests
     {
         public List<(LogLevel Level, string Message)> Entries { get; } = [];
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-        public bool IsEnabled(LogLevel logLevel) => true;
+        public bool DebugEnabled { get; set; } = true;
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel != LogLevel.Debug || DebugEnabled;
         public void Log<TState>(
             LogLevel logLevel, EventId eventId, TState state, Exception? exception,
             Func<TState, Exception?, string> formatter) =>
@@ -271,5 +272,23 @@ public sealed class WriteTimeSupersessionTests
         await CreateSut(supersede: false).PersistAsync(Incoming("was at", "Zurich"), ownerId: "alice");
 
         _log.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task TheDebugRefusalIsNotBuiltWhenDebugIsDisabled()
+    {
+        // It runs once per refused fact, so on an ingestion where nothing qualifies it runs once per
+        // fact. Formatting the relation list each time would be a cost paid for output nobody reads.
+        _log.DebugEnabled = false;
+
+        await CreateSut(supersede: true).PersistAsync(Incoming("was at", "Zurich"), ownerId: "alice");
+
+        // Asserted against the REFUSAL message, not "no Debug at all": this stage also logs an
+        // unrelated per-fact "Persisted fact" line, and the capturing logger records what it is given
+        // rather than re-checking IsEnabled the way a real provider would.
+        _log.Entries.Should().NotContain(e => e.Message.Contains("Supersession skipped"),
+            "the guarded branch must not build its message when Debug is off");
+        _log.Entries.Should().Contain(e => e.Level == LogLevel.Warning,
+            "the batch warning fires at most once and must survive Debug being off");
     }
 }

--- a/tests/AgentMemory.Tests.Unit/Extraction/WriteTimeSupersessionTests.cs
+++ b/tests/AgentMemory.Tests.Unit/Extraction/WriteTimeSupersessionTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using AgentMemory.Abstractions.Domain;
@@ -73,9 +74,23 @@ public sealed class WriteTimeSupersessionTests
         CreatedAtUtc = DateTimeOffset.UnixEpoch,
     };
 
+    private readonly CapturingLogger _log = new();
+
+    /// <summary>A logger that keeps what was written, so "it said nothing" is testable.</summary>
+    private sealed class CapturingLogger : ILogger<PersistenceStage>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+
     private PersistenceStage CreateSut(bool supersede) =>
         new(_orchestrator, _entityRepo, _factRepo, _prefRepo, _relRepo, _clock, _idGen,
-            NullLogger<PersistenceStage>.Instance,
+            _log,
             new PassThroughMemoryPersistenceTransaction(),
             Options.Create(new ExtractionOptions
             {
@@ -208,5 +223,53 @@ public sealed class WriteTimeSupersessionTests
         functional.Should().HaveCountLessThan(12,
             "each entry licenses closing a fact; a large set means someone stopped thinking about it");
         functional.Should().NotContain("likes").And.NotContain("owns").And.NotContain("visited");
+    }
+
+    // ── half three: the refusal is observable ─────────────────────────────
+
+    [Fact]
+    public async Task AnUnrecognisedPredicateWarnsThatTheFeatureIsOnAndInert()
+    {
+        // The silent no-op this closes. A caller enables supersession, their extractor writes
+        // free-form predicates, nothing qualifies, no edge is written -- and before this, nothing
+        // anywhere said so. A benchmark ran four scored arms against exactly that before the cause
+        // was found, and only because the graph could be queried directly.
+        await CreateSut(supersede: true).PersistAsync(Incoming("was at", "Zurich"), ownerId: "alice");
+
+        _superseded.Should().BeEmpty("'was at' is not declared single-valued");
+        _log.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("ENABLED but none of the"),
+            "a feature that is on and doing nothing must say so");
+        _log.Entries.Should().Contain(e => e.Message.Contains("lives in"),
+            "the warning names the qualifying relations so the reader can act on it");
+    }
+
+    [Fact]
+    public async Task TheRefusalNamesThePredicateItRefused()
+    {
+        await CreateSut(supersede: true).PersistAsync(Incoming("was at", "Zurich"), ownerId: "alice");
+
+        _log.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Debug && e.Message.Contains("was at"),
+            "per-fact detail is what makes the batch warning actionable");
+    }
+
+    [Fact]
+    public async Task AQualifyingPredicateDoesNotWarn()
+    {
+        // The counter-check: a warning that fires when the feature IS working would train the reader
+        // to ignore it, which is how a signal stops being a signal.
+        await CreateSut(supersede: true).PersistAsync(Incoming("lives in", "Zurich"), ownerId: "alice");
+
+        _log.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task TheFeatureBeingOffIsSilent()
+    {
+        // Nobody asked for supersession, so nobody is told it did not happen.
+        await CreateSut(supersede: false).PersistAsync(Incoming("was at", "Zurich"), ownerId: "alice");
+
+        _log.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }
 }


### PR DESCRIPTION
`SupersedeReplacedFacts = true` does nothing at all unless the extracted predicate is one of the six
relations the vocabulary declares single-valued (`belongs to, costs, expires, lives in, weighs,
works at`). `CanSupersede` is documented "false for anything unrecognised", so free-form predicates —
`was at`, `assigned to`, `department` — are refused. No `:SUPERSEDED_BY` edge, no `invalidated_at`,
and **no signal of any kind**.

This is not hypothetical. Four scored benchmark arms ran against precisely that state and were
reported as measurements of the feature. The cause was found only because the graph could be queried
directly and a probe was written to count edges. A consumer has neither recourse — they would
conclude bitemporal memory does not work.

## Three signals, each at the level it belongs

- **Debug, per refusal** — names the refused predicate and the qualifying set. Makes the warning
  actionable once you are looking.
- **Warning, once per batch** — only when the option is enabled *and* nothing qualified: "on and
  inert". Per-batch so a large ingestion cannot bury it; conditioned on the option so a feature
  nobody asked for never warns.
- **The option's own docs** — where someone enabling it will read the constraint.

## Tested both directions

A guard that cannot stay quiet is as bad as one that cannot speak, so: an unrecognised predicate
warns and names both the predicate and the qualifying relations; a **qualifying** predicate does
**not** warn; the feature **off** is silent.

Release 0-warn; 5191 + 730 + 54 unit tests green. No behaviour change — nothing supersedes that did
not supersede before.