### PR TITLE
Gate the re-grade on corpus identity: ids and text cannot detect a redraw

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/TypedMemEvalReplayAdapterTests.cs
@@ -131,6 +131,27 @@ public class TypedMemEvalReplayAdapterTests
     }
 
     [Fact]
+    public async Task PositionKeyingCannotDetectAGoldThatMovedBehindUnchangedText()
+    {
+        // Documents the LIMIT of this adapter, and why the re-grade needs a corpus-sha gate above it.
+        // AgentEval redraws corpora keeping the question_id set identical with zero byte-identical
+        // items; for bitemporal, 27 of 60 keep the SAME question text with a DIFFERENT gold. The
+        // replay verifies text per position and is therefore blind to exactly that case -- it will
+        // happily replay, and the answers will be graded against keys they were never produced for.
+        //
+        // This test asserts the blindness rather than pretending it away: the guard that catches it
+        // lives in TypedMemEvalRegradeProgram, which compares corpus_sha256 before spending.
+        var adapter = Adapter(("Which department was Colm Whitaker at in February?", "Lowick"));
+
+        var response = await adapter.InvokeAsync("Which department was Colm Whitaker at in February?");
+
+        response.Text.Should().Be("Lowick");
+        adapter.OrderingMismatches.Should().BeEmpty(
+            "identical text passes the positional check no matter what the gold now says — which is "
+            + "why corpus identity must be established before the replay runs at all");
+    }
+
+    [Fact]
     public async Task TheHistoryHooksAreInertAndDoNotDisturbReplay()
     {
         // Implemented only so the runner takes the same branches it takes for the real adapter. If

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -114,7 +114,11 @@ internal static class TypedMemEvalRegradeProgram
                 report.RootElement.TryGetProperty("TypedOutcomes", out var outcomes)
                 && outcomes.ValueKind == JsonValueKind.Object
                 && outcomes.TryGetProperty("CorpusSha256", out var sha)
-                    ? sha.GetString()
+                && sha.ValueKind == JsonValueKind.String
+                    // ValueKind-checked rather than GetString()-and-hope: a null, number or object
+                    // here would throw and kill the tool on a malformed or older artifact, and this
+                    // gate's whole job is to fail SAFELY before anything is spent.
+                    ? sha.GetString() is { Length: > 0 } value ? value.Trim() : null
                     : null;
             var currentCorpusSha = CurrentCorpusSha(verticalSlug);
 
@@ -353,18 +357,23 @@ internal static class TypedMemEvalRegradeProgram
     private static string? CurrentCorpusSha(string verticalSlug)
     {
         var assembly = typeof(TypedMemEvalRunner).Assembly;
-        var name = assembly.GetManifestResourceNames().FirstOrDefault(resource =>
-            resource.Contains($".{verticalSlug}.", StringComparison.OrdinalIgnoreCase)
-            && resource.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
-            && !resource.EndsWith(".meta.json", StringComparison.OrdinalIgnoreCase));
-        if (name is null) return null;
+        var matches = assembly.GetManifestResourceNames().Where(resource =>
+                resource.Contains($".{verticalSlug}.", StringComparison.OrdinalIgnoreCase)
+                && resource.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+                && !resource.EndsWith(".meta.json", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
 
-        using var stream = assembly.GetManifestResourceStream(name);
+        // Exactly one, or nothing. FirstOrDefault would resolve an ambiguity by manifest ordering,
+        // which is not guaranteed -- and a gate that picks a different corpus on a different run is
+        // worse than no gate, because it looks like it verified something.
+        if (matches.Length != 1) return null;
+
+        using var stream = assembly.GetManifestResourceStream(matches[0]);
         if (stream is null) return null;
 
-        using var buffer = new MemoryStream();
-        stream.CopyTo(buffer);
-        return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(buffer.ToArray()))
+        // Hashed straight off the stream: the corpora run to ~1.5 MB and buffering them twice to
+        // compute a digest is allocation for nothing.
+        return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(stream))
             .ToLowerInvariant();
     }
 

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -98,6 +98,49 @@ internal static class TypedMemEvalRegradeProgram
                 .Vertical;
             var armToken = sidecar.RootElement.GetProperty("arm").GetProperty("token").GetString();
 
+            // CORPUS IDENTITY GATE, checked before a single judge call.
+            //
+            // AgentEval redraws corpora keeping the question_id set 100% IDENTICAL with ZERO
+            // byte-identical items, and neither corpus_id nor revision moves either -- corpus_sha256
+            // is the ONLY distinguishing field. For bitemporal, 27 of 60 items keep the SAME question
+            // text and carry a DIFFERENT gold.
+            //
+            // That defeats the protection this program already had. The replay is position-keyed and
+            // verifies the question TEXT at each position, which catches a redraw that reworded
+            // anything -- and catches nothing at all when the text is stable and only the gold moved.
+            // Re-grading across such a redraw would replay the right answers against the wrong keys
+            // and report an agreement rate that means nothing.
+            var storedCorpusSha =
+                report.RootElement.TryGetProperty("TypedOutcomes", out var outcomes)
+                && outcomes.ValueKind == JsonValueKind.Object
+                && outcomes.TryGetProperty("CorpusSha256", out var sha)
+                    ? sha.GetString()
+                    : null;
+            var currentCorpusSha = CurrentCorpusSha(verticalSlug);
+
+            if (storedCorpusSha is null)
+            {
+                // Not fatal, and deliberately so: artifacts predating provenance capture are still
+                // re-gradable. But it is the one case where nothing can be verified, so it is said
+                // out loud rather than passing quietly.
+                Console.WriteLine(
+                    "regrade: WARNING the stored artifact records no corpus sha, so corpus identity " +
+                    "CANNOT be verified. If it predates the current corpus, the replay may grade " +
+                    "against different gold behind identical question text.");
+            }
+            else if (currentCorpusSha is not null &&
+                     !string.Equals(storedCorpusSha, currentCorpusSha, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine(
+                    $"regrade: ABORT — corpus mismatch. The artifact was produced against " +
+                    $"{storedCorpusSha[..16]}… and this build carries {currentCorpusSha[..16]}…. " +
+                    "Question ids and text are NOT sufficient to detect this: corpora are redrawn " +
+                    "keeping ids identical, and gold can move behind unchanged text. Re-grade with " +
+                    "the package the artifact was produced against.");
+                return 5;
+            }
+
+
             Console.WriteLine(
                 $"regrade: source {Path.GetFileName(reportPath)} — vertical {verticalSlug}, " +
                 $"arm {armToken}, {storedRows.Count} stored answers replayed in artifact order");
@@ -299,6 +342,30 @@ internal static class TypedMemEvalRegradeProgram
         File.WriteAllText(
             sidecarPath,
             node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
+    }
+
+    /// <summary>The sha256 of the corpus this build actually carries, or null if not found.</summary>
+    /// <remarks>
+    /// Hashed from the embedded resource rather than read from a manifest, so it is the bytes the run
+    /// would use and not a claim about them. Null when the resource cannot be located, which is
+    /// treated as "cannot verify" rather than as "matches".
+    /// </remarks>
+    private static string? CurrentCorpusSha(string verticalSlug)
+    {
+        var assembly = typeof(TypedMemEvalRunner).Assembly;
+        var name = assembly.GetManifestResourceNames().FirstOrDefault(resource =>
+            resource.Contains($".{verticalSlug}.", StringComparison.OrdinalIgnoreCase)
+            && resource.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+            && !resource.EndsWith(".meta.json", StringComparison.OrdinalIgnoreCase));
+        if (name is null) return null;
+
+        using var stream = assembly.GetManifestResourceStream(name);
+        if (stream is null) return null;
+
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(buffer.ToArray()))
+            .ToLowerInvariant();
     }
 
     private static string AgentEvalVersion() =>


### PR DESCRIPTION
From the SHA-only keying audit.

AgentEval redraws corpora keeping the `question_id` set **100% identical with zero byte-identical
items**, and neither `corpus_id` nor `revision` moves — **`corpus_sha256` is the only distinguishing
field**. For bitemporal, **27 of 60** items keep the *same question text* with a *different gold*.

That defeats the protection the re-grade already had. The replay is position-keyed and verifies
question **text** per position: it catches a redraw that reworded anything, and catches **nothing**
when the text is stable and only the gold moved. Re-grading across such a redraw replays the right
answers against the wrong keys and reports an agreement rate that means nothing — after paying for
the judge pass.

## The gate

Corpus sha compared **before any judge call**. Stored value from the artifact's own
`TypedOutcomes.CorpusSha256`; current value **hashed from the embedded resource this build carries**,
rather than read from a manifest — the bytes the run would use, not a claim about them.

Three outcomes, deliberately distinct:

- **match** → proceed
- **mismatch** → **ABORT**, naming both shas
- **no sha recorded** → **warn, don't fail** — artifacts predating provenance capture are still
  re-gradable, but it is the one case where nothing can be verified, so it says so rather than
  passing quietly

Verified both ways: a matching artifact proceeds; an artifact whose sha is moved to the current
bitemporal lineage (`abf2f3f4`) aborts with both shas named.

Also **documents the adapter's blindness as a test** rather than pretending it away — identical text
passes the positional check whatever the gold now says, which is exactly why identity belongs one
layer up.

Release 0-warn; 734/734.