### PR TITLE
Close the id-keying audit: make the corpus-identity gate a tested unit

### DIFF
--- a/tests/AgentMemory.Tests.Unit.LongMemEval/CorpusIdentityTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/CorpusIdentityTests.cs
@@ -60,4 +60,18 @@ public class CorpusIdentityTests
     public void AnUnknownShaIsUnverifiableAndNotAMatch(string? stored, string? current) =>
         TypedMemEvalRegradeProgram.CorpusIdentity.Verify(stored, current)
             .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Unverifiable);
+
+    /// <summary>A mismatch on a malformed sha must still be a MISMATCH, not an exception.</summary>
+    /// <remarks>
+    /// The abort path formats both shas into its message. It previously sliced them at a fixed 16
+    /// characters, which throws on a truncated or corrupt value — in the one branch whose entire job
+    /// is to fail safely with an exit code. Second time on this gate: #213 hardened the sha's type
+    /// and left its length assumed.
+    /// </remarks>
+    [Theory]
+    [InlineData("abc", "def")]
+    [InlineData("f5b384d7", "abf2f3f4")]
+    public void AShortOrMalformedShaStillCompares(string stored, string current) =>
+        TypedMemEvalRegradeProgram.CorpusIdentity.Verify(stored, current)
+            .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Mismatch);
 }

--- a/tests/AgentMemory.Tests.Unit.LongMemEval/CorpusIdentityTests.cs
+++ b/tests/AgentMemory.Tests.Unit.LongMemEval/CorpusIdentityTests.cs
@@ -1,0 +1,63 @@
+using AgentMemory.LongMemEval;
+using FluentAssertions;
+using Xunit;
+
+namespace AgentMemory.Tests.Unit.LongMemEval;
+
+/// <summary>
+/// The gate standing between a re-grade and a meaningless agreement rate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AgentEval redraws corpora keeping the <c>question_id</c> set 100% identical with zero
+/// byte-identical items, and neither <c>corpus_id</c> nor <c>revision</c> moves —
+/// <c>corpus_sha256</c> is the only distinguishing field. For bitemporal, <b>27 of 60 items keep the
+/// same question text and carry a different gold</b>.
+/// </para>
+/// <para>
+/// The re-grade's replay is position-keyed and verifies question text per position, so it catches a
+/// redraw that reworded anything and catches <b>nothing</b> when the text is stable and only the gold
+/// moved. This comparison is what closes that, and it runs before any judge call — the cost of
+/// getting it wrong is a paid pass whose output means nothing.
+/// </para>
+/// </remarks>
+public class CorpusIdentityTests
+{
+    private const string Bitemporal = "f5b384d7f0ff9c0fbef8b962a5f4d678";
+    private const string Redrawn = "abf2f3f4f0ff9c0fbef8b962a5f4d678";
+
+    [Fact]
+    public void TheSameCorpusMatches() =>
+        TypedMemEvalRegradeProgram.CorpusIdentity.Verify(Bitemporal, Bitemporal)
+            .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Match);
+
+    [Fact]
+    public void CaseDoesNotMakeTwoShasDifferent() =>
+        TypedMemEvalRegradeProgram.CorpusIdentity.Verify(Bitemporal, Bitemporal.ToUpperInvariant())
+            .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Match,
+                "artifacts and manifests disagree about hex casing and that is not a redraw");
+
+    [Fact]
+    public void ARedrawnCorpusIsAMismatch() =>
+        TypedMemEvalRegradeProgram.CorpusIdentity.Verify(Bitemporal, Redrawn)
+            .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Mismatch);
+
+    /// <summary>
+    /// The outcome that must stay its own thing: absence of evidence is not evidence of a match.
+    /// </summary>
+    /// <remarks>
+    /// Folded into Match it passes silently — which is the constant-column failure this project has
+    /// been bitten by three times. Folded into Mismatch it blocks every artifact older than
+    /// provenance capture, which would make the gate so obstructive it gets bypassed. Hence three
+    /// verdicts, and hence a warning rather than a refusal at the call site.
+    /// </remarks>
+    [Theory]
+    [InlineData(null, "abc")]
+    [InlineData("abc", null)]
+    [InlineData(null, null)]
+    [InlineData("", "abc")]
+    [InlineData("   ", "abc")]
+    public void AnUnknownShaIsUnverifiableAndNotAMatch(string? stored, string? current) =>
+        TypedMemEvalRegradeProgram.CorpusIdentity.Verify(stored, current)
+            .Should().Be(TypedMemEvalRegradeProgram.CorpusIdentityVerdict.Unverifiable);
+}

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -122,26 +122,26 @@ internal static class TypedMemEvalRegradeProgram
                     : null;
             var currentCorpusSha = CurrentCorpusSha(verticalSlug);
 
-            if (storedCorpusSha is null)
+            switch (CorpusIdentity.Verify(storedCorpusSha, currentCorpusSha))
             {
-                // Not fatal, and deliberately so: artifacts predating provenance capture are still
-                // re-gradable. But it is the one case where nothing can be verified, so it is said
-                // out loud rather than passing quietly.
-                Console.WriteLine(
-                    "regrade: WARNING the stored artifact records no corpus sha, so corpus identity " +
-                    "CANNOT be verified. If it predates the current corpus, the replay may grade " +
-                    "against different gold behind identical question text.");
-            }
-            else if (currentCorpusSha is not null &&
-                     !string.Equals(storedCorpusSha, currentCorpusSha, StringComparison.OrdinalIgnoreCase))
-            {
-                Console.Error.WriteLine(
-                    $"regrade: ABORT — corpus mismatch. The artifact was produced against " +
-                    $"{storedCorpusSha[..16]}… and this build carries {currentCorpusSha[..16]}…. " +
-                    "Question ids and text are NOT sufficient to detect this: corpora are redrawn " +
-                    "keeping ids identical, and gold can move behind unchanged text. Re-grade with " +
-                    "the package the artifact was produced against.");
-                return 5;
+                case CorpusIdentityVerdict.Unverifiable:
+                    // Not fatal, and deliberately so: artifacts predating provenance capture are
+                    // still re-gradable. But it is the one case where nothing can be verified, so it
+                    // is said out loud rather than passing quietly.
+                    Console.WriteLine(
+                        "regrade: WARNING corpus identity CANNOT be verified (the artifact or this " +
+                        "build records no corpus sha). If the corpus has since been redrawn, the " +
+                        "replay may grade against different gold behind identical question text.");
+                    break;
+
+                case CorpusIdentityVerdict.Mismatch:
+                    Console.Error.WriteLine(
+                        $"regrade: ABORT — corpus mismatch. The artifact was produced against " +
+                        $"{storedCorpusSha![..16]}… and this build carries {currentCorpusSha![..16]}…. " +
+                        "Question ids and text are NOT sufficient to detect this: corpora are redrawn " +
+                        "keeping ids identical, and gold can move behind unchanged text. Re-grade " +
+                        "with the package the artifact was produced against.");
+                    return 5;
             }
 
 
@@ -346,6 +346,36 @@ internal static class TypedMemEvalRegradeProgram
         File.WriteAllText(
             sidecarPath,
             node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
+    }
+
+    /// <summary>What a corpus-sha comparison concluded.</summary>
+    internal enum CorpusIdentityVerdict
+    {
+        /// <summary>Both shas known and equal — the artifact and this build share a corpus.</summary>
+        Match,
+
+        /// <summary>Both known and different — the corpus was redrawn; re-grading would be meaningless.</summary>
+        Mismatch,
+
+        /// <summary>One or both unknown. NOT a match: it is the absence of evidence, and saying so
+        /// is the difference between a check and a formality.</summary>
+        Unverifiable,
+    }
+
+    /// <summary>The corpus-identity decision, extracted so it can be tested rather than only run.</summary>
+    /// <remarks>
+    /// Three outcomes and not two. Collapsing <see cref="CorpusIdentityVerdict.Unverifiable"/> into
+    /// either of the others is the mistake this whole gate exists to avoid: folded into Match it
+    /// passes silently, folded into Mismatch it blocks every artifact older than provenance capture.
+    /// </remarks>
+    internal static class CorpusIdentity
+    {
+        public static CorpusIdentityVerdict Verify(string? stored, string? current) =>
+            string.IsNullOrWhiteSpace(stored) || string.IsNullOrWhiteSpace(current)
+                ? CorpusIdentityVerdict.Unverifiable
+                : string.Equals(stored, current, StringComparison.OrdinalIgnoreCase)
+                    ? CorpusIdentityVerdict.Match
+                    : CorpusIdentityVerdict.Mismatch;
     }
 
     /// <summary>The sha256 of the corpus this build actually carries, or null if not found.</summary>

--- a/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
+++ b/tools/AgentMemory.LongMemEval/TypedMemEvalRegradeProgram.cs
@@ -137,7 +137,7 @@ internal static class TypedMemEvalRegradeProgram
                 case CorpusIdentityVerdict.Mismatch:
                     Console.Error.WriteLine(
                         $"regrade: ABORT — corpus mismatch. The artifact was produced against " +
-                        $"{storedCorpusSha![..16]}… and this build carries {currentCorpusSha![..16]}…. " +
+                        $"{ShortSha(storedCorpusSha)} and this build carries {ShortSha(currentCorpusSha)}. " +
                         "Question ids and text are NOT sufficient to detect this: corpora are redrawn " +
                         "keeping ids identical, and gold can move behind unchanged text. Re-grade " +
                         "with the package the artifact was produced against.");
@@ -347,6 +347,18 @@ internal static class TypedMemEvalRegradeProgram
             sidecarPath,
             node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
     }
+
+    /// <summary>A sha abbreviated for a message, without assuming it is well-formed.</summary>
+    /// <remarks>
+    /// A fixed <c>[..16]</c> throws on a truncated or corrupt value — and this is the ABORT path,
+    /// whose entire purpose is to fail safely with an exit code rather than an exception. Second time
+    /// on this gate: #213 hardened the sha's TYPE and left its LENGTH assumed. A guard that can throw
+    /// is not a guard.
+    /// </remarks>
+    private static string ShortSha(string? sha) =>
+        string.IsNullOrWhiteSpace(sha) ? "(none)"
+        : sha.Length <= 16 ? sha
+        : sha[..16] + "…";
 
     /// <summary>What a corpus-sha comparison concluded.</summary>
     internal enum CorpusIdentityVerdict


### PR DESCRIPTION
Discharges the family-wide audit of anything that could key on `question_id` / `corpus_id` /
`revision` across corpus versions.

**Why it was needed:** AgentEval redraws corpora keeping the `question_id` set **100% identical with
zero byte-identical items**, and neither `corpus_id` nor `revision` moves — `corpus_sha256` is the
only distinguishing field. For bitemporal, **27 of 60 items keep the same question text with a
different gold**. Anything joining across corpus versions on an id is silently wrong, in the
direction that yields a confident number rather than an error.

## Result: one gap, one surface, already closed in #213

| surface | keys on | verdict |
|---|---|---|
| `--regrade` cross-artifact join | position + question text | ❌ gap — closed in #213 |
| prepared-corpus reuse | `datasetSha256` + 11 identity fields | ✅ already correct |
| perf ledger | scenario names | ✅ not corpus-versioned |
| TypedMemEval runs | fresh container per run | ✅ no cross-version cache |
| evidence index | question id, within one load | ✅ single-corpus scope |
| any other two-artifact verb | — | ✅ none exist |

Two results worth more than a tick: **prepared-corpus reuse already compares `datasetSha256`** and its
own header states the principle this audit is about — *"treating unknown as equal is how a check stops
being able to fail"* — reporting unrecorded fields on older manifests as **drift, not agreement**.
That is the standard the re-grade has now been raised to. And **no other verb reads two artifacts**,
so `--regrade` was the only place the hazard could live.

## What this PR adds

The gate's decision was a code path only exercisable by running the tool against a hand-mutated
artifact. It is now `CorpusIdentity.Verify` with three verdicts and unit tests for each — including
hex casing, since artifacts and manifests disagree about it and that is not a redraw.

**`Unverifiable` stays its own verdict deliberately.** Folded into `Match` it passes silently — the
constant-column failure this project has hit three times. Folded into `Mismatch` it blocks every
artifact older than provenance capture, making the gate obstructive enough to get bypassed. So it
warns at the call site and refuses to be read as agreement.

Release 0-warn; LongMemEval 742/742.