### PR TITLE
Feed the runner's evidence options, and add the caller-feeds standing check

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/FacadeCallerFeedsTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/FacadeCallerFeedsTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using AgentEval.Memory.External.Models;
+using AgentEval.Memory.External.TypedMemEval;
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// Every option the runner accepts must be either FED by our facade or declared as deliberately left
+/// at its default — the caller-feeds standing check.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The shape this exists to catch.</b> "Reachable is not the same as fed" has now cost this
+/// project on four separate codepaths: an extraction lever no harness set, a renderer no harness set,
+/// a public write verb no pipeline calls, and — the one that prompted this test —
+/// <c>EvidenceCaptureMode</c>, which <c>TypedMemEvalOptionMapping</c> faithfully passes through to the
+/// runner while <c>BuildFacade</c> never set it. So <c>--evidence-detail</c> configured our adapter
+/// and left the runner on its default, and the flag looked wired because half of it was.
+/// </para>
+/// <para>
+/// <b>Why a declared map rather than a clever diff.</b> Comparing a built facade against a default
+/// one cannot tell "fed with a value that happens to equal the default" from "never fed" — and that
+/// ambiguity is precisely the bug. So every property must be classified BY HAND, with a reason, and a
+/// property nobody has classified fails this test. The cost is one line when the runner gains an
+/// option; the alternative is discovering it during a paid run.
+/// </para>
+/// </remarks>
+public class FacadeCallerFeedsTests
+{
+    /// <summary>Set by <c>BuildFacade</c> from a run option.</summary>
+    private static readonly HashSet<string> Fed = new(StringComparer.Ordinal)
+    {
+        "MaxQuestions", "RandomSeed", "AnswerSeed", "TemporalGrounding", "ControlArm",
+        // Added when this test was written: --evidence-detail previously reached the adapter only.
+        "EvidenceCaptureMode", "EvidenceTopK",
+    };
+
+    /// <summary>Deliberately left at the runner's default, with the reason recorded.</summary>
+    private static readonly Dictionary<string, string> IntentionallyDefaulted = new(StringComparer.Ordinal)
+    {
+        ["AnswerTemperature"] = "answer determinism is controlled through the chat client, not here",
+        ["HistoryInjectionMode"] = "the adapter implements the timestamped interface; the runner picks",
+        ["IncludeTimestamps"] = "subsumed by TemporalGrounding, which this facade does set",
+        ["JudgeTemperature"] = "judge configuration is AgentEval's to own; we grade with their defaults",
+        ["JudgeMaxOutputTokens"] = "as above",
+        ["MaxJudgeRetries"] = "as above — and a retry count we chose would make our scores incomparable",
+        ["JudgeFailurePolicy"] = "as above",
+        ["JudgeEvidenceMode"] = "as above",
+        ["RetainRawJudgeResponse"] = "raw judge text is theirs; our artifacts carry verdicts, not prose",
+    };
+
+    [Fact]
+    public void EveryRunnerOptionIsEitherFedOrDeclaredDefaulted()
+    {
+        var settable = typeof(TypedMemEvalOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanWrite)
+            .Select(property => property.Name)
+            .ToArray();
+
+        var classified = Fed.Concat(IntentionallyDefaulted.Keys).ToHashSet(StringComparer.Ordinal);
+
+        settable.Should().BeSubsetOf(classified,
+            "an option nobody has classified is an option nobody has decided about — which is how "
+            + "EvidenceCaptureMode ended up passed through to the runner and never set");
+
+        classified.Should().BeSubsetOf(settable,
+            "a classification for an option that no longer exists is stale and will mislead the next "
+            + "reader into thinking it was considered");
+    }
+
+    [Fact]
+    public void TheEvidenceFlagReachesTheRunnerAndNotOnlyTheAdapter()
+    {
+        // The concrete regression. Before the fix this property was default regardless of the flag.
+        foreach (var (detail, expected) in new[]
+        {
+            (LongMemEvalEvidenceDetail.None, EvidenceCaptureMode.None),
+            (LongMemEvalEvidenceDetail.Identifiers, EvidenceCaptureMode.References),
+            (LongMemEvalEvidenceDetail.Content, EvidenceCaptureMode.Full),
+        })
+        {
+            LongMemEvalBenchmarkProtocol.CaptureModeFor(detail).Should().Be(expected);
+        }
+    }
+}

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/FacadeCallerFeedsTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/FacadeCallerFeedsTests.cs
@@ -33,23 +33,28 @@ public class FacadeCallerFeedsTests
     /// <summary>Set by <c>BuildFacade</c> from a run option.</summary>
     private static readonly HashSet<string> Fed = new(StringComparer.Ordinal)
     {
-        "MaxQuestions", "RandomSeed", "AnswerSeed", "TemporalGrounding", "ControlArm",
+        nameof(TypedMemEvalOptions.MaxQuestions),
+        nameof(TypedMemEvalOptions.RandomSeed),
+        nameof(TypedMemEvalOptions.AnswerSeed),
+        nameof(TypedMemEvalOptions.TemporalGrounding),
+        nameof(TypedMemEvalOptions.ControlArm),
         // Added when this test was written: --evidence-detail previously reached the adapter only.
-        "EvidenceCaptureMode", "EvidenceTopK",
+        nameof(TypedMemEvalOptions.EvidenceCaptureMode),
+        nameof(TypedMemEvalOptions.EvidenceTopK),
     };
 
     /// <summary>Deliberately left at the runner's default, with the reason recorded.</summary>
     private static readonly Dictionary<string, string> IntentionallyDefaulted = new(StringComparer.Ordinal)
     {
-        ["AnswerTemperature"] = "answer determinism is controlled through the chat client, not here",
-        ["HistoryInjectionMode"] = "the adapter implements the timestamped interface; the runner picks",
-        ["IncludeTimestamps"] = "subsumed by TemporalGrounding, which this facade does set",
-        ["JudgeTemperature"] = "judge configuration is AgentEval's to own; we grade with their defaults",
-        ["JudgeMaxOutputTokens"] = "as above",
-        ["MaxJudgeRetries"] = "as above — and a retry count we chose would make our scores incomparable",
-        ["JudgeFailurePolicy"] = "as above",
-        ["JudgeEvidenceMode"] = "as above",
-        ["RetainRawJudgeResponse"] = "raw judge text is theirs; our artifacts carry verdicts, not prose",
+        [nameof(TypedMemEvalOptions.AnswerTemperature)] = "answer determinism is controlled through the chat client, not here",
+        [nameof(TypedMemEvalOptions.HistoryInjectionMode)] = "the adapter implements the timestamped interface; the runner picks",
+        [nameof(TypedMemEvalOptions.IncludeTimestamps)] = "subsumed by TemporalGrounding, which this facade does set",
+        [nameof(TypedMemEvalOptions.JudgeTemperature)] = "judge configuration is AgentEval's to own; we grade with their defaults",
+        [nameof(TypedMemEvalOptions.JudgeMaxOutputTokens)] = "as above",
+        [nameof(TypedMemEvalOptions.MaxJudgeRetries)] = "as above — and a retry count we chose would make our scores incomparable",
+        [nameof(TypedMemEvalOptions.JudgeFailurePolicy)] = "as above",
+        [nameof(TypedMemEvalOptions.JudgeEvidenceMode)] = "as above",
+        [nameof(TypedMemEvalOptions.RetainRawJudgeResponse)] = "raw judge text is theirs; our artifacts carry verdicts, not prose",
     };
 
     [Fact]
@@ -73,9 +78,14 @@ public class FacadeCallerFeedsTests
     }
 
     [Fact]
-    public void TheEvidenceFlagReachesTheRunnerAndNotOnlyTheAdapter()
+    public void BuildFacadeItselfCarriesTheEvidenceModeToTheRunner()
     {
-        // The concrete regression. Before the fix this property was default regardless of the flag.
+        // The first version of this asserted the MAPPING FUNCTION and not the assignment, so deleting
+        // the line in BuildFacade would have left it green -- a guard that cannot come out the other
+        // way, in the very test written to enforce that rule. It now calls BuildFacade.
+        //
+        // A [Fact] with a loop rather than a [Theory]: xUnit requires a public test class, and the
+        // detail enum is internal, so it cannot appear in a public method signature.
         foreach (var (detail, expected) in new[]
         {
             (LongMemEvalEvidenceDetail.None, EvidenceCaptureMode.None),
@@ -83,7 +93,23 @@ public class FacadeCallerFeedsTests
             (LongMemEvalEvidenceDetail.Content, EvidenceCaptureMode.Full),
         })
         {
-            LongMemEvalBenchmarkProtocol.CaptureModeFor(detail).Should().Be(expected);
+            TypedMemEvalProgram.BuildFacade(Options(detail)).EvidenceCaptureMode
+                .Should().Be(expected, "detail {0} must reach the runner", detail);
         }
     }
+
+    [Fact]
+    public void BuildFacadeCarriesAnEvidenceTopK()
+    {
+        TypedMemEvalProgram.BuildFacade(Options(LongMemEvalEvidenceDetail.Identifiers))
+            .EvidenceTopK.Should().BeGreaterThan(0,
+                "zero would silently capture no evidence while looking configured");
+    }
+
+    private static TypedMemEvalProgram.TypedMemEvalRunOptions Options(
+        LongMemEvalEvidenceDetail detail) => new(
+        [TypedMemEvalVertical.Arithmetic], MaxQuestions: null, RandomSeed: 1, AnswerSeed: null,
+        Runs: 1, Oracle: false, Control: false, Phase30: PhaseThirtyFeatures.AllOff,
+        RescueShortOwnerResults: false, SupersedeReplacedFacts: false, EvidenceDetail: detail,
+        FactWeightedBudget: false, ResolveSupersessions: false, DryRun: false);
 }

--- a/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
+++ b/tools/AgentMemory.LongMemEval/LongMemEvalBenchmarkProtocol.cs
@@ -73,14 +73,23 @@ internal static class LongMemEvalBenchmarkProtocol
             // messages were this boilerplate, and it read as a defect in OUR retrieval for weeks.
             // Empty marker == omit. Default keeps the historical text so sealed bases stay comparable.
             SyntheticTurnMarker = suppressSyntheticBoundaries ? string.Empty : null,
-            EvidenceCaptureMode = evidenceDetail switch
-            {
-                LongMemEvalEvidenceDetail.None => EvidenceCaptureMode.None,
-                LongMemEvalEvidenceDetail.Identifiers => EvidenceCaptureMode.References,
-                LongMemEvalEvidenceDetail.Content => EvidenceCaptureMode.Full,
-                _ => throw new ArgumentOutOfRangeException(nameof(evidenceDetail))
-            },
+            EvidenceCaptureMode = CaptureModeFor(evidenceDetail),
             EvidenceTopK = maxRelevantMessages
+        };
+
+    /// <summary>Maps our evidence-detail flag onto the runner's capture mode.</summary>
+    /// <remarks>
+    /// Shared rather than duplicated because it was duplicated by omission once already: the
+    /// typedmemeval verb's facade never set <c>EvidenceCaptureMode</c> at all, so `--evidence-detail`
+    /// fed the adapter and left the runner on its default. One definition, two callers.
+    /// </remarks>
+    internal static EvidenceCaptureMode CaptureModeFor(LongMemEvalEvidenceDetail evidenceDetail) =>
+        evidenceDetail switch
+        {
+            LongMemEvalEvidenceDetail.None => EvidenceCaptureMode.None,
+            LongMemEvalEvidenceDetail.Identifiers => EvidenceCaptureMode.References,
+            LongMemEvalEvidenceDetail.Content => EvidenceCaptureMode.Full,
+            _ => throw new ArgumentOutOfRangeException(nameof(evidenceDetail))
         };
 
     internal static IReadOnlyList<(string UserMessage, string AssistantResponse)> History(

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -291,7 +291,14 @@ internal static class TypedMemEvalProgram
         // family's published pairing: same corpus, same hash, dates re-added to the text, and the
         // run labelled so it can never be banded with the probe by accident.
         TemporalGrounding = options.Control ? TemporalGroundingMode.TimestampsAndText : null,
-        ControlArm = options.Control
+        ControlArm = options.Control,
+        // These two were NEVER SET, and `--evidence-detail` therefore only did half its job on this
+        // verb: it reached the adapter (which builds our own evidence view) and left the RUNNER's
+        // capture mode on its default, even though TypedMemEvalOptionMapping reads it and passes it
+        // straight through. A flag that configures one of two consumers is the same reachable-but-not-
+        // fed shape this project has now found on four codepaths.
+        EvidenceCaptureMode = LongMemEvalBenchmarkProtocol.CaptureModeFor(options.EvidenceDetail),
+        EvidenceTopK = DefaultMaxRelevant,
     };
 
     /// <summary>

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalProgram.cs
@@ -282,7 +282,8 @@ internal static class TypedMemEvalProgram
         return results;
     }
 
-    private static TypedMemEvalOptions BuildFacade(TypedMemEvalRunOptions options) => new()
+    /// <summary>Internal so the caller-feeds guard can assert the real assignment, not a proxy.</summary>
+    internal static TypedMemEvalOptions BuildFacade(TypedMemEvalRunOptions options) => new()
     {
         MaxQuestions = options.MaxQuestions,
         RandomSeed = options.RandomSeed,


### PR DESCRIPTION
`--evidence-detail` was doing half its job on the typedmemeval verb: it reached the **adapter** and
never the **runner**. `TypedMemEvalOptionMapping` faithfully copies `facade.EvidenceCaptureMode` and
`facade.EvidenceTopK` through to AgentEval, and `BuildFacade` set neither. The flag looked wired
because half of it was.

That is the **fourth codepath in a week** where reachable was not the same as fed — after an
extraction lever no harness could set, a renderer no harness could set, and a public write verb no
pipeline calls.

The mapping is now shared (`CaptureModeFor`, one definition, two callers) rather than duplicated —
it had already been duplicated by *omission* once.

## The standing check is the more useful half

`FacadeCallerFeedsTests` reflects over every settable option the runner accepts and requires each to
be classified: **fed** by `BuildFacade`, or **deliberately defaulted with the reason recorded**. An
option nobody has classified fails the suite.

It is a declared map rather than a clever diff on purpose: comparing a built facade against a default
one cannot distinguish *"fed with a value that happens to equal the default"* from *"never fed"* —
and that ambiguity is precisely the bug. Hand classification costs one line when the runner gains an
option; the alternative is finding out during a paid run, which is what happened here.

Nine options are recorded as deliberately defaulted, mostly judge configuration — choosing our own
retry count or temperature would make our scores incomparable with anyone else's.

Release 0-warn; 5192 + 732 green.